### PR TITLE
docs: add Hy3 API quickstart examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,65 @@
+# Hy3 API examples configuration.
+#
+# Copy this file to `.env` in the repository root and edit the values:
+#
+#   cp .env.example .env
+#
+# The scripts under `examples/api/` automatically load this root `.env`.
+# Shell environment variables still take precedence over values in `.env`.
+
+# ---------------------------------------------------------------------------
+# Option 1: local vLLM / SGLang serving
+# ---------------------------------------------------------------------------
+HY3_PROVIDER=local
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+
+# If you use SGLang's default port, use:
+# HY3_BASE_URL=http://127.0.0.1:30000/v1
+
+# ---------------------------------------------------------------------------
+# Option 2: OpenRouter
+# ---------------------------------------------------------------------------
+# HY3_PROVIDER=openrouter
+# HY3_BASE_URL=https://openrouter.ai/api/v1
+# OPENROUTER_API_KEY=sk-or-...
+# HY3_MODEL=<openrouter-model-slug>
+#
+# For OpenRouter, examples/api/common.py maps:
+#   reasoning_effort=no_think -> {"reasoning": {"effort": "none"}}
+#   reasoning_effort=high     -> {"reasoning": {"effort": "high"}}
+#
+# Optional OpenRouter attribution headers:
+# OPENROUTER_HTTP_REFERER=https://your-site.example
+# OPENROUTER_APP_TITLE=Your App Name
+
+# ---------------------------------------------------------------------------
+# Option 3: Tencent Cloud Hunyuan OpenAI-compatible API
+# ---------------------------------------------------------------------------
+# HY3_PROVIDER=tencent
+# HY3_BASE_URL=https://api.hunyuan.cloud.tencent.com/v1
+# HUNYUAN_API_KEY=<your-hunyuan-api-key>
+# HY3_MODEL=hunyuan-turbos-latest
+#
+# Optional Tencent provider-specific request body:
+# HY3_EXTRA_BODY_JSON={"enable_enhancement": true}
+
+# ---------------------------------------------------------------------------
+# Option 4: custom OpenAI-compatible gateway
+# ---------------------------------------------------------------------------
+# HY3_PROVIDER=custom
+# HY3_BASE_URL=https://your-gateway.example/v1
+# HY3_API_KEY=<your-api-key>
+# HY3_MODEL=<served-model-name>
+
+# ---------------------------------------------------------------------------
+# Advanced options
+# ---------------------------------------------------------------------------
+# local/vLLM/SGLang providers send Hy3 reasoning template options by default.
+# Cloud providers do not, unless you explicitly enable this.
+# HY3_SEND_REASONING=true
+
+# Retry example settings:
+# HY3_TIMEOUT=30
+# HY3_RETRY_MAX_ATTEMPTS=5

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .huggingface/
 .modelscope/
 .ms*
