### PR TITLE
Add Hy3 code review MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# Hy3 Code Review MCP Server configuration.
+#
+# Copy this file to `.env` in the repository root and edit the values:
+#
+#   cp .env.example .env
+#
+# The MCP server searches for `.env` from the current working directory upward.
+# You can also pass HY3_ENV_FILE in your MCP client config.
+# Shell environment variables take precedence over values in `.env`.
+
+# ---------------------------------------------------------------------------
+# Option 1: local vLLM / SGLang serving
+# ---------------------------------------------------------------------------
+# HY3_BASE_URL=http://127.0.0.1:8000/v1
+# HY3_API_KEY=EMPTY
+# HY3_MODEL=hy3
+
+# If you use SGLang's default port, use:
+# HY3_BASE_URL=http://127.0.0.1:30000/v1
+
+# ---------------------------------------------------------------------------
+# Option 2: OpenRouter
+# ---------------------------------------------------------------------------
+# HY3_BASE_URL=https://openrouter.ai/api/v1
+# OPENROUTER_API_KEY=
+# HY3_MODEL=tencent/hy3:free
+
+# You can also use HY3_API_KEY directly for OpenRouter:
+# HY3_API_KEY=sk-or-...
+
+# ---------------------------------------------------------------------------
+# Option 3: Tencent Cloud Hunyuan OpenAI-compatible API
+# ---------------------------------------------------------------------------
+# HY3_BASE_URL=https://api.hunyuan.cloud.tencent.com/v1
+# HUNYUAN_API_KEY=<your-hunyuan-api-key>
+# HY3_MODEL=hunyuan-turbos-latest
+
+# ---------------------------------------------------------------------------
+# Option 4: custom OpenAI-compatible gateway
+# ---------------------------------------------------------------------------
+# HY3_BASE_URL=https://your-gateway.example/v1
+# HY3_API_KEY=<your-api-key>
+# HY3_MODEL=<served-model-name>
+
+# ---------------------------------------------------------------------------
+# Generation options
+# ---------------------------------------------------------------------------
+# HY3_TEMPERATURE=0.2
+# HY3_TOP_P=1.0
+# HY3_MAX_TOKENS=1600
+# HY3_REASONING_EFFORT=no_think

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 .huggingface/
 .modelscope/
 .ms*
