### PR TITLE
feat(examples): add integration guide and research CLI for Hy3 in popular tools.

### DIFF
--- a/examples/integrations/INTEGRATION_GUIDE.md
+++ b/examples/integrations/INTEGRATION_GUIDE.md
@@ -1,0 +1,130 @@
+# Using Hy3 in Popular AI Products & Tools
+
+This guide shows how to connect Hy3 to mainstream AI clients and platforms, and includes a small showcase application built with Hy3.
+
+## Prerequisites
+
+Deploy Hy3 first (see [main README](../../README.md#deployment)):
+
+```bash
+# vLLM (recommended for production)
+vllm serve tencent/Hy3 --tensor-parallel-size 8
+
+# SGLang (alternative)
+python -m sglang.launch_server --model-path tencent/Hy3 --tp 8
+```
+
+Both expose an OpenAI-compatible endpoint at `http://localhost:8000/v1`.
+
+---
+
+## 1. Claude Code (Anthropic CLI)
+
+Claude Code supports [custom model endpoints](https://docs.anthropic.com/en/docs/claude-code/settings) via the `ANTHROPIC_BASE_URL` override, but Hy3 is an OpenAI-compatible API, not Anthropic. Use the MCP Server approach instead:
+
+```bash
+# Install the Hy3 MCP server (in this repo)
+pip install -e ../../mcp-server
+
+# Register with Claude Code
+claude mcp add hy3-research -- python -m hy3_mcp
+```
+
+Claude Code can now call `search_web`, `analyze_with_hy3`, and `generate_report` tools backed by your local Hy3 instance.
+
+---
+
+## 2. Cursor
+
+Cursor supports [custom OpenAI-compatible endpoints](https://docs.cursor.com/advanced/models#custom-openai-compatible-models) in **Settings → Models → Add Model**:
+
+| Field | Value |
+|-------|-------|
+| Model name | `hy3` |
+| Base URL | `http://localhost:8000/v1` |
+| API Key | `EMPTY` |
+
+After adding, select `hy3` from the model dropdown in the chat panel.
+
+**Tip**: Hy3 shines for complex reasoning tasks. Set `temperature=0.9` and use prompts that benefit from chain-of-thought (`reasoning_effort: "high"` can be enabled by adding `extra_body` if Cursor exposes it, otherwise the model defaults to `no_think`).
+
+---
+
+## 3. Open WebUI
+
+Open WebUI natively supports OpenAI-compatible backends:
+
+```bash
+# Start Open WebUI pointing at Hy3
+docker run -d -p 3000:8080 \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
+  -e OPENAI_API_KEY=EMPTY \
+  ghcr.io/open-webui/open-webui:main
+```
+
+Then open `http://localhost:3000`, sign in, and select `hy3` from the model dropdown.
+
+For **reasoning mode**, add a system prompt:
+```
+You are Hy3. For complex questions, reason step by step before answering.
+```
+
+---
+
+## 4. LangChain
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="EMPTY",
+    model="hy3",
+    temperature=0.9,
+    model_kwargs={"extra_body": {"chat_template_kwargs": {"reasoning_effort": "no_think"}}},
+)
+
+response = llm.invoke("Summarise the key findings of the 2025 AI Safety Report.")
+print(response.content)
+```
+
+For agents and chains, Hy3's strong instruction-following makes it a drop-in replacement for GPT-4-class models.
+
+---
+
+## 5. LlamaIndex
+
+```python
+from llama_index.llms.openai import OpenAI
+
+llm = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="EMPTY",
+    model="hy3",
+    temperature=0.9,
+)
+
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+docs = SimpleDirectoryReader("./data").load_data()
+index = VectorStoreIndex.from_documents(docs, llm=llm)
+query_engine = index.as_query_engine()
+print(query_engine.query("What are the main themes?"))
+```
+
+---
+
+## Showcase: CLI Research Assistant
+
+`research_cli.py` is a minimal terminal application that uses Hy3 to do multi-step research:
+
+1. Accept a research question from the user
+2. Search the web for relevant sources
+3. Analyse each source with Hy3
+4. Synthesise a final Markdown report
+
+```bash
+pip install openai httpx
+python research_cli.py "What are the latest advances in MoE model efficiency?"
+```
+
+See [`research_cli.py`](./research_cli.py) for the full implementation.

--- a/examples/integrations/research_cli.py
+++ b/examples/integrations/research_cli.py
@@ -1,0 +1,123 @@
+"""
+Terminal research assistant powered by Hy3.
+
+Usage:
+    python research_cli.py "Your research question"
+
+Requires: openai httpx
+"""
+import re
+import sys
+import textwrap
+import httpx
+from openai import OpenAI
+
+_DDG_URL = "https://html.duckduckgo.com/html/"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; hy3-research/0.1)"}
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _client() -> OpenAI:
+    return OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+
+def _hy3(prompt: str, reasoning: str = "no_think") -> str:
+    resp = _client().chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.9,
+        top_p=1.0,
+        extra_body={"chat_template_kwargs": {"reasoning_effort": reasoning}},
+    )
+    return resp.choices[0].message.content or ""
+
+
+def _search(query: str, n: int = 5) -> list[dict[str, str]]:
+    try:
+        with httpx.Client(timeout=15, follow_redirects=True) as c:
+            resp = c.post(_DDG_URL, data={"q": query}, headers=_HEADERS)
+            resp.raise_for_status()
+    except Exception as exc:
+        print(f"  [search error] {exc}", file=sys.stderr)
+        return []
+
+    text = resp.text
+    results: list[dict[str, str]] = []
+    idx = 0
+    while len(results) < n:
+        if (start := text.find('class="result__title"', idx)) == -1:
+            break
+        href_start = text.find('href="', start)
+        href_end = text.find('"', href_start + 6)
+        url = text[href_start + 6 : href_end] if href_start != -1 else ""
+        a_end = text.find("</a>", href_start)
+        title = _TAG_RE.sub("", text[href_end + 2 : a_end] if a_end != -1 else "").strip()
+        snip_start = text.find('class="result__snippet"', a_end)
+        snip_end = text.find("</a>", snip_start) if snip_start != -1 else -1
+        snippet = (
+            _TAG_RE.sub("", text[snip_start:snip_end]).strip()
+            if snip_start != -1 and snip_end != -1
+            else ""
+        )
+        if title:
+            results.append({"title": title, "url": url, "snippet": snippet})
+        idx = (a_end + 1) if a_end != -1 else start + 1
+    return results
+
+
+def _analyse(source: dict[str, str], question: str) -> str:
+    content = f"Title: {source['title']}\nURL: {source['url']}\n\n{source['snippet']}"
+    return _hy3(textwrap.dedent(f"""\
+        Based on the following source, answer this question: {question}
+
+        Source:
+        {content}
+
+        Be concise and cite specific details from the source.
+    """))
+
+
+def _report(question: str, findings: str) -> str:
+    return _hy3(textwrap.dedent(f"""\
+        Write a structured Markdown research report answering: {question}
+
+        Research findings:
+        {findings}
+
+        Structure:
+        # {question}
+        ## Summary
+        ## Key Findings
+        ## Analysis
+        ## Conclusion
+    """), reasoning="high")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python research_cli.py \"<question>\"", file=sys.stderr)
+        sys.exit(1)
+
+    question = " ".join(sys.argv[1:])
+    print(f"\nResearching: {question}\n")
+
+    print("Searching...")
+    sources = _search(question)
+    if not sources:
+        print("No search results. Check your network connection.")
+        sys.exit(1)
+
+    print(f"Found {len(sources)} sources. Analysing with Hy3...\n")
+    findings: list[str] = []
+    for i, src in enumerate(sources, 1):
+        print(f"  [{i}/{len(sources)}] {src['title'][:60]}")
+        analysis = _analyse(src, question)
+        findings.append(f"[{i}] {src['title']} ({src['url']})\n{analysis}")
+
+    print("\nSynthesising report (high reasoning)...\n")
+    report = _report(question, "\n\n".join(findings))
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quickstart/research_demo.py
+++ b/examples/quickstart/research_demo.py
@@ -1,0 +1,81 @@
+"""
+Hy3 Deep Research Demo — minimal end-to-end example.
+
+Requires:
+    pip install openai httpx
+
+Usage:
+    HY3_API_BASE=http://127.0.0.1:8000/v1 python research_demo.py
+"""
+
+import os
+import re
+import textwrap
+
+import httpx
+from openai import OpenAI
+
+API_BASE = os.environ.get("HY3_API_BASE", "http://127.0.0.1:8000/v1")
+API_KEY = os.environ.get("HY3_API_KEY", "EMPTY")
+
+_client = OpenAI(base_url=API_BASE, api_key=API_KEY)
+_DDG_URL = "https://html.duckduckgo.com/html/"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; hy3-demo/0.1)"}
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def search(query: str, n: int = 5) -> str:
+    with httpx.Client(timeout=15, follow_redirects=True) as c:
+        resp = c.post(_DDG_URL, data={"q": query}, headers=_HEADERS)
+        resp.raise_for_status()
+    text, results, idx = resp.text, [], 0
+    while len(results) < n:
+        if (start := text.find('class="result__title"', idx)) == -1:
+            break
+        href_s = text.find('href="', start)
+        href_e = text.find('"', href_s + 6)
+        url = text[href_s + 6:href_e] if href_s != -1 else ""
+        a_end = text.find("</a>", href_s)
+        title = _TAG_RE.sub("", text[href_e + 2:a_end] if a_end != -1 else "").strip()
+        if title:
+            results.append(f"[{len(results)+1}] {title}\n    {url}")
+        idx = (a_end + 1) if a_end != -1 else start + 1
+    return "\n\n".join(results) if results else "No results."
+
+
+def ask_hy3(prompt: str, reasoning: str = "no_think") -> str:
+    resp = _client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.9,
+        extra_body={"chat_template_kwargs": {"reasoning_effort": reasoning}},
+    )
+    return resp.choices[0].message.content or ""
+
+
+def research(topic: str) -> str:
+    print(f"[1/3] Searching: {topic}")
+    findings = search(topic)
+
+    print("[2/3] Analysing with Hy3 ...")
+    analysis = ask_hy3(textwrap.dedent(f"""\
+        Based on these search results, answer: what are the key points about "{topic}"?
+
+        Results:
+        {findings}
+    """))
+
+    print("[3/3] Generating report ...")
+    return ask_hy3(textwrap.dedent(f"""\
+        Write a concise Markdown research report on "{topic}".
+
+        Findings:
+        {analysis}
+    """), reasoning="high")
+
+
+if __name__ == "__main__":
+    topic = "Tencent Hunyuan Hy3 model capabilities"
+    report = research(topic)
+    print("\n" + "=" * 60)
+    print(report)

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,131 @@
+# Hy3 MCP Server - Deep Research Assistant
+
+An MCP (Model Context Protocol) server that wraps [Hy3](https://github.com/Tencent-Hunyuan/Hy3) API capabilities into three composable tools for deep research workflows.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_web` | DuckDuckGo search - returns top-5 results (title, URL, snippet) |
+| `analyze_with_hy3` | Send content + question to Hy3 for in-depth analysis |
+| `generate_report` | Ask Hy3 to synthesise findings into a structured Markdown report |
+
+## Prerequisites
+
+Deploy Hy3 locally with [vLLM](https://github.com/vllm-project/vllm) or [SGLang](https://github.com/sgl-project/sglang):
+
+```bash
+# vLLM example
+vllm serve tencent/Hy3 --host 127.0.0.1 --port 8000
+```
+
+## Installation
+
+```bash
+# From source (recommended for development)
+cd mcp-server
+pip install -e .
+
+# Or once published to PyPI
+pip install hy3-mcp
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `HY3_API_BASE` | `http://127.0.0.1:8000/v1` | Hy3 OpenAI-compatible endpoint |
+| `HY3_API_KEY` | `EMPTY` | API key (use `EMPTY` for local vLLM) |
+
+## MCP Client Configuration
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "hy3-mcp",
+      "env": {
+        "HY3_API_BASE": "http://127.0.0.1:8000/v1",
+        "HY3_API_KEY": "EMPTY"
+      }
+    }
+  }
+}
+```
+
+### CodeBuddy / WorkBuddy
+
+Project-level MCP config (`.codebuddy/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "hy3-mcp",
+      "args": [],
+      "env": {
+        "HY3_API_BASE": "http://127.0.0.1:8000/v1",
+        "HY3_API_KEY": "EMPTY"
+      }
+    }
+  }
+}
+```
+
+CLI add command:
+```bash
+codebuddy mcp add hy3-research --command "hy3-mcp" \
+  --env HY3_API_BASE=http://127.0.0.1:8000/v1 \
+  --env HY3_API_KEY=EMPTY
+```
+
+## Usage Examples
+
+### Tool 1 - Search the web
+
+```
+Tool: search_web
+Input: {"query": "transformer architecture 2024 advances"}
+Output: Top-5 DuckDuckGo results with titles, URLs, and snippets
+```
+
+### Tool 2 - Analyze with Hy3
+
+```
+Tool: analyze_with_hy3
+Input: {
+  "content": "<paste search results or document here>",
+  "question": "What are the main breakthroughs in 2024?",
+  "reasoning": "high"
+}
+Output: Hy3's detailed analysis
+```
+
+### Tool 3 - Generate report
+
+```
+Tool: generate_report
+Input: {
+  "topic": "Transformer Architecture Advances in 2024",
+  "findings": "<accumulated notes from search + analysis steps>"
+}
+Output: Complete Markdown research report
+```
+
+### Full research workflow example
+
+A typical session with an MCP client:
+
+1. `search_web(query="mixture of experts LLM 2024")`
+2. `analyze_with_hy3(content=<results>, question="summarize key MoE innovations", reasoning="no_think")`
+3. `search_web(query="MoE training efficiency benchmarks")`
+4. `analyze_with_hy3(content=<results>, question="what do benchmarks show about efficiency gains?")`
+5. `generate_report(topic="MoE LLM Advances 2024", findings=<combined notes>)`
+
+## License
+
+Apache 2.0 - see [LICENSE](../LICENSE)

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hy3-mcp"
+version = "0.1.0"
+description = "MCP Server for Hy3 - Deep Research Assistant"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.0.0",
+    "openai>=1.0.0",
+    "httpx>=0.24.0",
+]
+
+[project.scripts]
+hy3-mcp = "hy3_mcp.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hy3_mcp"]

--- a/mcp-server/src/hy3_mcp/server.py
+++ b/mcp-server/src/hy3_mcp/server.py
@@ -1,0 +1,221 @@
+import os
+import re
+import textwrap
+from typing import Any
+
+import httpx
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+from openai import OpenAI
+
+
+# lazy-init so env vars are resolved at call time, not module load
+def _hy3_client() -> OpenAI:
+    return OpenAI(
+        base_url=os.environ.get("HY3_API_BASE", "http://127.0.0.1:8000/v1"),
+        api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    )
+
+
+def _call_hy3(prompt: str, reasoning: str = "no_think") -> str:
+    resp = _hy3_client().chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.9,
+        top_p=1.0,
+        extra_body={"chat_template_kwargs": {"reasoning_effort": reasoning}},
+    )
+    return resp.choices[0].message.content or ""
+
+
+_DDG_URL = "https://html.duckduckgo.com/html/"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; hy3-mcp/0.1)"}
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(html: str) -> str:
+    return _TAG_RE.sub("", html)
+
+
+def _search_web(query: str) -> str:
+    try:
+        with httpx.Client(timeout=15, follow_redirects=True) as client:
+            resp = client.post(_DDG_URL, data={"q": query}, headers=_HEADERS)
+            resp.raise_for_status()
+
+        # lightweight extraction - avoids a heavy HTML-parser dependency
+        text = resp.text
+        results: list[str] = []
+        idx = 0
+        while len(results) < 5:
+            if (start := text.find('class="result__title"', idx)) == -1:
+                break
+            href_start = text.find('href="', start)
+            href_end = text.find('"', href_start + 6)
+            url = text[href_start + 6: href_end] if href_start != -1 else ""
+            a_end = text.find("</a>", href_start)
+            title = _strip_tags(text[href_end + 2: a_end] if a_end != -1 else "").strip()
+            snip_start = text.find('class="result__snippet"', a_end)
+            snip_end = text.find("</a>", snip_start) if snip_start != -1 else -1
+            snippet = _strip_tags(text[snip_start: snip_end]).strip() if snip_start != -1 and snip_end != -1 else ""
+            if title:
+                results.append(f"[{len(results)+1}] {title}\n    {url}\n    {snippet}")
+            idx = (a_end + 1) if a_end != -1 else start + 1
+
+        return "\n\n".join(results) if results else f"No results found for: {query}"
+
+    except Exception as exc:  # noqa: BLE001
+        return f"Search error: {exc}"
+
+
+def _analyze_with_hy3(content: str, question: str, reasoning: str = "no_think") -> str:
+    return _call_hy3(textwrap.dedent(f"""\
+        You are a rigorous research analyst. Based on the provided content, answer the question.
+
+        ## Content
+        {content}
+
+        ## Question
+        {question}
+
+        Provide a clear, evidence-based answer. Cite specific parts of the content where relevant.
+    """), reasoning=reasoning)
+
+
+def _generate_report(topic: str, findings: str) -> str:
+    return _call_hy3(textwrap.dedent(f"""\
+        You are an expert research writer. Generate a well-structured Markdown research report.
+
+        ## Topic
+        {topic}
+
+        ## Research Findings
+        {findings}
+
+        ## Report Structure (follow exactly)
+        # {topic}
+
+        ## Executive Summary
+        (2-3 sentences)
+
+        ## Key Findings
+        (bullet points)
+
+        ## Analysis
+        (detailed paragraphs)
+
+        ## Conclusion
+        (actionable insights)
+
+        ## References
+        (list sources mentioned in findings)
+    """), reasoning="high")
+
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="search_web",
+        description=(
+            "Search the web using DuckDuckGo and return the top 5 results "
+            "(title, URL, snippet). Use this to gather information on a topic."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query"},
+            },
+            "required": ["query"],
+        },
+    ),
+    Tool(
+        name="analyze_with_hy3",
+        description=(
+            "Send content to Hy3 for in-depth analysis. "
+            "Returns Hy3's analytical response to the given question about the content."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The source content to analyse (search results, documents, etc.)",
+                },
+                "question": {
+                    "type": "string",
+                    "description": "The specific question or analysis task",
+                },
+                "reasoning": {
+                    "type": "string",
+                    "enum": ["no_think", "low", "high"],
+                    "description": "Reasoning depth: 'no_think' (fast), 'low', 'high' (deep CoT)",
+                    "default": "no_think",
+                },
+            },
+            "required": ["content", "question"],
+        },
+    ),
+    Tool(
+        name="generate_report",
+        description=(
+            "Ask Hy3 to generate a structured Markdown research report on a topic, "
+            "given accumulated findings. Returns a complete report with summary, "
+            "key findings, analysis, conclusion and references."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "topic": {"type": "string", "description": "The research topic or title"},
+                "findings": {
+                    "type": "string",
+                    "description": "Accumulated research findings and notes to synthesise",
+                },
+            },
+            "required": ["topic", "findings"],
+        },
+    ),
+]
+
+
+async def _handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    match name:
+        case "search_web":
+            result = _search_web(arguments["query"])
+        case "analyze_with_hy3":
+            result = _analyze_with_hy3(
+                arguments["content"],
+                arguments["question"],
+                arguments.get("reasoning", "no_think"),
+            )
+        case "generate_report":
+            result = _generate_report(arguments["topic"], arguments["findings"])
+        case _:
+            result = f"Unknown tool: {name}"
+    return [TextContent(type="text", text=result)]
+
+
+_server = Server("hy3-research-assistant")
+
+
+@_server.list_tools()
+async def _list_tools() -> list[Tool]:
+    return TOOLS
+
+
+@_server.call_tool()
+async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    return await _handle_call_tool(name, arguments)
+
+
+def main() -> None:
+    import asyncio
+
+    async def _run() -> None:
+        async with stdio_server() as (read_stream, write_stream):
+            await _server.run(read_stream, write_stream, _server.create_initialization_options())
+
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2

Adds `examples/integrations/` with two files:

**INTEGRATION_GUIDE.md** — step-by-step guide for connecting Hy3 to:
- Claude Code (via MCP server from this repo)
- Cursor (custom OpenAI-compatible endpoint)
- Open WebUI (Docker one-liner)
- LangChain (`ChatOpenAI` + `extra_body` for reasoning mode)
- LlamaIndex (RAG pipeline example)

**research_cli.py** — a 100-line terminal research assistant that:
1. Searches the web (DuckDuckGo) for the given question
2. Analyses each source with Hy3 (`no_think` for speed)
3. Synthesises a structured Markdown report with `reasoning_effort: high`

No extra dependencies beyond `openai` and `httpx` (already required by the MCP server).