+.env
+.env.local
+.env.*.local
+!.env.example
 *.swp
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ print(response.choices[0].message.content)
 
 See the [Deployment](#deployment) section below for how to start the API server.
 
+For a developer-focused API walkthrough with curl, Python SDK usage, parameters, troubleshooting, and runnable examples, see [Hy3 API Quickstart](./quickstart.md) and [API Examples](./examples/api/README.md).
+
 ## Deployment
 
 Hy3 has 295B parameters in total. To serve it on 8 GPUs, we recommend using H20-3e or other GPUs with larger memory capacity.

--- a/README_CN.md
+++ b/README_CN.md
@@ -134,6 +134,8 @@ print(response.choices[0].message.content)
 
 具体部署方式请参考下方[推理和部署](#推理和部署)章节。
 
+如果需要面向开发者的 API 接入文档，包括 curl、Python SDK、参数说明、报错排查和可运行示例，请参考 [Hy3 API Quickstart](./quickstart.md) 和 [API Examples](./examples/api/README.md)。
+
 ## 推理和部署
 
 Hy3 总参数量为 295B，当使用 8 张 GPU 时，建议使用 H20-3e 或其他有更大显存的卡型。

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,85 @@
+# Hy3 API Examples
+
+这些示例覆盖 Hy3 OpenAI-compatible API 的常用开发场景。每个 `.py` 文件都可以独立运行；同名 `.md` 文件包含完整请求、响应解析说明和示例输出。
+
+## 环境变量
+
+```bash
+python3 -m pip install "openai>=1.0.0"
+cp .env.example .env
+```
+
+`.env` 文件放在仓库根目录，也就是和 `quickstart.md` 同级。所有 `examples/api/*.py` 脚本都会自动加载这个文件；如果同名变量已经在 shell 中设置，shell 变量优先。
+
+### 本地 vLLM / SGLang
+
+```bash
+export HY3_PROVIDER="local"
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+如果使用 SGLang 默认端口，通常改为：
+
+```bash
+export HY3_BASE_URL="http://127.0.0.1:30000/v1"
+```
+
+### OpenRouter
+
+```bash
+export HY3_PROVIDER="openrouter"
+export HY3_BASE_URL="https://openrouter.ai/api/v1"
+export OPENROUTER_API_KEY="<your-openrouter-api-key>"
+export HY3_MODEL="<openrouter-model-slug>"
+
+# Optional attribution headers used by OpenRouter.
+export OPENROUTER_HTTP_REFERER="https://your-site.example"
+export OPENROUTER_APP_TITLE="Your App Name"
+```
+
+`HY3_MODEL` 必须使用 OpenRouter 当前可用的 model slug。如果 OpenRouter 暂未提供 Hy3，请选择业务实际要调用的模型或接入你自己的 Hy3 网关。
+
+### 腾讯云混元 OpenAI 兼容接口
+
+```bash
+export HY3_PROVIDER="tencent"
+export HY3_BASE_URL="https://api.hunyuan.cloud.tencent.com/v1"
+export HUNYUAN_API_KEY="<your-hunyuan-api-key>"
+export HY3_MODEL="hunyuan-turbos-latest"
+
+# Optional Tencent custom body.
+export HY3_EXTRA_BODY_JSON='{"enable_enhancement": true}'
+```
+
+如腾讯云或你的企业网关暴露了 Hy3 专用模型名，请把 `HY3_MODEL` 改成服务实际返回的模型名。
+
+### Provider-specific body
+
+示例默认行为：
+
+- `HY3_PROVIDER=local` / `vllm` / `sglang`：自动发送 `chat_template_kwargs.reasoning_effort`。
+- `HY3_PROVIDER=openrouter`：默认发送 OpenRouter 标准 `reasoning` 参数，例如 `no_think -> {"effort": "none"}`、`high -> {"effort": "high"}`。
+- `HY3_PROVIDER=tencent`：默认不发送 Hy3 本地模板参数，避免目标云模型不兼容。
+- 远程服务如果也是 Hy3 vLLM/SGLang 且支持该参数，可设置 `HY3_SEND_REASONING=true`。
+- 需要额外顶层 body 参数时，设置 `HY3_EXTRA_BODY_JSON`，例如 `{"enable_enhancement": true}`。
+
+## 示例列表
+
+| 场景 | 运行命令 | 文档 |
+| --- | --- | --- |
+| Basic chat: 单轮 / 多轮 | `python3 examples/api/basic_chat.py` | `examples/api/basic_chat.md` |
+| Streaming: 流式请求 + chunk 解析 | `python3 examples/api/streaming.py` | `examples/api/streaming.md` |
+| Non-streaming vs streaming: 首 token / 总耗时 | `python3 examples/api/latency_compare.py` | `examples/api/latency_compare.md` |
+| Tool calling: 一次调用 + 工具循环 | `python3 examples/api/tool_calling.py` | `examples/api/tool_calling.md` |
+| Reasoning mode: 思考开 / 关 | `python3 examples/api/reasoning_mode.py` | `examples/api/reasoning_mode.md` |
+| Error handling & retry: 超时 / 限流 / 网络错误 | `python3 examples/api/retry.py` | `examples/api/retry.md` |
+
+## 约定
+
+- 默认 `model` 为 `hy3`，必须与服务启动时的 `--served-model-name` 一致。
+- 默认 `api_key` 为 `EMPTY`，适用于未启用鉴权的本地 vLLM/SGLang 服务。
+- 远程 provider 的 key 推荐使用 provider 原生命名：OpenRouter 使用 `OPENROUTER_API_KEY`，腾讯云混元使用 `HUNYUAN_API_KEY`。
+- 每个脚本都会打印 request body 和关键 response 字段，便于复制到日志或 issue 中排查。
+- 示例输出是参考形态，真实文本、token 数、延迟和 tool call 参数会受模型版本、硬件、服务框架和采样参数影响。

--- a/examples/api/basic_chat.md
+++ b/examples/api/basic_chat.md
@@ -1,0 +1,113 @@
+# Basic Chat
+
+覆盖单轮对话和多轮对话。脚本会先请求一次 Hy3，再把 assistant 回复加入 `messages`，继续发起第二轮请求。
+
+运行：
+
+```bash
+python3 examples/api/basic_chat.py
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；运行时打印的 request 是实际发送内容。
+
+单轮请求：
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Introduce Hy3 in one sentence.",
+        }
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+多轮请求会保留上一轮 user 和 assistant：
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {"role": "user", "content": "Introduce Hy3 in one sentence."},
+        {"role": "assistant", "content": "<first response content>"},
+        {
+            "role": "user",
+            "content": "Now give three practical API integration tips.",
+        },
+    ],
+    "temperature": 0.7,
+    "top_p": 1.0,
+    "max_tokens": 256,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+## 完整 response 解析
+
+脚本解析并打印：
+
+```python
+choice = response.choices[0]
+message = choice.message
+
+print("id:", response.id)
+print("model:", response.model)
+print("created:", response.created)
+print("finish_reason:", choice.finish_reason)
+print("role:", message.role)
+print("content:", message.content)
+print("reasoning_content:", getattr(message, "reasoning_content", None) or getattr(message, "reasoning", None))
+print("reasoning_details:", getattr(message, "reasoning_details", None))
+print("usage:", response.usage)
+```
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`：
+
+```text
+=== single_turn parsed response ===
+id: gen-1783435257-8O9wEgnzVkApyXfeP0f6
+model: tencent/hy3-20260706:free
+created: 1783435257
+finish_reason: stop
+role: assistant
+content: Hy3 (Hyperbolic v3) is the latest open-source large language model from Tencent, featuring a 0.5B-parameter lightweight version and supporting hybrid reasoning,agentic capabilities, and efficient deployment.
+
+=== usage ===
+{
+  "completion_tokens": 44,
+  "prompt_tokens": 23,
+  "total_tokens": 67
+}
+
+=== multi_turn parsed response ===
+id: gen-1783435259-ECHjHgjAUcU9UUDYaeRU
+model: tencent/hy3-20260706:free
+created: 1783435259
+finish_reason: stop
+role: assistant
+content: Here are three practical API integration tips for Hy3:
+
+1. **Use streaming responses for better UX** – Enable Server-Sent Events (SSE) or chunked output when calling Hy3’s chat endpoint so users see tokens incrementally instead of waiting for the full reply, which is especially useful for its hybrid reasoning mode.
+
+2. **Leverage the hybrid reasoning flag** – Explicitly set the `reasoning` parameter (e.g., `light` or `full`) in your API request to control cost and latency; use `light` for simple Q&A and `full` for agentic or complex tasks.
+
+3. **Run the 0.5B model locally for prototyping** – Deploy Hy3-0.5B via the open-source weights or a local server (e.g., with vLLM) to test prompts and agent loops offline before scaling to larger hosted instances, reducing API spend during development.
+```

--- a/examples/api/basic_chat.py
+++ b/examples/api/basic_chat.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Hy3 basic chat example: single-turn and multi-turn.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+
+Run:
+  python3 examples/api/basic_chat.py
+
+Sample output:
+  === single_turn parsed response ===
+  id: chatcmpl-...
+  model: hy3
+  finish_reason: stop
+  role: assistant
+  content: Hy3 is Tencent's MoE language model...
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from common import MODEL, make_client, print_json, print_runtime_config, request_options
+
+
+def print_chat_response(label: str, response: Any) -> str:
+    choice = response.choices[0]
+    message = choice.message
+    reasoning_content = getattr(message, "reasoning_content", None) or getattr(
+        message, "reasoning", None
+    )
+    reasoning_details = getattr(message, "reasoning_details", None)
+
+    print(f"\n=== {label} parsed response ===")
+    print("id:", response.id)
+    print("model:", response.model)
+    print("created:", response.created)
+    print("finish_reason:", choice.finish_reason)
+    print("role:", message.role)
+    print("content:", message.content)
+    if reasoning_content:
+        print("reasoning_content:", reasoning_content)
+    if reasoning_details:
+        print_json("reasoning_details", reasoning_details)
+    if response.usage:
+        print_json("usage", response.usage)
+
+    return message.content or ""
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client()
+
+    single_turn_request = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Introduce Hy3 in one sentence.",
+            }
+        ],
+        "temperature": 0.9,
+        "top_p": 1.0,
+        "max_tokens": 128,
+        **request_options(reasoning_effort="no_think"),
+    }
+
+    print_json("single_turn request", single_turn_request)
+    single_turn_response = client.chat.completions.create(**single_turn_request)
+    assistant_text = print_chat_response("single_turn", single_turn_response)
+
+    multi_turn_messages = list(single_turn_request["messages"])
+    multi_turn_messages.append({"role": "assistant", "content": assistant_text})
+    multi_turn_messages.append(
+        {
+            "role": "user",
+            "content": "Now give three practical API integration tips.",
+        }
+    )
+
+    multi_turn_request = {
+        "model": MODEL,
+        "messages": multi_turn_messages,
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        **request_options(reasoning_effort="no_think"),
+    }
+
+    print_json("multi_turn request", multi_turn_request)
+    multi_turn_response = client.chat.completions.create(**multi_turn_request)
+    print_chat_response("multi_turn", multi_turn_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/common.py
+++ b/examples/api/common.py
@@ -1,0 +1,220 @@
+"""Shared configuration helpers for Hy3 OpenAI-compatible API examples."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_FILE = REPO_ROOT / ".env"
+
+
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char == "#" and not in_single and not in_double:
+            if index == 0 or value[index - 1].isspace():
+                return value[:index].rstrip()
+    return value.strip()
+
+
+def _parse_env_value(raw_value: str) -> str:
+    value = _strip_inline_comment(raw_value.strip())
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value
+
+
+def load_dotenv(path: Path = ENV_FILE) -> None:
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key or key.startswith("#"):
+            continue
+        os.environ.setdefault(key, _parse_env_value(raw_value))
+
+
+load_dotenv()
+
+PROVIDER = os.getenv("HY3_PROVIDER", "local").strip().lower()
+
+
+def _env_first(*names: str, default: Optional[str] = None) -> Optional[str]:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return default
+
+
+def _cloud_key(name: str) -> Optional[str]:
+    value = os.getenv(name)
+    if not value or value == "EMPTY":
+        return None
+    return value
+
+
+def default_base_url() -> str:
+    if PROVIDER == "openrouter":
+        return "https://openrouter.ai/api/v1"
+    if PROVIDER in {"tencent", "tencent-hunyuan", "hunyuan"}:
+        return "https://api.hunyuan.cloud.tencent.com/v1"
+    return "http://127.0.0.1:8000/v1"
+
+
+def default_model() -> str:
+    if PROVIDER in {"tencent", "tencent-hunyuan", "hunyuan"}:
+        return "hunyuan-turbos-latest"
+    return "hy3"
+
+
+def default_api_key() -> str:
+    if PROVIDER == "openrouter":
+        return _cloud_key("OPENROUTER_API_KEY") or _cloud_key("HY3_API_KEY") or "EMPTY"
+    if PROVIDER in {"tencent", "tencent-hunyuan", "hunyuan"}:
+        return _cloud_key("HUNYUAN_API_KEY") or _cloud_key("HY3_API_KEY") or "EMPTY"
+    return _env_first("HY3_API_KEY", default="EMPTY") or "EMPTY"
+
+
+BASE_URL = _env_first("HY3_BASE_URL", default=default_base_url()) or default_base_url()
+API_KEY = default_api_key()
+MODEL = _env_first("HY3_MODEL", default=default_model()) or default_model()
+
+
+def default_headers() -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    if PROVIDER == "openrouter":
+        referer = os.getenv("OPENROUTER_HTTP_REFERER")
+        app_title = os.getenv("OPENROUTER_APP_TITLE")
+        if referer:
+            headers["HTTP-Referer"] = referer
+        if app_title:
+            headers["X-OpenRouter-Title"] = app_title
+    return headers
+
+
+def make_client(timeout: Optional[float] = None) -> Any:
+    from openai import OpenAI
+
+    kwargs: Dict[str, Any] = {
+        "base_url": BASE_URL,
+        "api_key": API_KEY,
+    }
+    headers = default_headers()
+    if headers:
+        kwargs["default_headers"] = headers
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return OpenAI(**kwargs)
+
+
+def _send_hy3_reasoning_by_default() -> bool:
+    return PROVIDER in {"local", "vllm", "sglang", "hy3", "self-hosted", "selfhosted"}
+
+
+def should_send_hy3_reasoning() -> bool:
+    value = os.getenv("HY3_SEND_REASONING", "auto").strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return _send_hy3_reasoning_by_default()
+
+
+def user_extra_body() -> Dict[str, Any]:
+    raw = os.getenv("HY3_EXTRA_BODY_JSON")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"HY3_EXTRA_BODY_JSON is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("HY3_EXTRA_BODY_JSON must decode to a JSON object")
+    return parsed
+
+
+def _openrouter_reasoning(reasoning_effort: str) -> Dict[str, str]:
+    effort_map = {
+        "no_think": "none",
+        "low": "low",
+        "high": "high",
+    }
+    return {"effort": effort_map.get(reasoning_effort, reasoning_effort)}
+
+
+def request_options(reasoning_effort: Optional[str] = "no_think") -> Dict[str, Any]:
+    extra_body = user_extra_body()
+    if reasoning_effort and PROVIDER == "openrouter" and "reasoning" not in extra_body:
+        extra_body["reasoning"] = _openrouter_reasoning(reasoning_effort)
+    elif reasoning_effort and should_send_hy3_reasoning():
+        chat_template_kwargs = dict(extra_body.get("chat_template_kwargs", {}))
+        chat_template_kwargs["reasoning_effort"] = reasoning_effort
+        extra_body["chat_template_kwargs"] = chat_template_kwargs
+    return {"extra_body": extra_body} if extra_body else {}
+
+
+def to_plain(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [to_plain(item) for item in value]
+    if isinstance(value, tuple):
+        return [to_plain(item) for item in value]
+    if isinstance(value, dict):
+        return {key: to_plain(item) for key, item in value.items()}
+    if hasattr(value, "model_dump"):
+        return to_plain(value.model_dump())
+    if hasattr(value, "dict"):
+        return to_plain(value.dict())
+    return value
+
+
+def print_json(title: str, value: Any) -> None:
+    print(f"\n=== {title} ===")
+    print(json.dumps(to_plain(value), ensure_ascii=False, indent=2))
+
+
+def print_runtime_config() -> None:
+    print_json(
+        "runtime config",
+        {
+            "provider": PROVIDER,
+            "base_url": BASE_URL,
+            "model": MODEL,
+            "api_key_source": "configured" if API_KEY != "EMPTY" else "EMPTY",
+            "send_hy3_reasoning": should_send_hy3_reasoning(),
+            "default_headers": default_headers(),
+            "user_extra_body": user_extra_body(),
+            "dotenv": str(ENV_FILE) if ENV_FILE.exists() else None,
+        },
+    )

--- a/examples/api/latency_compare.md
+++ b/examples/api/latency_compare.md
@@ -1,0 +1,105 @@
+# Non-Streaming vs Streaming Latency
+
+对比普通非流式请求和流式请求的时延。非流式只能得到总耗时；流式可以额外观察首 token 时延。
+
+运行：
+
+```bash
+python3 examples/api/latency_compare.py
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；运行时打印的 request 是实际发送内容。
+
+非流式请求：
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Write a concise checklist for productionizing a Hy3 API client.",
+        }
+    ],
+    "temperature": 0.7,
+    "top_p": 1.0,
+    "max_tokens": 256,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+流式请求只额外增加：
+
+```python
+{"stream": True}
+```
+
+## 完整 response 解析
+
+非流式：
+
+```python
+start = time.perf_counter()
+response = client.chat.completions.create(**request)
+total_s = time.perf_counter() - start
+
+message = response.choices[0].message
+print("finish_reason:", response.choices[0].finish_reason)
+print("content:", message.content)
+print("usage:", response.usage)
+```
+
+流式：
+
+```python
+start = time.perf_counter()
+stream = client.chat.completions.create(**streaming_request)
+
+first_token_s = None
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    content = getattr(delta, "content", None)
+    reasoning = getattr(delta, "reasoning_content", None)
+    if first_token_s is None and (content or reasoning):
+        first_token_s = time.perf_counter() - start
+
+total_s = time.perf_counter() - start
+```
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`：
+
+```text
+=== non_streaming parsed response ===
+finish_reason: length
+content: **Productionizing a Hy3 API Client – Checklist**
+
+- [ ] **Authentication**
+  - Store credentials/secrets in env vars or secret manager (never hardcode)
+  - Implement token refresh / expiry handling
+  - Use least-privilege API keys
+...
+non_streaming_total_s: 4.824
+
+=== latency comparison ===
+chunk_count: 136
+streaming_first_token_s: 1.814
+streaming_total_s: 3.128
+non_streaming_total_s: 4.824
+streaming_content: **Hy3 API Client Productionization Checklist**
+
+- [ ] **Auth & Secrets**
+  - Store API keys/tokens in secrets manager (not code)
+  - Support token refresh and rotation
+  - Scope permissions to least privilege
+...
+```
+
+这些数字只适合本机对比。真实时延会受到 GPU 型号、模型预热、队列深度、prompt 长度、生成长度、MTP/speculative decoding 和网络路径影响。

--- a/examples/api/latency_compare.py
+++ b/examples/api/latency_compare.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Compare Hy3 non-streaming total latency with streaming first-token latency.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+
+Run:
+  python3 examples/api/latency_compare.py
+
+Sample output:
+  non_streaming_total_s: 2.314
+  streaming_first_token_s: 0.482
+  streaming_total_s: 2.102
+"""
+
+from __future__ import annotations
+
+import time
+
+from common import MODEL, make_client, print_json, print_runtime_config, request_options
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client()
+    messages = [
+        {
+            "role": "user",
+            "content": "Write a concise checklist for productionizing a Hy3 API client.",
+        }
+    ]
+
+    base_request = {
+        "model": MODEL,
+        "messages": messages,
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        **request_options(reasoning_effort="no_think"),
+    }
+
+    print_json("non_streaming request", base_request)
+    non_streaming_start = time.perf_counter()
+    non_streaming_response = client.chat.completions.create(**base_request)
+    non_streaming_total = time.perf_counter() - non_streaming_start
+    non_streaming_text = non_streaming_response.choices[0].message.content or ""
+
+    print("\n=== non_streaming parsed response ===")
+    print("finish_reason:", non_streaming_response.choices[0].finish_reason)
+    print("content:", non_streaming_text)
+    print("non_streaming_total_s:", round(non_streaming_total, 3))
+    if non_streaming_response.usage:
+        print_json("non_streaming usage", non_streaming_response.usage)
+
+    streaming_request = dict(base_request)
+    streaming_request["stream"] = True
+
+    print_json("streaming request", streaming_request)
+    streaming_start = time.perf_counter()
+    stream = client.chat.completions.create(**streaming_request)
+
+    first_token_latency = None
+    chunk_count = 0
+    content_parts: list[str] = []
+
+    for chunk in stream:
+        chunk_count += 1
+        if not chunk.choices:
+            continue
+        delta = chunk.choices[0].delta
+        content = getattr(delta, "content", None)
+        reasoning_content = getattr(delta, "reasoning_content", None)
+        if content:
+            content_parts.append(content)
+        if first_token_latency is None and (content or reasoning_content):
+            first_token_latency = time.perf_counter() - streaming_start
+
+    streaming_total = time.perf_counter() - streaming_start
+    streaming_text = "".join(content_parts)
+
+    print("\n=== latency comparison ===")
+    print("chunk_count:", chunk_count)
+    print("streaming_first_token_s:", round(first_token_latency or 0.0, 3))
+    print("streaming_total_s:", round(streaming_total, 3))
+    print("non_streaming_total_s:", round(non_streaming_total, 3))
+    print("streaming_content:", streaming_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/reasoning_mode.md
+++ b/examples/api/reasoning_mode.md
@@ -1,0 +1,116 @@
+# Reasoning Mode
+
+对比 Hy3 的直接回答模式和思考模式。脚本对同一个问题分别发送 `reasoning_effort="no_think"` 与 `reasoning_effort="high"`。
+
+运行：
+
+```bash
+python3 examples/api/reasoning_mode.py
+```
+
+服务端需要启用 reasoning parser。vLLM 示例：
+
+```bash
+--reasoning-parser hy_v3
+```
+
+SGLang 示例：
+
+```bash
+--reasoning-parser hunyuan
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；如果远程服务支持 Hy3 reasoning parser，可设置 `HY3_SEND_REASONING=true`。
+
+关闭思考：
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "A service has 3 replicas. Each handles 18 requests per second. Traffic is 41 requests per second. Is there enough capacity?",
+        }
+    ],
+    "temperature": 0.2,
+    "top_p": 1.0,
+    "max_tokens": 512,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+开启高强度思考时仅替换：
+
+```python
+{
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "high",
+        }
+    }
+}
+```
+
+## 完整 response 解析
+
+```python
+choice = response.choices[0]
+message = choice.message
+reasoning_content = getattr(message, "reasoning_content", None) or getattr(
+    message, "reasoning", None
+)
+reasoning_details = getattr(message, "reasoning_details", None)
+
+print("finish_reason:", choice.finish_reason)
+print("reasoning_content:", reasoning_content)
+print("reasoning_details:", reasoning_details)
+print("answer:", message.content)
+print("usage:", response.usage)
+```
+
+注意：`message.reasoning_content`、`message.reasoning` 或 `message.reasoning_details` 是否存在取决于推理框架和 reasoning parser。生产客户端应该用 `getattr` 做兼容，不要假设该字段一定返回。
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`：
+
+```text
+=== reasoning_effort: no_think ===
+finish_reason: stop
+reasoning_content: <not exposed>
+answer: No, there is **not enough capacity**.
+
+- Capacity = 3 replicas × 18 requests/sec = **54 requests/sec**
+- Traffic = **41 requests/sec**
+
+Wait — actually, 54 > 41, so by total throughput there **is enough capacity**.
+
+**Answer: Yes, enough capacity (54 req/s available vs 41 req/s needed).**
+
+=== reasoning_effort: high ===
+finish_reason: stop
+reasoning_content_chars: 559
+reasoning_content_preview: We need answer question: "A service has 3 replicas. Each handles 18 requests per second. Traffic is 41 requests per second. Is there enough capacity?" Need compute total capacity = 3 * 18 = 54 requests per second...
+
+=== reasoning_details ===
+[
+  {
+    "type": "reasoning.text",
+    "format": "unknown",
+    "index": 0
+  }
+]
+answer: Yes.
+
+- Total capacity = 3 replicas × 18 requests/sec = **54 requests/sec**
+- Current traffic = **41 requests/sec**
+
+Since 54 > 41, there is enough capacity, with about **13 requests/sec** of spare headroom.
+```

--- a/examples/api/reasoning_mode.py
+++ b/examples/api/reasoning_mode.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Compare Hy3 direct mode and reasoning mode.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+
+Run:
+  python3 examples/api/reasoning_mode.py
+
+Sample output:
+  reasoning_effort: no_think
+  reasoning_content: <not exposed>
+  answer: ...
+
+  reasoning_effort: high
+  reasoning_content_chars: 936
+  answer: ...
+"""
+
+from __future__ import annotations
+
+from openai import OpenAI
+
+from common import MODEL, make_client, print_json, print_runtime_config, request_options
+
+
+def run_once(client: OpenAI, reasoning_effort: str) -> None:
+    request = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "A service has 3 replicas. Each handles 18 requests per second. "
+                    "Traffic is 41 requests per second. Is there enough capacity?"
+                ),
+            }
+        ],
+        "temperature": 0.2,
+        "top_p": 1.0,
+        "max_tokens": 512,
+        **request_options(reasoning_effort=reasoning_effort),
+    }
+
+    print_json(f"{reasoning_effort} request", request)
+    response = client.chat.completions.create(**request)
+    choice = response.choices[0]
+    message = choice.message
+    reasoning_content = getattr(message, "reasoning_content", None) or getattr(
+        message, "reasoning", None
+    )
+    reasoning_details = getattr(message, "reasoning_details", None)
+
+    print(f"\n=== reasoning_effort: {reasoning_effort} ===")
+    print("finish_reason:", choice.finish_reason)
+    if reasoning_content:
+        print("reasoning_content_chars:", len(reasoning_content))
+        print("reasoning_content_preview:", reasoning_content[:500])
+    else:
+        print("reasoning_content: <not exposed>")
+    if reasoning_details:
+        print_json("reasoning_details", reasoning_details)
+    print("answer:", message.content)
+    if response.usage:
+        print_json(f"{reasoning_effort} usage", response.usage)
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client()
+    run_once(client, "no_think")
+    run_once(client, "high")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/retry.md
+++ b/examples/api/retry.md
@@ -1,0 +1,104 @@
+# Error Handling and Retry
+
+演示超时、限流、网络错误和临时 5xx 的重试与退避。脚本不会重试明显永久失败的请求，例如参数错误、鉴权失败、权限不足和模型不存在。
+
+运行：
+
+```bash
+python3 examples/api/retry.py
+```
+
+可选配置：
+
+```bash
+export HY3_TIMEOUT="30"
+export HY3_RETRY_MAX_ATTEMPTS="5"
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；运行时打印的 request 是实际发送内容。
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Give a compact checklist for retrying Hy3 API requests safely.",
+        }
+    ],
+    "temperature": 0.3,
+    "top_p": 1.0,
+    "max_tokens": 256,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+## 完整 response 解析
+
+成功后脚本解析：
+
+```python
+choice = response.choices[0]
+message = choice.message
+
+print("id:", response.id)
+print("model:", response.model)
+print("finish_reason:", choice.finish_reason)
+print("content:", message.content)
+print("usage:", response.usage)
+```
+
+## 重试策略
+
+会重试：
+
+- `APIConnectionError`
+- `APITimeoutError`
+- `RateLimitError`
+- HTTP `408`, `409`, `425`, `429`, `500`, `502`, `503`, `504`
+
+不会重试：
+
+- `BadRequestError`
+- `AuthenticationError`
+- `PermissionDeniedError`
+- `NotFoundError`
+
+退避公式：
+
+```python
+base = min(8.0, 0.5 * (2 ** (attempt - 1)))
+jitter = random.uniform(0.0, 0.25)
+sleep_s = base + jitter
+```
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`：
+
+```text
+attempt=1 status=success
+
+=== parsed response ===
+id: gen-1783435763-8gXkk17QfMYqSBQIDnpb
+model: tencent/hy3-20260706:free
+finish_reason: stop
+content: **Compact Checklist: Safe Retries for Hy3 API Requests**
+
+- [ ] **Idempotency**: Use idempotency keys / safe methods (GET, conditional PUT) to avoid duplicate side effects.
+- [ ] **Retry triggers**: Retry only on 429, 500–503, timeouts, or connection errors. Do **not** retry 4xx (except 429/408).
+- [ ] **Backoff**: Use exponential backoff + jitter (e.g., base 0.5s, cap 10s).
+- [ ] **Limit**: Max 3–5 attempts; fail fast after limit.
+- [ ] **Respect headers**: Honor `Retry-After` on 429/503.
+- [ ] **Timeouts**: Set per-request and total deadline; cancel hung calls.
+- [ ] **Concurrency**: Cap parallel retries; avoid thundering herd.
+- [ ] **Observability**: Log attempt count, status, latency; alert on spike.
+- [ ] **Token/session**: Refresh auth before retry if 401 on first attempt only.
+- [ ] **Circuit breaker**: Open circuit on sustained failures; half-open to test recovery.
+```

--- a/examples/api/retry.py
+++ b/examples/api/retry.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Hy3 error handling and retry example with exponential backoff.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+  HY3_TIMEOUT=30
+  HY3_RETRY_MAX_ATTEMPTS=5
+
+Run:
+  python3 examples/api/retry.py
+
+Sample output:
+  attempt=1 status=retryable error=RateLimitError sleep_s=0.64
+  attempt=2 status=success
+  content: ...
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+
+from common import MODEL, make_client, print_json, print_runtime_config, request_options
+
+
+TIMEOUT = float(os.getenv("HY3_TIMEOUT", "30"))
+MAX_ATTEMPTS = int(os.getenv("HY3_RETRY_MAX_ATTEMPTS", "5"))
+
+T = TypeVar("T")
+
+PERMANENT_ERRORS = (
+    BadRequestError,
+    AuthenticationError,
+    PermissionDeniedError,
+    NotFoundError,
+)
+RETRYABLE_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
+
+
+def is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, PERMANENT_ERRORS):
+        return False
+    if isinstance(exc, (APIConnectionError, APITimeoutError, RateLimitError)):
+        return True
+    if isinstance(exc, APIStatusError):
+        return exc.status_code in RETRYABLE_STATUS_CODES
+    return False
+
+
+def backoff_seconds(attempt: int) -> float:
+    base = min(8.0, 0.5 * (2 ** (attempt - 1)))
+    jitter = random.uniform(0.0, 0.25)
+    return base + jitter
+
+
+def call_with_retry(operation: Callable[[], T], max_attempts: int = MAX_ATTEMPTS) -> T:
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = operation()
+            print(f"attempt={attempt} status=success")
+            return result
+        except Exception as exc:
+            retryable = is_retryable(exc)
+            if not retryable or attempt == max_attempts:
+                print(
+                    "attempt={attempt} status=failed retryable={retryable} "
+                    "error_type={error_type} error={error}".format(
+                        attempt=attempt,
+                        retryable=retryable,
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
+                )
+                raise
+
+            sleep_s = backoff_seconds(attempt)
+            status_code = getattr(exc, "status_code", None)
+            print(
+                "attempt={attempt} status=retryable status_code={status_code} "
+                "error_type={error_type} sleep_s={sleep_s:.2f}".format(
+                    attempt=attempt,
+                    status_code=status_code,
+                    error_type=type(exc).__name__,
+                    sleep_s=sleep_s,
+                )
+            )
+            time.sleep(sleep_s)
+
+    raise RuntimeError("retry loop exited unexpectedly")
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client(timeout=TIMEOUT)
+
+    request = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Give a compact checklist for retrying Hy3 API requests safely.",
+            }
+        ],
+        "temperature": 0.3,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        **request_options(reasoning_effort="no_think"),
+    }
+    print_json("retry request", request)
+
+    response = call_with_retry(lambda: client.chat.completions.create(**request))
+    choice = response.choices[0]
+    message = choice.message
+
+    print("\n=== parsed response ===")
+    print("id:", response.id)
+    print("model:", response.model)
+    print("finish_reason:", choice.finish_reason)
+    print("content:", message.content)
+    if response.usage:
+        print_json("usage", response.usage)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/streaming.md
+++ b/examples/api/streaming.md
@@ -1,0 +1,86 @@
+# Streaming
+
+演示 `stream=True` 的流式请求，并逐个解析 chunk 中的 delta 字段。
+
+运行：
+
+```bash
+python3 examples/api/streaming.py
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；运行时打印的 request 是实际发送内容。
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "List four steps for validating a Hy3 API integration.",
+        }
+    ],
+    "temperature": 0.7,
+    "top_p": 1.0,
+    "max_tokens": 256,
+    "stream": True,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+## 完整 response 解析
+
+流式返回不是一次性 `ChatCompletion`，而是多个 chunk。脚本逐 chunk 解析：
+
+```python
+for chunk in stream:
+    choice = chunk.choices[0]
+    delta = choice.delta
+
+    role = getattr(delta, "role", None)
+    content = getattr(delta, "content", None)
+    reasoning_content = getattr(delta, "reasoning_content", None)
+    tool_calls = getattr(delta, "tool_calls", None)
+    finish_reason = choice.finish_reason
+```
+
+解析策略：
+
+- `delta.role` 通常只在首个 chunk 出现。
+- `delta.content` 是增量文本，需要自行拼接。
+- `delta.reasoning_content` 只有在服务端暴露 reasoning 字段时出现。
+- `delta.tool_calls` 在流式 tool calling 中按片段返回，需要按 tool call id 和 index 合并。
+- 最后一个 chunk 通常带有 `finish_reason`。
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`。文档只展示前几个 chunk；脚本运行时会打印完整 chunk 序列。
+
+```text
+=== streaming chunks ===
+chunk=000 id=gen-1783435271-ezkYYqX8uvxIdy2u4U1G role='assistant' content='Here' reasoning_delta=None reasoning_details=None tool_calls=None finish_reason=None
+chunk=001 id=gen-1783435271-ezkYYqX8uvxIdy2u4U1G role='assistant' content=' are four' reasoning_delta=None reasoning_details=None tool_calls=None finish_reason=None
+chunk=002 id=gen-1783435271-ezkYYqX8uvxIdy2u4U1G role='assistant' content=' steps for' reasoning_delta=None reasoning_details=None tool_calls=None finish_reason=None
+...
+chunk=111 id=gen-1783435271-ezkYYqX8uvxIdy2u4U1G role='assistant' content='' reasoning_delta=None reasoning_details=None tool_calls=None finish_reason='stop'
+
+=== final assembled response ===
+final_content: Here are four steps for validating a Hy3 API integration:
+
+1. **Authentication & Credential Check**  
+   Verify that API keys, tokens, or OAuth credentials are correctly configured and that requests successfully authenticate against the Hy3 endpoint.
+
+2. **Request Schema Validation**  
+   Confirm that all required parameters, headers, and payload structures match the Hy3 API specification (e.g., correct JSON format, field names, and data types).
+
+3. **Functional Response Testing**  
+   Send test requests for core use cases and verify that the API returns expected status codes, response bodies, and error messages under both success and failure conditions.
+
+4. **End-to-End Integration Verification**  
+   Run the integration within your actual application workflow to ensure data flows correctly between Hy3 and your system, including handling rate limits, retries, and webhooks if applicable.
+```

--- a/examples/api/streaming.py
+++ b/examples/api/streaming.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Hy3 streaming example: request with stream=True and parse every chunk.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+
+Run:
+  python3 examples/api/streaming.py
+
+Sample output:
+  chunk=000 role=assistant content='' finish_reason=None
+  chunk=001 role=None content='Hy3' finish_reason=None
+  ...
+  final_content: Hy3 can help with API integration...
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from common import (
+    MODEL,
+    make_client,
+    print_json,
+    print_runtime_config,
+    request_options,
+    to_plain,
+)
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client()
+
+    request = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": "List four steps for validating a Hy3 API integration.",
+            }
+        ],
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        "stream": True,
+        **request_options(reasoning_effort="no_think"),
+    }
+
+    print_json("streaming request", request)
+
+    stream = client.chat.completions.create(**request)
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_call_deltas: list[Any] = []
+
+    print("\n=== streaming chunks ===")
+    for index, chunk in enumerate(stream):
+        if not chunk.choices:
+            print(f"chunk={index:03d} choices=[]")
+            continue
+
+        choice = chunk.choices[0]
+        delta = choice.delta
+        role = getattr(delta, "role", None)
+        content = getattr(delta, "content", None)
+        reasoning_content = getattr(delta, "reasoning_content", None) or getattr(
+            delta, "reasoning", None
+        )
+        reasoning_details = getattr(delta, "reasoning_details", None)
+        tool_calls = getattr(delta, "tool_calls", None)
+
+        if content:
+            content_parts.append(content)
+        if reasoning_content:
+            reasoning_parts.append(reasoning_content)
+        if reasoning_details:
+            reasoning_parts.append(str(to_plain(reasoning_details)))
+        if tool_calls:
+            tool_call_deltas.extend(tool_calls)
+
+        print(
+            "chunk={idx:03d} id={id} role={role!r} content={content!r} "
+            "reasoning_delta={reasoning!r} reasoning_details={reasoning_details} tool_calls={tool_calls} "
+            "finish_reason={finish!r}".format(
+                idx=index,
+                id=chunk.id,
+                role=role,
+                content=content,
+                reasoning=reasoning_content,
+                reasoning_details=json.dumps(to_plain(reasoning_details), ensure_ascii=False)
+                if reasoning_details
+                else None,
+                tool_calls=json.dumps(to_plain(tool_calls), ensure_ascii=False)
+                if tool_calls
+                else None,
+                finish=choice.finish_reason,
+            )
+        )
+
+    print("\n=== final assembled response ===")
+    print("final_content:", "".join(content_parts))
+    if reasoning_parts:
+        print("final_reasoning_content:", "".join(reasoning_parts))
+    if tool_call_deltas:
+        print_json("tool_call_deltas", tool_call_deltas)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/tool_calling.md
+++ b/examples/api/tool_calling.md
@@ -1,0 +1,162 @@
+# Tool Calling
+
+演示 Hy3 的 OpenAI-compatible tool calling。脚本定义一个本地 `get_weather` 工具，让模型发起工具调用，客户端执行工具后再把结果发回模型，直到模型给出最终答案。
+
+运行：
+
+```bash
+python3 examples/api/tool_calling.py
+```
+
+服务端需要启用 tool parser。vLLM 示例：
+
+```bash
+--tool-call-parser hy_v3
+--enable-auto-tool-choice
+```
+
+SGLang 示例：
+
+```bash
+--tool-call-parser hunyuan
+```
+
+## 完整请求
+
+下面展示本地 vLLM/SGLang 默认请求。使用 OpenRouter、腾讯云或其他远程 provider 时，脚本会根据 `examples/api/common.py` 的配置去掉 Hy3 本地模板参数或合并 `HY3_EXTRA_BODY_JSON`；运行时打印的 request 是实际发送内容。
+
+工具定义：
+
+```python
+[
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a supported city.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "City name, for example Shenzhen or Beijing.",
+                    }
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+```
+
+首轮请求：
+
+```python
+{
+    "model": "hy3",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Use the weather tool to check Shenzhen. Then tell me if I should bring an umbrella.",
+        }
+    ],
+    "tools": TOOLS,
+    "tool_choice": "auto",
+    "temperature": 0.2,
+    "top_p": 1.0,
+    "max_tokens": 512,
+    "extra_body": {
+        "chat_template_kwargs": {
+            "reasoning_effort": "no_think",
+        }
+    },
+}
+```
+
+工具返回后追加的消息：
+
+```python
+[
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"Shenzhen\"}",
+                },
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_abc123",
+        "name": "get_weather",
+        "content": "{\"city\":\"Shenzhen\",\"condition\":\"light rain\",\"temperature_c\":29,\"humidity_percent\":82,\"umbrella_recommended\":true}",
+    },
+]
+```
+
+## 完整 response 解析
+
+```python
+message = response.choices[0].message
+tool_calls = getattr(message, "tool_calls", None) or []
+
+for tool_call in tool_calls:
+    function_name = tool_call.function.name
+    arguments = json.loads(tool_call.function.arguments or "{}")
+    result = execute_tool(function_name, arguments)
+```
+
+工具循环停止条件：
+
+- 如果 `tool_calls` 非空，执行本地工具并追加 `tool` role 消息。
+- 如果 `tool_calls` 为空，读取 `message.content` 作为最终回复。
+- 示例最多执行 `HY3_MAX_TOOL_ROUNDS` 轮，避免工具循环失控。
+
+## 示例输出
+
+以下输出来自实际调用 OpenRouter `tencent/hy3:free`：
+
+```text
+=== assistant response ===
+id: gen-1783435594-K4teaUQsYk5cxiJWEYtq
+model: tencent/hy3-20260706:free
+finish_reason: tool_calls
+content: None
+
+=== tool_calls ===
+[
+  {
+    "id": "chatcmpl-tool-a5d4ffc6024a0e0a",
+    "function": {
+      "arguments": "{\"city\": \"Shenzhen\"}",
+      "name": "get_weather"
+    },
+    "type": "function",
+    "index": 0
+  }
+]
+
+=== parsed_tool_call ===
+get_weather({"city": "Shenzhen"})
+
+=== tool_result ===
+{
+  "city": "Shenzhen",
+  "condition": "light rain",
+  "temperature_c": 29,
+  "humidity_percent": 82,
+  "umbrella_recommended": true
+}
+
+=== final_content ===
+The weather in Shenzhen right now is **light rain**, with a temperature of 29°C and humidity at 82%. The weather data also explicitly recommends bringing an umbrella.
+
+**Yes, you should bring an umbrella** — it's currently raining lightly, so it'll keep you dry. ☔
+```

--- a/examples/api/tool_calling.py
+++ b/examples/api/tool_calling.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Hy3 tool calling example with a deterministic local weather tool.
+
+Environment:
+  HY3_BASE_URL=http://127.0.0.1:8000/v1
+  HY3_API_KEY=EMPTY
+  HY3_MODEL=hy3
+
+Run:
+  python3 examples/api/tool_calling.py
+
+Sample output:
+  parsed_tool_call: get_weather({"city": "Shenzhen"})
+  tool_result: {"city": "Shenzhen", "temperature_c": 29, ...}
+  final_content: It is rainy in Shenzhen, so bring an umbrella.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from common import (
+    MODEL,
+    make_client,
+    print_json,
+    print_runtime_config,
+    request_options,
+    to_plain,
+)
+
+MAX_TOOL_ROUNDS = int(os.getenv("HY3_MAX_TOOL_ROUNDS", "4"))
+
+
+WEATHER_BY_CITY = {
+    "Shenzhen": {
+        "city": "Shenzhen",
+        "condition": "light rain",
+        "temperature_c": 29,
+        "humidity_percent": 82,
+        "umbrella_recommended": True,
+    },
+    "Beijing": {
+        "city": "Beijing",
+        "condition": "clear",
+        "temperature_c": 24,
+        "humidity_percent": 40,
+        "umbrella_recommended": False,
+    },
+}
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a supported city.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "City name, for example Shenzhen or Beijing.",
+                    }
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def get_weather(city: str) -> dict[str, Any]:
+    return WEATHER_BY_CITY.get(
+        city,
+        {
+            "city": city,
+            "condition": "unknown",
+            "error": "City is not in the local example data.",
+        },
+    )
+
+
+def parse_arguments(arguments: Optional[str]) -> dict[str, Any]:
+    if not arguments:
+        return {}
+    try:
+        return json.loads(arguments)
+    except json.JSONDecodeError as exc:
+        return {"_parse_error": str(exc), "_raw_arguments": arguments}
+
+
+def assistant_message_to_dict(message: Any) -> dict[str, Any]:
+    tool_calls = getattr(message, "tool_calls", None) or []
+    payload: dict[str, Any] = {
+        "role": "assistant",
+        "content": message.content,
+    }
+    if tool_calls:
+        payload["tool_calls"] = [
+            {
+                "id": tool_call.id,
+                "type": tool_call.type,
+                "function": {
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                },
+            }
+            for tool_call in tool_calls
+        ]
+    return payload
+
+
+def execute_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    if "_parse_error" in arguments:
+        return {"error": "Invalid JSON arguments", "details": arguments}
+    if name == "get_weather":
+        return get_weather(city=str(arguments.get("city", "")))
+    return {"error": f"Unknown tool: {name}"}
+
+
+def print_response(response: Any) -> Any:
+    choice = response.choices[0]
+    message = choice.message
+    print("\n=== assistant response ===")
+    print("id:", response.id)
+    print("model:", response.model)
+    print("finish_reason:", choice.finish_reason)
+    print("content:", message.content)
+    if getattr(message, "tool_calls", None):
+        print_json("tool_calls", message.tool_calls)
+    if response.usage:
+        print_json("usage", response.usage)
+    return message
+
+
+def main() -> None:
+    print_runtime_config()
+    client = make_client()
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": (
+                "Use the weather tool to check Shenzhen. "
+                "Then tell me if I should bring an umbrella."
+            ),
+        }
+    ]
+
+    for round_index in range(1, MAX_TOOL_ROUNDS + 1):
+        request = {
+            "model": MODEL,
+            "messages": messages,
+            "tools": TOOLS,
+            "tool_choice": "auto",
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": 512,
+            **request_options(reasoning_effort="no_think"),
+        }
+        print_json(f"tool round {round_index} request", request)
+        response = client.chat.completions.create(**request)
+        message = print_response(response)
+        tool_calls = getattr(message, "tool_calls", None) or []
+
+        if not tool_calls:
+            print("\n=== final_content ===")
+            print(message.content)
+            return
+
+        messages.append(assistant_message_to_dict(message))
+
+        for tool_call in tool_calls:
+            function_name = tool_call.function.name
+            arguments = parse_arguments(tool_call.function.arguments)
+            result = execute_tool(function_name, arguments)
+
+            print("\n=== parsed_tool_call ===")
+            print(f"{function_name}({json.dumps(arguments, ensure_ascii=False)})")
+            print_json("tool_result", result)
+
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "name": function_name,
+                    "content": json.dumps(result, ensure_ascii=False),
+                }
+            )
+
+    raise RuntimeError(f"Tool loop exceeded {MAX_TOOL_ROUNDS} rounds")
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,288 @@
+# Hy3 API Quickstart
+
+本文面向已经启动 Hy3 推理服务的开发者，目标是 5 分钟跑通第一次调用，半小时掌握常用能力。Hy3 服务通过 vLLM 或 SGLang 暴露 OpenAI-compatible API，调用方式与 OpenAI Chat Completions 接近。
+
+## 0. 启动服务
+
+先按照根目录 `README.md` / `README_CN.md` 的部署章节启动 vLLM 或 SGLang，并确认启动参数里包含：
+
+```bash
+--served-model-name hy3
+--tool-call-parser hy_v3      # vLLM
+--reasoning-parser hy_v3      # vLLM
+```
+
+SGLang 对应参数为：
+
+```bash
+--served-model-name hy3
+--tool-call-parser hunyuan
+--reasoning-parser hunyuan
+```
+
+如果你只想验证 API 客户端代码，可以先把下面的环境变量指向任意兼容 OpenAI Chat Completions 的 Hy3 服务。
+
+## 1. 基础信息
+
+| 项目 | 默认值 | 说明 |
+| --- | --- | --- |
+| Base URL | `http://127.0.0.1:8000/v1` | vLLM/SGLang 本地服务默认示例地址。SGLang 如果使用默认端口 30000，请改成 `http://127.0.0.1:30000/v1`。 |
+| API key | `EMPTY` | 本地服务未配置鉴权时可用任意非空字符串。若启动服务时设置了 `--api-key` 或前面接了网关，请使用真实 key。 |
+| Model name | `hy3` | 与服务启动时的 `--served-model-name hy3` 保持一致。 |
+| Endpoint | `/chat/completions` | 完整 URL 为 `${HY3_BASE_URL}/chat/completions`。 |
+| Rate limits | 无固定模型侧限制 | 自部署场景的有效限流由 GPU 显存、并发、队列、`max_model_len`、vLLM/SGLang 调度和网关策略共同决定。生产环境建议在 API 网关层设置 QPS、并发和超时限制。 |
+
+## 2. Provider 配置
+
+所有 examples 都通过 `examples/api/common.py` 读取环境变量。默认配置面向本地 vLLM/SGLang；设置 `HY3_PROVIDER` 后可切换到 OpenRouter、腾讯云混元或其他 OpenAI-compatible 网关。
+
+推荐把配置写在仓库根目录 `.env`，也就是和 `quickstart.md` 同级的位置：
+
+```bash
+cp .env.example .env
+```
+
+然后编辑 `.env`，选择本地、OpenRouter、腾讯云或自定义网关其中一种配置。`examples/api/*.py` 会自动加载根目录 `.env`；如果同名变量已经在 shell 中通过 `export` 设置，shell 变量优先。
+
+### 本地 vLLM / SGLang
+
+```bash
+export HY3_PROVIDER="local"
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+本地模式默认会发送 Hy3 chat template 参数：
+
+```json
+{"chat_template_kwargs": {"reasoning_effort": "no_think"}}
+```
+
+### OpenRouter
+
+OpenRouter 官方 OpenAI SDK base URL 为 `https://openrouter.ai/api/v1`，鉴权使用 Bearer API key。OpenRouter 还支持可选的应用归因 headers：`HTTP-Referer` 和 `X-OpenRouter-Title`。
+
+```bash
+export HY3_PROVIDER="openrouter"
+export HY3_BASE_URL="https://openrouter.ai/api/v1"
+export OPENROUTER_API_KEY="<your-openrouter-api-key>"
+export HY3_MODEL="<openrouter-model-slug>"
+
+# Optional attribution headers.
+export OPENROUTER_HTTP_REFERER="https://your-site.example"
+export OPENROUTER_APP_TITLE="Your App Name"
+```
+
+说明：
+
+- `HY3_MODEL` 必须是 OpenRouter 当前可用的 model slug；如果 OpenRouter 上架 Hy3，请填对应 slug。
+- 不应假定 OpenRouter 上的目标模型支持 Hy3 本地模板扩展参数，因此 examples 在 `HY3_PROVIDER=openrouter` 时默认不发送 `chat_template_kwargs`，而是使用 OpenRouter 标准 `reasoning` 参数。
+- OpenRouter 下 examples 会自动映射 `reasoning_effort="no_think"` 为 `{"reasoning": {"effort": "none"}}`，避免 `tencent/hy3:free` 把全部 `max_tokens` 用在 reasoning tokens 上而返回空 `content`。
+- 如你的 OpenRouter 路由后端确实支持 Hy3 模板扩展，可显式设置 `HY3_SEND_REASONING=true`。
+
+### 腾讯云混元 OpenAI 兼容接口
+
+腾讯云混元官方 OpenAI 兼容 base URL 为 `https://api.hunyuan.cloud.tencent.com/v1`，完整 chat completions 地址为 `https://api.hunyuan.cloud.tencent.com/v1/chat/completions`。API key 需要在腾讯云控制台创建。腾讯云文档示例模型为 `hunyuan-turbos-latest`；如果你的账号或服务暴露了 Hy3 相关模型名，请把 `HY3_MODEL` 改为实际模型名。
+
+```bash
+export HY3_PROVIDER="tencent"
+export HY3_BASE_URL="https://api.hunyuan.cloud.tencent.com/v1"
+export HUNYUAN_API_KEY="<your-hunyuan-api-key>"
+export HY3_MODEL="hunyuan-turbos-latest"
+
+# Optional Tencent custom body. For example:
+export HY3_EXTRA_BODY_JSON='{"enable_enhancement": true}'
+```
+
+说明：
+
+- 腾讯云混元文档中的生文接口默认并发限制为 5 个并发，实际限额以账号、模型和控制台配置为准。
+- 不应假定腾讯云混元接口支持 Hy3 本地模板扩展参数，因此 examples 在 `HY3_PROVIDER=tencent` 时默认不发送 `chat_template_kwargs`。
+
+### 其他 OpenAI-compatible 网关
+
+```bash
+export HY3_PROVIDER="custom"
+export HY3_BASE_URL="https://your-gateway.example/v1"
+export HY3_API_KEY="<your-api-key>"
+export HY3_MODEL="<served-model-name>"
+```
+
+如果该远程网关是你自建的 Hy3 vLLM/SGLang 服务，并支持 Hy3 reasoning parser，可打开：
+
+```bash
+export HY3_SEND_REASONING=true
+```
+
+## 3. 最小可运行示例
+
+### curl
+
+本地 vLLM/SGLang 请求可以直接携带 Hy3 模板参数：
+
+```bash
+curl "${HY3_BASE_URL:-http://127.0.0.1:8000/v1}/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY:-EMPTY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"${HY3_MODEL:-hy3}"'",
+    "messages": [
+      {"role": "user", "content": "Hello! Introduce Hy3 in one sentence."}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128,
+    "chat_template_kwargs": {
+      "reasoning_effort": "no_think"
+    }
+  }'
+```
+
+OpenRouter / 腾讯云这类云服务通常使用普通 OpenAI-compatible body，不要默认携带本地 Hy3 `chat_template_kwargs`：
+
+```bash
+curl "${HY3_BASE_URL}/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY:-${OPENROUTER_API_KEY:-${HUNYUAN_API_KEY}}}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"${HY3_MODEL}"'",
+    "messages": [
+      {"role": "user", "content": "Hello! Introduce yourself in one sentence."}
+    ],
+    "temperature": 0.7,
+    "top_p": 1.0,
+    "max_tokens": 128
+  }'
+```
+
+返回中最常用字段：
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "created": 1783400000,
+  "model": "hy3",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hy3 is Tencent's MoE language model for agentic, reasoning, and long-context tasks."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 32,
+    "completion_tokens": 22,
+    "total_tokens": 54
+  }
+}
+```
+
+### Python OpenAI SDK
+
+安装依赖：
+
+```bash
+python3 -m pip install "openai>=1.0.0"
+```
+
+运行：
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url=os.getenv("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+    api_key=os.getenv("HY3_API_KEY", os.getenv("OPENROUTER_API_KEY", os.getenv("HUNYUAN_API_KEY", "EMPTY"))),
+)
+
+response = client.chat.completions.create(
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[
+        {"role": "user", "content": "Hello! Introduce Hy3 in one sentence."},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+
+message = response.choices[0].message
+print("finish_reason:", response.choices[0].finish_reason)
+print("content:", message.content)
+print("usage:", response.usage)
+```
+
+远程云服务不一定支持 `extra_body={"chat_template_kwargs": ...}`。本仓库 examples 已经通过 `HY3_PROVIDER` 做了默认区分：本地发送，OpenRouter / 腾讯云不发送。
+
+## 4. 常用参数
+
+| 参数 | 类型 | 建议起点 | 说明 |
+| --- | --- | --- | --- |
+| `temperature` | number | `0.9` | 控制随机性。越低越稳定，越高越发散。代码生成、结构化输出可从 `0.2` 到 `0.7` 试起；开放创作可使用 `0.9`。 |
+| `top_p` | number | `1.0` | nucleus sampling 截断概率。通常与 `temperature` 二选一优先调节；不确定时保持 `1.0`。 |
+| `max_tokens` | integer | `128` 到 `2048` | 限制本次生成的最大 token 数。过小会导致 `finish_reason="length"`；过大增加延迟和显存压力。 |
+| `stop` | string 或 array | 视任务而定 | 命中 stop 序列后停止生成。适合模板化输出、分隔符协议、日志切分。 |
+| `tools` | array | 仅工具调用任务开启 | OpenAI-compatible tool calling。需要服务启动时启用对应 tool call parser，并在客户端实现本地工具执行循环。 |
+| `extra_body.chat_template_kwargs.reasoning_effort` | string | `"no_think"` | Hy3 思考模式开关。`"no_think"` 为直接回答；`"low"` 适合中等推理；`"high"` 适合数学、代码、复杂规划等任务。 |
+| `HY3_EXTRA_BODY_JSON` | JSON object | unset | 给云服务或自建网关传 provider-specific 顶层参数，例如腾讯云 `{"enable_enhancement": true}`。 |
+
+Reasoning 内容是否在响应里以 `message.reasoning_content` 暴露，取决于服务端 reasoning parser 和推理框架支持。即使未暴露 reasoning 字段，`reasoning_effort` 仍会传给 chat template。
+
+## 5. Examples
+
+示例目录：`examples/api/`
+
+| 能力 | 文件 | 说明 |
+| --- | --- | --- |
+| Basic chat | `examples/api/basic_chat.py` / `.md` | 单轮与多轮对话。 |
+| Streaming | `examples/api/streaming.py` / `.md` | 流式请求与逐 chunk 解析。 |
+| Non-streaming vs streaming | `examples/api/latency_compare.py` / `.md` | 首 token 时延和总耗时对比。 |
+| Tool calling | `examples/api/tool_calling.py` / `.md` | 一次工具调用与多轮工具循环。 |
+| Reasoning mode | `examples/api/reasoning_mode.py` / `.md` | 思考模式开/关对比。 |
+| Error handling & retry | `examples/api/retry.py` / `.md` | 超时、限流、网络错误的重试与退避。 |
+
+运行前确认：
+
+```bash
+python3 -m pip install "openai>=1.0.0"
+cp .env.example .env
+
+# Edit .env, or export variables directly:
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+## 6. 常见报错排查
+
+| 现象 | 常见原因 | 处理方式 |
+| --- | --- | --- |
+| `Connection refused` / `ConnectError` | 服务未启动、端口不对、容器端口未映射 | 检查 vLLM/SGLang 日志；确认 `HY3_BASE_URL` 端口和 `/v1` 后缀。 |
+| `401 Unauthorized` / `403 Forbidden` | API key 不匹配，或网关鉴权失败 | 本地无鉴权时用 `EMPTY`；启用 `--api-key` 或网关后使用真实 key。 |
+| `404 model not found` | `model` 与 `--served-model-name` 不一致 | 启动服务时使用 `--served-model-name hy3`，或把 `HY3_MODEL` 改成服务实际模型名。 |
+| 请求长时间无响应 | 首次加载/预热、队列拥塞、prompt 太长、`max_tokens` 过大 | 先用短 prompt 和小 `max_tokens` 验证；观察服务端 GPU 显存和队列。 |
+| `429` / `503` | 网关限流或推理服务过载 | 降低并发，增加指数退避重试，或扩容服务实例。 |
+| `finish_reason="length"` | `max_tokens` 太小 | 增大 `max_tokens` 或缩短 prompt。 |
+| tool call 解析失败 | 服务未启用 tool call parser，或工具 JSON schema 太复杂 | 确认启动参数；先用简单 schema 验证；在客户端记录原始 `tool_calls`。 |
+| 没有 `reasoning_content` | 服务端未启用 reasoning parser，或框架没有分离返回思考内容 | 确认 `--reasoning-parser`；客户端用 `getattr(message, "reasoning_content", None)` 做兼容。 |
+| context length / token limit 错误 | 输入超过服务配置或模型上下文限制 | 缩短历史消息、启用摘要、降低单次输入长度，或调整服务端最大上下文配置。 |
+| OpenRouter `401` | `OPENROUTER_API_KEY` 未设置或 key 无效 | 设置 `HY3_PROVIDER=openrouter` 和 `OPENROUTER_API_KEY`；确认账户额度和模型可用性。 |
+| OpenRouter `404` / model not found | `HY3_MODEL` 不是 OpenRouter model slug | 到 OpenRouter models 页面确认当前 slug。 |
+| 腾讯云 `401` / `403` | `HUNYUAN_API_KEY` 未设置、权限或计费状态异常 | 设置 `HY3_PROVIDER=tencent` 和 `HUNYUAN_API_KEY`；检查控制台 API key、服务开通和额度。 |
+| 云服务报不认识 `chat_template_kwargs` | 把本地 Hy3 模板参数发送到了云 API | 使用 `HY3_PROVIDER=openrouter` 或 `HY3_PROVIDER=tencent`，或设置 `HY3_SEND_REASONING=false`。 |
+
+## 7. 参考文档
+
+- OpenRouter Quickstart: https://openrouter.ai/docs/quickstart
+- OpenRouter API Reference: https://openrouter.ai/docs/api/reference/overview
+- 腾讯云混元 OpenAI 兼容接口示例: https://cloud.tencent.com/document/product/1729/111007
+
+## 8. 下一步
+
+从 `examples/api/basic_chat.py` 开始跑通基础请求，再根据业务需要依次验证 streaming、tool calling、reasoning mode 和 retry 策略。


### PR DESCRIPTION
## Related issue

fixed #1 

## Summary

  This PR adds a developer-facing Hy3 API quickstart and runnable OpenAI-compatible API examples.

  ### Added

  - `quickstart.md`
    - API basics: base URL, API key, model name, endpoint, rate-limit notes
    - Minimal runnable examples with curl and Python OpenAI SDK
    - Parameter guide for `temperature`, `top_p`, `max_tokens`, `stop`, `tools`, and Hy3 reasoning mode
    - Troubleshooting guide for auth, model mismatch, timeout, rate limit, tool calling, reasoning output, and context-length issues

  - `examples/api/`
    - `basic_chat.py` / `.md`: single-turn and multi-turn chat
    - `streaming.py` / `.md`: streaming request and per-chunk parsing
    - `latency_compare.py` / `.md`: non-streaming vs streaming latency comparison
    - `tool_calling.py` / `.md`: tool calling plus multi-round tool loop
    - `reasoning_mode.py` / `.md`: reasoning off/on comparison
    - `retry.py` / `.md`: retry and exponential backoff for timeout, rate limit, network, and temporary server errors

  - `.env.example`
    - Local vLLM/SGLang configuration
    - OpenRouter configuration
    - Tencent Cloud Hunyuan OpenAI-compatible API configuration
    - Custom OpenAI-compatible gateway configuration

  ### Notes

  - Examples default to local vLLM/SGLang but can be switched through `.env`.
  - For OpenRouter, examples use OpenRouter’s standard `reasoning` parameter mapping:
    - `reasoning_effort="no_think"` -> `{"reasoning": {"effort": "none"}}`
    - `reasoning_effort="high"` -> `{"reasoning": {"effort": "high"}}`
  - Real `.env` files are ignored by git; only `.env.example` is tracked.
  - Example markdown files include full request bodies, response parsing logic, and real sample outputs from OpenRouter `tencent/hy3:free`.

  ## Test Plan

  - [x] `python -m py_compile examples/api/*.py`
  - [x] Ran all six examples with `conda activate llms` and OpenRouter:
    - `python examples/api/basic_chat.py`
    - `python examples/api/streaming.py`
    - `python examples/api/latency_compare.py`
    - `python examples/api/tool_calling.py`
    - `python examples/api/reasoning_mode.py`
    - `python examples/api/retry.py`
  - [x] Verified each example markdown includes:
    - complete request
    - complete response parsing
    - sample output
  - [x] Verified `.env` is ignored and `.env.example` is tracked