+.env
+.env.local
+.env.*.local
+!.env.example
+.pytest_cache
+mcp_servers/code_review/demo/*.mp4
+mcp_servers/code_review/demo/*.mov
 *.swp
 *.log
 .DS_Store

--- a/mcp_servers/code_review/README.md
+++ b/mcp_servers/code_review/README.md
@@ -1,0 +1,188 @@
+# Hy3 Code Review MCP Server
+
+`hy3-code-review-mcp` is a local stdio MCP Server that exposes Hy3-powered code review tools to MCP clients. The current examples and hands-on validation cover Trae and CodeBuddy.
+
+Cursor, Qoder, Cline, WorkBuddy, and other vibe-coding clients may support the same MCP stdio shape, but they have not been practiced for this branch yet.
+
+The server reads a git diff, pasted patch, or test-planning request, calls a Hy3 OpenAI-compatible API, and returns structured markdown review output.
+
+## Tools
+
+| Tool | Purpose | Key parameters |
+| --- | --- | --- |
+| `review_git_diff` | Read a local git diff and ask Hy3 for a prioritized code review. | `repo_path`, `base_ref`, `target_ref`, `focus`, `max_chars` |
+| `review_patch` | Review a pasted patch or unified diff. | `patch_text`, `language`, `focus`, `context` |
+| `suggest_tests` | Generate unit, integration, edge-case, and regression test suggestions for a diff. | `diff_text`, `test_framework`, `risk_level` |
+
+## Install
+
+From this repository:
+
+```bash
+pip install ./mcp_servers/code_review
+```
+
+For local development:
+
+```bash
+pip install -e ./mcp_servers/code_review[dev]
+```
+
+After installation, the MCP server command is:
+
+```bash
+hy3-code-review-mcp
+```
+
+If you installed the package inside a conda environment, GUI clients may not inherit that environment's `PATH`. In that case, configure the client with the environment's Python executable:
+
+```json
+{
+  "command": "/absolute/path/to/conda/envs/llms/bin/python",
+  "args": ["-m", "hy3_code_review_mcp.server"]
+}
+```
+
+## Configure Hy3 API
+
+The server never hardcodes API keys. Use environment variables or a `.env` file.
+
+When running from this repository, place `.env` in the repository root:
+
+```bash
+cp .env.example .env
+```
+
+The server searches for `.env` from the current working directory upward. You can also point to a specific file:
+
+```bash
+export HY3_ENV_FILE=/absolute/path/to/.env
+```
+
+Local vLLM/SGLang example:
+
+```bash
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_TEMPERATURE=0.2
+HY3_TOP_P=1.0
+HY3_MAX_TOKENS=1600
+HY3_REASONING_EFFORT=no_think
+```
+
+OpenRouter example:
+
+```bash
+HY3_BASE_URL=https://openrouter.ai/api/v1
+HY3_API_KEY=sk-or-...
+# OPENROUTER_API_KEY=sk-or-... also works when HY3_API_KEY is unset or EMPTY
+HY3_MODEL=tencent/hy3:free
+HY3_REASONING_EFFORT=no_think
+```
+
+Tencent Cloud Hunyuan example:
+
+```bash
+HY3_BASE_URL=https://api.hunyuan.cloud.tencent.com/v1
+HUNYUAN_API_KEY=...
+HY3_MODEL=hunyuan-turbos-latest
+```
+
+For OpenRouter, `HY3_REASONING_EFFORT=no_think` maps to `{"reasoning": {"effort": "none"}}`. For local vLLM/SGLang, it maps to Hy3 chat template kwargs.
+
+## Client Configuration
+
+Trae and CodeBuddy use the same stdio server process. Prefer a project-level MCP config when the client supports it, and pass only `HY3_ENV_FILE` in the client config so API keys stay in your local `.env`.
+
+### Trae / CodeBuddy
+
+Use `examples/trae-codebuddy.mcp.json` as the shared stdio config template. See `docs/clients/trae-codebuddy.md` for setup details and the actual Trae review output.
+
+Example prompt:
+
+```text
+Use hy3-code-review to review the demo code in mcp_servers/code_review/examples/review_demo_payment.py. Focus on correctness, security, reliability, and missing tests.
+```
+
+### Unverified MCP Clients
+
+Cursor, Qoder, Cline, WorkBuddy, and other vibe-coding clients have not been practiced in this branch. If a client accepts `mcpServers` JSON, it will likely use the same stdio shape, but this repository does not claim those clients are verified yet:
+
+```json
+{
+  "mcpServers": {
+    "hy3-code-review": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_code_review_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}
+```
+
+Example prompt:
+
+```text
+Use the hy3-code-review MCP server. Call review_git_diff with repo_path set to this project, base_ref "main", and focus "correctness, security, and missing tests".
+```
+
+## Tool Examples
+
+### `review_git_diff`
+
+```json
+{
+  "repo_path": "/absolute/path/to/project",
+  "base_ref": "main",
+  "target_ref": null,
+  "focus": "correctness, security, reliability, and tests",
+  "max_chars": 24000
+}
+```
+
+### `review_patch`
+
+```json
+{
+  "patch_text": "diff --git a/app.py b/app.py\n+ risky_change()",
+  "language": "python",
+  "focus": "correctness and missing tests",
+  "context": "Backend service handling user requests."
+}
+```
+
+### `suggest_tests`
+
+```json
+{
+  "diff_text": "diff --git a/app.py b/app.py\n+ add_retry_loop()",
+  "test_framework": "pytest",
+  "risk_level": "high"
+}
+```
+
+## Test
+
+```bash
+PYTHONPATH=mcp_servers/code_review/src pytest -q mcp_servers/code_review/tests
+python -m py_compile mcp_servers/code_review/src/hy3_code_review_mcp/*.py
+```
+
+## Demo Recording Checklist
+
+1. Install the package with `pip install ./mcp_servers/code_review`.
+2. Configure `.env` with Hy3 API settings.
+3. Add the server to Trae and CodeBuddy.
+4. In Trae, call `review_patch` against `examples/review_demo_payment.py`.
+5. In CodeBuddy, call `review_patch` or `suggest_tests` against the same demo diff.
+6. Record the screen as a GIF or video and attach it to the PR or issue comment.
+
+## Safety Notes
+
+- The server only reads local git data for the `repo_path` explicitly passed by the MCP client.
+- Diffs are truncated by `max_chars` before being sent to Hy3.
+- API keys are read from environment variables or `.env`; they are not logged or returned by tools.
+- stdio MCP servers must not write logs to stdout. This server does not print during normal operation.

--- a/mcp_servers/code_review/docs/clients/trae-codebuddy.md
+++ b/mcp_servers/code_review/docs/clients/trae-codebuddy.md
@@ -1,0 +1,159 @@
+# Trae and CodeBuddy MCP Configuration
+
+Trae and CodeBuddy use the same local stdio MCP server configuration. Keep one shared template and paste it into whichever client UI or project config you use.
+
+The current hands-on examples are scoped to Trae and CodeBuddy. Cursor, Qoder, Cline, WorkBuddy, and other vibe-coding clients are not claimed as practiced yet.
+
+## Install
+
+From the Hy3 repository root:
+
+```bash
+conda activate llms
+pip install -e ./mcp_servers/code_review[dev]
+```
+
+Confirm the package is installed in the conda environment:
+
+```bash
+python -c "import hy3_code_review_mcp; print(hy3_code_review_mcp.__file__)"
+```
+
+## Configure API Credentials
+
+Create `.env` in the Hy3 repository root:
+
+```bash
+cp .env.example .env
+```
+
+For OpenRouter:
+
+```bash
+HY3_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_API_KEY=sk-or-...
+HY3_MODEL=tencent/hy3:free
+HY3_REASONING_EFFORT=no_think
+```
+
+For local vLLM/SGLang:
+
+```bash
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_REASONING_EFFORT=no_think
+```
+
+Do not paste API keys into client MCP config. The server reads them from `HY3_ENV_FILE`.
+
+## Shared MCP Config
+
+Use `examples/trae-codebuddy.mcp.json` as the template:
+
+```json
+{
+  "mcpServers": {
+    "hy3-code-review": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_code_review_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}
+```
+
+On this machine, after `conda activate llms`, `which python` returns:
+
+```text
+/opt/miniconda3/envs/llms/bin/python
+```
+
+So the local config can use:
+
+```json
+{
+  "mcpServers": {
+    "hy3-code-review": {
+      "command": "/opt/miniconda3/envs/llms/bin/python",
+      "args": ["-m", "hy3_code_review_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/Volumes/KimariYB Disk/Project/tencent/Hy3/.env"
+      }
+    }
+  }
+}
+```
+
+## Client Notes
+
+Trae:
+
+- Add the shared server block through Trae's MCP settings UI or project-level MCP config if your version supports it.
+- Use the same command, args, and `HY3_ENV_FILE` environment variable.
+
+CodeBuddy:
+
+- CodeBuddy's local MCP config commonly lives at `~/.codebuddy/mcp.json`.
+- Merge the `hy3-code-review` entry under `mcpServers`, or add the same stdio server through CodeBuddy's UI if available.
+
+## Tool Call Demo
+
+Prompt:
+
+```text
+Use hy3-code-review to review this demo code.
+Call review_patch with:
+- patch_text: use the diff returned by build_demo_patch() from mcp_servers/code_review/examples/review_demo_payment.py
+- language: python
+- focus: security, correctness, reliability, and missing tests
+- context: Payment service helper that charges a user's saved payment token.
+```
+
+Expected tool:
+
+```json
+{
+  "tool": "review_patch",
+  "arguments": {
+    "patch_text": "diff --git a/payment.py b/payment.py\nindex 1111111..2222222 100644\n--- a/payment.py\n+++ b/payment.py\n@@ -1,8 +1,20 @@\n import requests\n \n def charge_user(user_id, amount, token):\n+    print(\"charging\", user_id, amount, token)\n     response = requests.post(\n         \"https://payments.example.com/charge\",\n         json={\"user_id\": user_id, \"amount\": amount, \"token\": token},\n+        timeout=1,\n     )\n+    if response.status_code >= 500:\n+        return charge_user(user_id, amount, token)\n     response.raise_for_status()\n     return response.json()\n",
+    "language": "python",
+    "focus": "security, correctness, reliability, and missing tests",
+    "context": "Payment service helper that charges a user's saved payment token."
+  }
+}
+```
+
+## Actual Trae Output
+
+The following result was captured from Trae after calling the `hy3-code-review` MCP server on `examples/review_demo_payment.py`.
+
+```markdown
+Review Results
+
+Blocker
+
+- Sensitive data exposure via print - `print("charging", user_id, amount, token)` writes the payment token to stdout/logs. Tokens are secrets; this violates PCI/security best practices. Remove it or use redacted logging (`token[:4] + "****"`).
+- Unbounded recursive retry on 5xx - `return charge_user(...)` with no limit or backoff causes infinite recursion / stack overflow and amplifies load on a failing gateway.
+
+Major
+
+- Non-idempotent retry correctness - Retrying on 5xx without an idempotency key can double-charge if the gateway processed but returned an error. Send an `Idempotency-Key` header.
+- Hardcoded 1s timeout too low - May abort legitimate slow charges. Make it configurable, for example 5-10 seconds.
+
+Minor / Nit
+
+- No input validation (`amount > 0`, token format).
+- Missing docstring/type hints.
+
+Missing tests
+
+- No unit tests mocking `requests.post` for success path, 4xx `raise_for_status`, 5xx retry bounded behavior, timeout handling, and token redaction.
+- No integration or contract tests.
+
+Concrete fix
+
+Use `requests.Session` with `Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])`, add an `Idempotency-Key` header via `uuid4()`, validate input, make timeout a parameter, drop the print, and add pytest tests.
+```

--- a/mcp_servers/code_review/docs/demo.md
+++ b/mcp_servers/code_review/docs/demo.md
@@ -1,0 +1,138 @@
+# Demo Script
+
+Use this script to record the required demo GIF or video.
+
+## Setup
+
+```bash
+pip install ./mcp_servers/code_review
+cp .env.example .env
+```
+
+Edit `.env` with a working Hy3 endpoint and API key.
+
+## Demo 1: Trae
+
+1. Add `mcp_servers/code_review/examples/trae-codebuddy.mcp.json` to Trae's MCP settings.
+2. Open this repository and use `mcp_servers/code_review/examples/review_demo_payment.py` as the review target.
+3. Ask:
+
+```text
+Use hy3-code-review to review this demo code.
+Call review_patch with the diff returned by build_demo_patch() from mcp_servers/code_review/examples/review_demo_payment.py.
+Focus on security, correctness, reliability, and missing tests.
+```
+
+4. Show the `review_patch` tool call and Hy3 review response.
+
+## Demo 2: CodeBuddy
+
+1. Add `mcp_servers/code_review/examples/trae-codebuddy.mcp.json` to CodeBuddy's MCP settings, or merge the same server entry into `~/.codebuddy/mcp.json`.
+2. Ask:
+
+```text
+Use hy3-code-review to suggest pytest coverage for the review_demo_payment.py diff.
+Call suggest_tests with risk_level "high".
+```
+
+3. Show the tool call arguments and test suggestions.
+
+## Client Scope
+
+This branch documents practical setup for Trae and CodeBuddy only. Cursor, Qoder, Cline, WorkBuddy, and other vibe-coding clients may support a similar MCP stdio config, but they have not been practiced here yet.
+
+## Real OpenRouter Smoke Test Output
+
+The following output was captured from a successful `review_patch` call through the same Hy3/OpenRouter-compatible path. A later repeat attempt on 2026-07-08 hit OpenRouter `502` responses, so keep this fixture as a known-good example and rerun when the upstream endpoint is healthy.
+
+Tool request:
+
+```json
+{
+  "tool": "review_patch",
+  "arguments": {
+    "patch_text": "diff --git a/payment.py b/payment.py\nindex 1111111..2222222 100644\n--- a/payment.py\n+++ b/payment.py\n@@ -1,8 +1,20 @@\n import requests\n \n def charge_user(user_id, amount, token):\n+    print(\"charging\", user_id, amount, token)\n     response = requests.post(\n         \"https://payments.example.com/charge\",\n         json={\"user_id\": user_id, \"amount\": amount, \"token\": token},\n+        timeout=1,\n     )\n+    if response.status_code >= 500:\n+        return charge_user(user_id, amount, token)\n     response.raise_for_status()\n     return response.json()\n",
+    "language": "python",
+    "focus": "security, correctness, reliability, and missing tests",
+    "context": "Payment service helper that charges a user's saved payment token."
+  }
+}
+```
+
+Response parsing:
+
+```json
+{
+  "review": "<markdown review text>",
+  "metadata": {
+    "language": "python",
+    "focus": "security, correctness, reliability, and missing tests",
+    "diff_chars": 574
+  }
+}
+```
+
+Example model output:
+
+```markdown
+## Summary
+
+The change adds logging, a one-second timeout, and recursive retry behavior around a payment charge request. It introduces a blocker security leak and major reliability/correctness risks in a payment path.
+
+## Findings ordered by severity
+
+- blocker - `payment.py:charge_user` logs the raw payment token with `print("charging", user_id, amount, token)`. This can expose sensitive payment credentials in stdout, container logs, CI logs, and centralized logging systems. It is a direct credential leak and likely violates payment data handling requirements.
+- major - `payment.py:charge_user` retries 5xx responses with unbounded recursion. A persistent upstream outage can exhaust the Python stack, keep workers occupied, and amplify traffic to the payment provider.
+- major - The retry path can duplicate charges because the request has no idempotency key and blindly repeats the same payment operation after a 5xx. A provider may process the original request even when the client receives a server error.
+- minor - `timeout=1` is hard-coded and very aggressive for a payment provider. This can create false timeouts under normal network variance and increase the chance of duplicate retry behavior.
+
+## Missing or weak tests
+
+- Add a test proving sensitive values such as `token` are not printed or logged.
+- Add tests for 5xx responses to verify bounded retry behavior and backoff.
+- Add a regression test for idempotency headers or request identifiers on retry.
+- Add timeout handling tests so network failures return a controlled error instead of recursively retrying forever.
+
+## Concrete fix suggestions
+
+- Remove token logging. If logging is required, log a request id, user id, amount, and a redacted token suffix only when policy allows it.
+- Replace recursion with a bounded retry loop using exponential backoff and jitter.
+- Send an idempotency key with the charge request and reuse it across retries.
+- Make timeout configurable and handle `requests.Timeout` and `requests.RequestException` explicitly.
+```
+
+## Actual Trae Client Output
+
+This output was captured from Trae after calling the MCP server with `review_patch` on `mcp_servers/code_review/examples/review_demo_payment.py`.
+
+```markdown
+Review Results
+
+Blocker
+
+- Sensitive data exposure via print - `print("charging", user_id, amount, token)` writes the payment token to stdout/logs. Tokens are secrets; this violates PCI/security best practices. Remove it or use redacted logging (`token[:4] + "****"`).
+- Unbounded recursive retry on 5xx - `return charge_user(...)` with no limit or backoff causes infinite recursion / stack overflow and amplifies load on a failing gateway.
+
+Major
+
+- Non-idempotent retry correctness - Retrying on 5xx without an idempotency key can double-charge if the gateway processed but returned an error. Send an `Idempotency-Key` header.
+- Hardcoded 1s timeout too low - May abort legitimate slow charges. Make it configurable, for example 5-10 seconds.
+
+Minor / Nit
+
+- No input validation (`amount > 0`, token format).
+- Missing docstring/type hints.
+
+Missing tests
+
+- No unit tests mocking `requests.post` for success path, 4xx `raise_for_status`, 5xx retry bounded behavior, timeout handling, and token redaction.
+- No integration or contract tests.
+
+Concrete fix
+
+Use `requests.Session` with `Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])`, add an `Idempotency-Key` header via `uuid4()`, validate input, make timeout a parameter, drop the print, and add pytest tests.
+```
+
+## Output to Attach
+
+Attach the generated GIF/video to the PR or issue comment. The repository intentionally does not commit large binary demo files.

--- a/mcp_servers/code_review/examples/review_demo_payment.py
+++ b/mcp_servers/code_review/examples/review_demo_payment.py
@@ -1,0 +1,50 @@
+"""Small code-review demo target for the Hy3 MCP server."""
+
+from __future__ import annotations
+
+import requests
+
+
+PAYMENT_ENDPOINT = "https://payments.example.com/charge"
+
+
+def charge_user(user_id: str, amount: float, token: str) -> dict:
+    print("charging", user_id, amount, token)
+
+    response = requests.post(
+        PAYMENT_ENDPOINT,
+        json={
+            "user_id": user_id,
+            "amount": amount,
+            "token": token,
+        },
+        timeout=1,
+    )
+
+    if response.status_code >= 500:
+        return charge_user(user_id, amount, token)
+
+    response.raise_for_status()
+    return response.json()
+
+
+def build_demo_patch() -> str:
+    return """diff --git a/payment.py b/payment.py
+index 1111111..2222222 100644
+--- a/payment.py
++++ b/payment.py
+@@ -1,8 +1,20 @@
+ import requests
+ 
+ def charge_user(user_id, amount, token):
++    print("charging", user_id, amount, token)
+     response = requests.post(
+         "https://payments.example.com/charge",
+         json={"user_id": user_id, "amount": amount, "token": token},
++        timeout=1,
+     )
++    if response.status_code >= 500:
++        return charge_user(user_id, amount, token)
+     response.raise_for_status()
+     return response.json()
+"""

--- a/mcp_servers/code_review/examples/trae-codebuddy.mcp.json
+++ b/mcp_servers/code_review/examples/trae-codebuddy.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "hy3-code-review": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_code_review_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}

--- a/mcp_servers/code_review/pyproject.toml
+++ b/mcp_servers/code_review/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hy3-code-review-mcp"
+version = "0.1.0"
+description = "A stdio MCP server that uses Hy3 to review code diffs and suggest tests."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Tencent Hunyuan Hy3 contributors" }
+]
+dependencies = [
+  "mcp>=1.27,<2",
+  "openai>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8",
+]
+
+[project.scripts]
+hy3-code-review-mcp = "hy3_code_review_mcp.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hy3_code_review_mcp"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/__init__.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Hy3 code review MCP server package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/config.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/config.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char == "#" and not in_single and not in_double:
+            if index == 0 or value[index - 1].isspace():
+                return value[:index].rstrip()
+    return value.strip()
+
+
+def _parse_env_value(raw_value: str) -> str:
+    value = _strip_inline_comment(raw_value.strip())
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value
+
+
+def load_dotenv_file(path: Path) -> None:
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key and not key.startswith("#"):
+            os.environ.setdefault(key, _parse_env_value(raw_value))
+
+
+def find_dotenv(start: Optional[Path] = None) -> Optional[Path]:
+    explicit = os.getenv("HY3_ENV_FILE")
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+
+    current = (start or Path.cwd()).resolve()
+    candidates = [current, *current.parents]
+    for directory in candidates:
+        env_file = directory / ".env"
+        if env_file.exists():
+            return env_file
+    return None
+
+
+def load_default_dotenv(start: Optional[Path] = None) -> Optional[Path]:
+    env_file = find_dotenv(start)
+    if env_file is None:
+        return None
+    load_dotenv_file(env_file)
+    return env_file
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    return default if value is None else float(value)
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None else int(value)
+
+
+def _api_key_for_base_url(base_url: str) -> str:
+    hy3_key = os.getenv("HY3_API_KEY")
+    if hy3_key and hy3_key != "EMPTY":
+        return hy3_key
+    if "openrouter.ai" in base_url:
+        return os.getenv("OPENROUTER_API_KEY") or hy3_key or "EMPTY"
+    if "hunyuan.cloud.tencent.com" in base_url:
+        return os.getenv("HUNYUAN_API_KEY") or hy3_key or "EMPTY"
+    return hy3_key or "EMPTY"
+
+
+@dataclass(frozen=True)
+class Hy3Settings:
+    base_url: str
+    api_key: str
+    model: str
+    temperature: float
+    top_p: float
+    max_tokens: int
+    reasoning_effort: str
+
+    @classmethod
+    def from_env(cls) -> "Hy3Settings":
+        base_url = os.getenv("HY3_BASE_URL", "http://127.0.0.1:8000/v1")
+        return cls(
+            base_url=base_url,
+            api_key=_api_key_for_base_url(base_url),
+            model=os.getenv("HY3_MODEL", "hy3"),
+            temperature=_float_env("HY3_TEMPERATURE", 0.2),
+            top_p=_float_env("HY3_TOP_P", 1.0),
+            max_tokens=_int_env("HY3_MAX_TOKENS", 1600),
+            reasoning_effort=os.getenv("HY3_REASONING_EFFORT", "no_think"),
+        )

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/git_utils.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/git_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def truncate_text(text: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}\n\n[truncated: original {len(text)} chars]"
+
+
+def get_git_diff(
+    repo_path: str,
+    base_ref: str = "HEAD",
+    target_ref: Optional[str] = None,
+    max_chars: int = 24000,
+) -> str:
+    repo = Path(repo_path).expanduser().resolve()
+    if not repo.exists() or not repo.is_dir():
+        raise ValueError(f"repo_path must be an existing directory: {repo}")
+
+    command = ["git", "diff", base_ref]
+    if target_ref:
+        command.append(target_ref)
+    command.append("--")
+
+    result = subprocess.run(
+        command,
+        cwd=repo,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+
+    diff = result.stdout.strip()
+    if not diff:
+        return "No diff found for the requested refs/worktree."
+    return truncate_text(diff, max_chars=max_chars)

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/hy3_client.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/hy3_client.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .config import Hy3Settings
+
+
+class Hy3Client:
+    def __init__(self, settings: Hy3Settings):
+        self.settings = settings
+
+    @classmethod
+    def from_env(cls) -> "Hy3Client":
+        return cls(Hy3Settings.from_env())
+
+    def _extra_body(self) -> Dict[str, Any]:
+        effort = self.settings.reasoning_effort
+        if not effort:
+            return {}
+        if "openrouter.ai" in self.settings.base_url:
+            mapped = "none" if effort == "no_think" else effort
+            return {"reasoning": {"effort": mapped}}
+        return {"chat_template_kwargs": {"reasoning_effort": effort}}
+
+    def complete(self, prompt: str) -> str:
+        from openai import OpenAI
+
+        client = OpenAI(base_url=self.settings.base_url, api_key=self.settings.api_key)
+        response = client.chat.completions.create(
+            model=self.settings.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a senior software engineer performing rigorous, "
+                        "actionable code review. Prioritize correctness, security, "
+                        "reliability, and missing tests."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=self.settings.temperature,
+            top_p=self.settings.top_p,
+            max_tokens=self.settings.max_tokens,
+            extra_body=self._extra_body(),
+        )
+        message = response.choices[0].message
+        content = message.content or getattr(message, "reasoning", None)
+        return content or ""

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/review.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/review.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol
+
+from .git_utils import get_git_diff
+
+
+class CompletionClient(Protocol):
+    def complete(self, prompt: str) -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class ReviewRequest:
+    diff_text: str
+    focus: str = "correctness, security, reliability, and tests"
+    context: str = ""
+
+
+def build_review_prompt(request: ReviewRequest) -> str:
+    context = request.context.strip() or "No extra context was provided."
+    return f"""Review the following code change.
+
+Focus areas: {request.focus}
+Project context: {context}
+
+Return concise markdown with these sections:
+1. Summary
+2. Findings ordered by severity: blocker, major, minor, nit
+3. Missing or weak tests
+4. Concrete fix suggestions
+
+For each finding, include the impacted file/function when inferable and explain why it matters.
+
+Diff:
+```diff
+{request.diff_text}
+```
+"""
+
+
+def build_test_prompt(diff_text: str, test_framework: str, risk_level: str) -> str:
+    return f"""Suggest tests for this code change.
+
+Preferred test framework: {test_framework}
+Risk level: {risk_level}
+
+Return markdown with:
+1. Highest-risk behavior to verify
+2. Unit tests
+3. Integration or regression tests
+4. Edge cases and failure modes
+5. Example test names
+
+Diff:
+```diff
+{diff_text}
+```
+"""
+
+
+def review_patch_with_client(
+    patch_text: str,
+    client: CompletionClient,
+    language: str = "unknown",
+    focus: str = "correctness, security, reliability, and tests",
+    context: str = "",
+) -> Dict[str, Any]:
+    prompt = build_review_prompt(
+        ReviewRequest(
+            diff_text=patch_text,
+            focus=focus,
+            context=f"Language: {language}. {context}".strip(),
+        )
+    )
+    return {
+        "review": client.complete(prompt),
+        "metadata": {
+            "language": language,
+            "focus": focus,
+            "diff_chars": len(patch_text),
+        },
+    }
+
+
+def review_git_diff_with_client(
+    repo_path: str,
+    client: CompletionClient,
+    base_ref: str = "HEAD",
+    target_ref: str | None = None,
+    focus: str = "correctness, security, reliability, and tests",
+    max_chars: int = 24000,
+) -> Dict[str, Any]:
+    diff = get_git_diff(
+        repo_path=repo_path,
+        base_ref=base_ref,
+        target_ref=target_ref,
+        max_chars=max_chars,
+    )
+    result = review_patch_with_client(
+        patch_text=diff,
+        client=client,
+        language="diff",
+        focus=focus,
+        context=f"Repository: {repo_path}. Base ref: {base_ref}. Target ref: {target_ref or 'worktree'}.",
+    )
+    result["metadata"].update(
+        {
+            "repo_path": repo_path,
+            "base_ref": base_ref,
+            "target_ref": target_ref,
+            "max_chars": max_chars,
+        }
+    )
+    return result
+
+
+def suggest_tests_with_client(
+    diff_text: str,
+    client: CompletionClient,
+    test_framework: str = "pytest",
+    risk_level: str = "medium",
+) -> Dict[str, Any]:
+    prompt = build_test_prompt(
+        diff_text=diff_text,
+        test_framework=test_framework,
+        risk_level=risk_level,
+    )
+    return {
+        "test_suggestions": client.complete(prompt),
+        "metadata": {
+            "test_framework": test_framework,
+            "risk_level": risk_level,
+            "diff_chars": len(diff_text),
+        },
+    }

--- a/mcp_servers/code_review/src/hy3_code_review_mcp/server.py
+++ b/mcp_servers/code_review/src/hy3_code_review_mcp/server.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import load_default_dotenv
+from .hy3_client import Hy3Client
+from .review import (
+    review_git_diff_with_client,
+    review_patch_with_client,
+    suggest_tests_with_client,
+)
+
+
+mcp = FastMCP("Hy3 Code Review MCP", json_response=True)
+
+
+def _client() -> Hy3Client:
+    load_default_dotenv()
+    return Hy3Client.from_env()
+
+
+@mcp.tool()
+def review_git_diff(
+    repo_path: str,
+    base_ref: str = "HEAD",
+    target_ref: Optional[str] = None,
+    focus: str = "correctness, security, reliability, and tests",
+    max_chars: int = 24000,
+) -> Dict[str, Any]:
+    """Review a local git diff with Hy3.
+
+    Args:
+        repo_path: Local repository path to inspect.
+        base_ref: Base git ref for `git diff`, for example `main` or `HEAD`.
+        target_ref: Optional target ref. When omitted, reviews worktree changes against base_ref.
+        focus: Review focus areas, such as security, correctness, performance, or tests.
+        max_chars: Maximum diff characters sent to Hy3; longer diffs are truncated with a notice.
+    """
+    return review_git_diff_with_client(
+        repo_path=repo_path,
+        base_ref=base_ref,
+        target_ref=target_ref,
+        focus=focus,
+        max_chars=max_chars,
+        client=_client(),
+    )
+
+
+@mcp.tool()
+def review_patch(
+    patch_text: str,
+    language: str = "unknown",
+    focus: str = "correctness, security, reliability, and tests",
+    context: str = "",
+) -> Dict[str, Any]:
+    """Review a pasted patch or diff with Hy3.
+
+    Args:
+        patch_text: Patch, unified diff, or code-change text to review.
+        language: Primary language or stack for the patch.
+        focus: Review focus areas, such as security, correctness, performance, or tests.
+        context: Optional project or business context that helps Hy3 judge the change.
+    """
+    return review_patch_with_client(
+        patch_text=patch_text,
+        language=language,
+        focus=focus,
+        context=context,
+        client=_client(),
+    )
+
+
+@mcp.tool()
+def suggest_tests(
+    diff_text: str,
+    test_framework: str = "pytest",
+    risk_level: str = "medium",
+) -> Dict[str, Any]:
+    """Suggest unit, integration, edge-case, and regression tests for a diff.
+
+    Args:
+        diff_text: Diff or patch text that needs test coverage.
+        test_framework: Preferred test framework, for example pytest, unittest, jest, or go test.
+        risk_level: Expected risk level of the change: low, medium, high, or critical.
+    """
+    return suggest_tests_with_client(
+        diff_text=diff_text,
+        test_framework=test_framework,
+        risk_level=risk_level,
+        client=_client(),
+    )
+
+
+def main() -> None:
+    load_default_dotenv()
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_servers/code_review/tests/test_config.py
+++ b/mcp_servers/code_review/tests/test_config.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from hy3_code_review_mcp.config import Hy3Settings, load_dotenv_file
+
+
+def test_load_dotenv_file_sets_missing_values_without_overriding_existing(monkeypatch, tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "HY3_BASE_URL=https://from-dotenv.example/v1",
+                "HY3_API_KEY=from-dotenv",
+                "HY3_MODEL='hy3-dotenv'",
+                "HY3_MAX_TOKENS=2048 # inline comment",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HY3_API_KEY", "from-shell")
+    monkeypatch.delenv("HY3_BASE_URL", raising=False)
+    monkeypatch.delenv("HY3_MODEL", raising=False)
+    monkeypatch.delenv("HY3_MAX_TOKENS", raising=False)
+
+    load_dotenv_file(env_file)
+
+    assert Hy3Settings.from_env().base_url == "https://from-dotenv.example/v1"
+    assert Hy3Settings.from_env().api_key == "from-shell"
+    assert Hy3Settings.from_env().model == "hy3-dotenv"
+    assert Hy3Settings.from_env().max_tokens == 2048
+
+
+def test_settings_defaults_match_local_hy3(monkeypatch):
+    for key in [
+        "HY3_BASE_URL",
+        "HY3_API_KEY",
+        "HY3_MODEL",
+        "HY3_TEMPERATURE",
+        "HY3_TOP_P",
+        "HY3_MAX_TOKENS",
+        "HY3_REASONING_EFFORT",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    settings = Hy3Settings.from_env()
+
+    assert settings.base_url == "http://127.0.0.1:8000/v1"
+    assert settings.api_key == "EMPTY"
+    assert settings.model == "hy3"
+    assert settings.temperature == 0.2
+    assert settings.top_p == 1.0
+    assert settings.max_tokens == 1600
+    assert settings.reasoning_effort == "no_think"
+
+
+def test_openrouter_settings_fall_back_to_openrouter_api_key(monkeypatch):
+    monkeypatch.setenv("HY3_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("HY3_API_KEY", "EMPTY")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter")
+
+    assert Hy3Settings.from_env().api_key == "sk-openrouter"
+
+
+def test_tencent_settings_fall_back_to_hunyuan_api_key(monkeypatch):
+    monkeypatch.setenv("HY3_BASE_URL", "https://api.hunyuan.cloud.tencent.com/v1")
+    monkeypatch.setenv("HY3_API_KEY", "EMPTY")
+    monkeypatch.setenv("HUNYUAN_API_KEY", "sk-hunyuan")
+
+    assert Hy3Settings.from_env().api_key == "sk-hunyuan"

--- a/mcp_servers/code_review/tests/test_git_utils.py
+++ b/mcp_servers/code_review/tests/test_git_utils.py
@@ -1,0 +1,32 @@
+import subprocess
+from pathlib import Path
+
+from hy3_code_review_mcp.git_utils import get_git_diff, truncate_text
+
+
+def run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_get_git_diff_reads_worktree_diff(tmp_path: Path):
+    run(["git", "init"], tmp_path)
+    run(["git", "config", "user.email", "test@example.com"], tmp_path)
+    run(["git", "config", "user.name", "Test User"], tmp_path)
+
+    source = tmp_path / "app.py"
+    source.write_text("print('old')\n", encoding="utf-8")
+    run(["git", "add", "app.py"], tmp_path)
+    run(["git", "commit", "-m", "initial"], tmp_path)
+    source.write_text("print('new')\n", encoding="utf-8")
+
+    diff = get_git_diff(repo_path=str(tmp_path), base_ref="HEAD")
+
+    assert "diff --git a/app.py b/app.py" in diff
+    assert "-print('old')" in diff
+    assert "+print('new')" in diff
+
+
+def test_truncate_text_preserves_prefix_and_reports_original_size():
+    text = "abcdef"
+
+    assert truncate_text(text, max_chars=4) == "abcd\n\n[truncated: original 6 chars]"

--- a/mcp_servers/code_review/tests/test_server.py
+++ b/mcp_servers/code_review/tests/test_server.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from hy3_code_review_mcp.server import mcp
+
+
+def test_server_exposes_three_code_review_tools():
+    tools = asyncio.run(mcp.list_tools())
+    names = {tool.name for tool in tools}
+
+    assert names == {"review_git_diff", "review_patch", "suggest_tests"}
+    assert all(tool.description for tool in tools)

--- a/mcp_servers/code_review/tests/test_tools.py
+++ b/mcp_servers/code_review/tests/test_tools.py
@@ -1,0 +1,60 @@
+from hy3_code_review_mcp.review import (
+    ReviewRequest,
+    build_review_prompt,
+    review_patch_with_client,
+    suggest_tests_with_client,
+)
+
+
+class FakeHy3Client:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return "HY3 review result"
+
+
+def test_build_review_prompt_includes_focus_and_patch():
+    prompt = build_review_prompt(
+        ReviewRequest(
+            diff_text="+ risky_change()",
+            focus="security",
+            context="Python service",
+        )
+    )
+
+    assert "security" in prompt
+    assert "Python service" in prompt
+    assert "+ risky_change()" in prompt
+    assert "blocker" in prompt.lower()
+
+
+def test_review_patch_with_client_calls_hy3_client():
+    client = FakeHy3Client()
+
+    result = review_patch_with_client(
+        patch_text="+ risky_change()",
+        client=client,
+        language="python",
+        focus="correctness",
+    )
+
+    assert result["review"] == "HY3 review result"
+    assert result["metadata"]["language"] == "python"
+    assert client.prompts and "+ risky_change()" in client.prompts[0]
+
+
+def test_suggest_tests_with_client_calls_hy3_client():
+    client = FakeHy3Client()
+
+    result = suggest_tests_with_client(
+        diff_text="+ add retry loop",
+        client=client,
+        test_framework="pytest",
+        risk_level="high",
+    )
+
+    assert result["test_suggestions"] == "HY3 review result"
+    assert "pytest" in client.prompts[0]
+    assert "high" in client.prompts[0]


### PR DESCRIPTION
fixed #3 

## Summary

  This PR adds a local stdio MCP Server for Hy3-powered code review. 

  The server packages Hy3 API capabilities into MCP tools that can be used from vibe-coding clients. Current hands-on validation and documentation are scoped to Trae and CodeBuddy. Cursor, Qoder, Cline, WorkBuddy, and other MCP-compatible clients may use a similar stdio configuration, but they have not been practiced in this branch.

  ## New Features

  - Add `hy3-code-review-mcp`, a pip-installable MCP Python package.
  - Expose 3 MCP tools:
    - `review_git_diff`: read a local git diff and ask Hy3 for prioritized review findings.
    - `review_patch`: review a pasted patch or unified diff.
    - `suggest_tests`: generate unit, integration, regression, and edge-case test suggestions.
  - Add OpenAI-compatible Hy3 client support with `.env` configuration.
  - Support local vLLM/SGLang, OpenRouter, Tencent Cloud Hunyuan, and custom OpenAI-compatible gateways.
  - Add Trae/CodeBuddy shared MCP config template.
  - Add a Python payment-review demo target and actual Trae MCP review output.
  - Add tests for config loading, git diff reading, prompt/tool helpers, and MCP tool registration.

  ## Documentation

  - `mcp_servers/code_review/README.md`: install, configuration, tools, examples, safety notes.
  - `mcp_servers/code_review/docs/clients/trae-codebuddy.md`: shared Trae/CodeBuddy setup guide.
  - `mcp_servers/code_review/docs/demo.md`: demo recording flow and real review output.
  - `.env.example`: environment variable template for Hy3/OpenRouter/Tencent/local vLLM usage.

  ## Test Plan

  - [x] `pytest -q mcp_servers/code_review/tests`
  - [x] `python -m py_compile mcp_servers/code_review/src/hy3_code_review_mcp/*.py 
mcp_servers/code_review/examples/review_demo_payment.py`
  - [x] Validate all JSON config/doc examples parse successfully.
  - [x] Verify MCP server exposes `review_git_diff`, `review_patch`, and `suggest_tests`.
  - [x] Scan staged diff for API key patterns.

https://github.com/user-attachments/assets/f07ab031-f428-4920-a755-37dc1e885508
