### PR TITLE
feat(research-mcp): Hy3 deep research MCP server

### DIFF
--- a/mcp_servers/deep_research/.env.example
+++ b/mcp_servers/deep_research/.env.example
@@ -1,0 +1,18 @@
+# Hy3 endpoint. Local vLLM/SGLang default; override for OpenRouter/Cloud.
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_TEMPERATURE=0.9
+HY3_TOP_P=1.0
+HY3_MAX_TOKENS=2048
+# Reasoning effort: no_think (default), low, high.
+HY3_REASONING_EFFORT=high
+
+# Web data source. DuckDuckGo needs no key. Set a backend for richer results.
+# HY3_SEARCH_ENGINE=tavily
+# HY3_SEARCH_API_KEY=tvly-...
+# HY3_MAX_SEARCH_RESULTS=5
+# HY3_PAGE_TIMEOUT=15
+# HY3_MAX_PAGE_CHARS=8000
+# Override the default User-Agent if a site blocks the built-in one.
+# HY3_USER_AGENT=Mozilla/5.0 ...

--- a/mcp_servers/deep_research/.gitignore
+++ b/mcp_servers/deep_research/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.venv/
+.env

--- a/mcp_servers/deep_research/README.md
+++ b/mcp_servers/deep_research/README.md
@@ -1,0 +1,218 @@
+# Hy3 Deep Research MCP Server
+
+`hy3-research-mcp` is a local stdio MCP Server that turns Hy3 into a **deep research assistant**: it searches the web, reads pages, and asks a Hy3 OpenAI-compatible endpoint to synthesize grounded, cited conclusions.
+
+It is designed to be plug-and-play for any MCP client (Trae / CodeBuddy / Cursor / Cline / WorkBuddy / Qoder / Open WebUI ...). Web search uses DuckDuckGo HTML by default and **needs no extra API key**, so the server is useful the moment a Hy3 endpoint is configured.
+
+## Scenario
+
+A user asks a question. An MCP client (e.g. Cursor) is free to:
+
+1. call `web_search_tool` to gather sources,
+2. call `read_url_tool` to read a promising page,
+3. call `research_question` to let Hy3 synthesize a cited answer, or
+4. call `summarize_documents` / `generate_research_outline` for follow-ups.
+
+Hy3 is the core reasoning engine; the web is the external data source.
+
+## Tools
+
+| Tool | Purpose | Key parameters |
+| --- | --- | --- |
+| `web_search_tool` | Search the web and return titles, URLs, snippets. No API key required (DuckDuckGo). | `query`, `max_results` |
+| `read_url_tool` | Fetch a web page and return readable plain text. | `url`, `max_chars` |
+| `research_question` | Search + (optional) page reads + Hy3 synthesis into a cited answer. | `question`, `searches`, `focus`, `depth`, `read_top_pages` |
+| `summarize_documents` | Summarize pasted documents into a cited answer for a question. | `question`, `documents` |
+| `generate_research_outline` | Generate a structured report outline grounded in live search evidence. | `question`, `searches` |
+
+## Install
+
+From this repository:
+
+```bash
+pip install ./mcp_servers/deep_research
+```
+
+For local development:
+
+```bash
+pip install -e ./mcp_servers/deep_research[dev]
+```
+
+After installation, the MCP server command is:
+
+```bash
+hy3-research-mcp
+```
+
+If you installed the package inside a conda environment, GUI clients may not inherit that environment's `PATH`. In that case, configure the client with the environment's Python executable:
+
+```json
+{
+  "command": "/absolute/path/to/conda/envs/llms/bin/python",
+  "args": ["-m", "hy3_research_mcp.server"]
+}
+```
+
+## Configure Hy3 API
+
+The server never hardcodes API keys. Use environment variables or a `.env` file.
+
+When running from this repository, place `.env` in the repository root:
+
+```bash
+cp mcp_servers/deep_research/.env.example .env
+```
+
+The server searches for `.env` from the current working directory upward. You can also point to a specific file:
+
+```bash
+export HY3_ENV_FILE=/absolute/path/to/.env
+```
+
+Local vLLM/SGLang example:
+
+```bash
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_TEMPERATURE=0.9
+HY3_TOP_P=1.0
+HY3_MAX_TOKENS=2048
+HY3_REASONING_EFFORT=high
+```
+
+OpenRouter example:
+
+```bash
+HY3_BASE_URL=https://openrouter.ai/api/v1
+HY3_API_KEY=sk-or-...
+# OPENROUTER_API_KEY=sk-or-... also works when HY3_API_KEY is unset or EMPTY
+HY3_MODEL=tencent/hy3:free
+HY3_REASONING_EFFORT=high
+```
+
+Tencent Cloud Hunyuan example:
+
+```bash
+HY3_BASE_URL=https://api.hunyuan.cloud.tencent.com/v1
+HUNYUAN_API_KEY=...
+HY3_MODEL=hunyuan-turbos-latest
+```
+
+For OpenRouter, `HY3_REASONING_EFFORT=no_think` maps to `{"reasoning": {"effort": "none"}}`. For local vLLM/SGLang, it maps to Hy3 chat template kwargs.
+
+## Web data source (optional)
+
+`web_search_tool` defaults to DuckDuckGo HTML and needs no key. For richer results, set a search backend:
+
+```bash
+# Tavily
+HY3_SEARCH_ENGINE=tavily
+HY3_SEARCH_API_KEY=tvly-...
+# or Brave
+HY3_SEARCH_ENGINE=brave
+HY3_SEARCH_API_KEY=...
+HY3_MAX_SEARCH_RESULTS=5
+HY3_PAGE_TIMEOUT=15
+HY3_MAX_PAGE_CHARS=8000
+```
+
+(Tavily keys are also recognized as `TAVILY_API_KEY`; Brave as `BRAVE_API_KEY`.)
+
+## Client Configuration
+
+All MCP clients below use the same stdio server process. Prefer a project-level MCP config when the client supports it, and pass only `HY3_ENV_FILE` in the client config so API keys stay in your local `.env`.
+
+### Trae / CodeBuddy
+
+Use `examples/trae-codebuddy.mcp.json` as the shared stdio config template. See `docs/clients/trae-codebuddy.md` for setup details.
+
+### Cursor
+
+Add the server to `~/.cursor/mcp.json` (or the project-level `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": { "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env" }
+    }
+  }
+}
+```
+
+### Cline / Qoder / Open WebUI
+
+Any client that accepts an `mcpServers` block uses the same stdio shape as above.
+
+## Tool Examples
+
+### `web_search_tool`
+
+```json
+{ "query": "vLLM hy3 tool call parser", "max_results": 5 }
+```
+
+### `read_url_tool`
+
+```json
+{ "url": "https://github.com/Tencent-Hunyuan/Hy3", "max_chars": 8000 }
+```
+
+### `research_question`
+
+```json
+{
+  "question": "How does Hy3 compare to GLM-5.1 on SWE-Bench Verified?",
+  "searches": "Hy3 SWE-Bench Verified, GLM-5.1 SWE-Bench Verified",
+  "focus": "benchmark numbers and scaffold variance",
+  "depth": "balanced",
+  "read_top_pages": 2
+}
+```
+
+### `summarize_documents`
+
+```json
+{
+  "question": "What are the deployment requirements?",
+  "documents": ["...", "..."]
+}
+```
+
+### `generate_research_outline`
+
+```json
+{ "question": "Designing a Hy3-powered agent for log triage", "searches": "MCP log triage, Hy3 agent tools" }
+```
+## Test
+
+```bash
+PYTHONPATH=mcp_servers/deep_research/src pytest -q mcp_servers/deep_research/tests
+python -m py_compile mcp_servers/deep_research/src/hy3_research_mcp/*.py
+# End-to-end over the real stdio protocol (hits the live web, no key needed):
+python mcp_servers/deep_research/scripts/stdio_smoke.py
+```
+
+> `read_url_tool` extracts plain text from static HTML. JavaScript-rendered
+> pages (e.g. some GitHub views) may return little text; prefer raw document
+> URLs (e.g. `raw.githubusercontent.com/...`) for best results.
+
+## Demo Recording Checklist
+
+1. Install the package with `pip install ./mcp_servers/deep_research`.
+2. Configure `.env` with Hy3 API settings.
+3. Add the server to two MCP clients (e.g. CodeBuddy/WorkBuddy + Cursor).
+4. In client 1, ask a question and show `research_question` returning a cited answer.
+5. In client 2, show `web_search_tool` + `read_url_tool` + `summarize_documents`.
+6. Record the screen as a GIF or video and attach it to the PR or issue comment.
+
+## Safety Notes
+
+- The server only reads URLs explicitly passed by the MCP client or derived from a search the client requested.
+- Web pages are truncated by `HY3_MAX_PAGE_CHARS` before being sent to Hy3.
+- API keys are read from environment variables or `.env`; they are not logged or returned by tools.
+- stdio MCP servers must not write logs to stdout. This server does not print during normal operation.

--- a/mcp_servers/deep_research/docs/clients/cursor.md
+++ b/mcp_servers/deep_research/docs/clients/cursor.md
@@ -1,0 +1,43 @@
+# Cursor MCP Configuration
+
+Cursor uses the same stdio MCP server. Use `examples/cursor.mcp.json`.
+
+## Install
+
+```bash
+pip install ./mcp_servers/deep_research
+```
+
+## Configure
+
+Add the server to `~/.cursor/mcp.json` (or the project-level `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}
+```
+
+## Tool Call Demo
+
+Prompt:
+
+```text
+Use the hy3-research MCP server.
+Call research_question with:
+- question: "What are Hy3's recommended vLLM serving flags for MTP?"
+- searches: "Hy3 vLLM MTP speculative, vLLM hy_v3 tool parser"
+- depth: "balanced"
+- read_top_pages: 1
+```
+
+Cursor may also call `web_search_tool` and `read_url_tool` directly to gather
+sources before synthesis.

--- a/mcp_servers/deep_research/docs/clients/trae-codebuddy.md
+++ b/mcp_servers/deep_research/docs/clients/trae-codebuddy.md
@@ -1,0 +1,128 @@
+# Trae / CodeBuddy MCP Configuration
+
+Trae and CodeBuddy use the same local stdio MCP server configuration. Keep one
+shared template and paste it into whichever client UI or project config you use.
+
+The current hands-on examples are scoped to Trae and CodeBuddy. Cursor, Qoder,
+Cline, WorkBuddy, and other clients are not claimed as practiced yet, but use the
+same stdio shape.
+
+## Install
+
+From the Hy3 repository root:
+
+```bash
+conda activate llms
+pip install -e ./mcp_servers/deep_research[dev]
+```
+
+Confirm the package is installed in the conda environment:
+
+```bash
+python -c "import hy3_research_mcp; print(hy3_research_mcp.__file__)"
+```
+
+## Configure API Credentials
+
+Create `.env` in the Hy3 repository root:
+
+```bash
+cp mcp_servers/deep_research/.env.example .env
+```
+
+For OpenRouter:
+
+```bash
+HY3_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_API_KEY=sk-or-...
+HY3_MODEL=tencent/hy3:free
+HY3_REASONING_EFFORT=high
+```
+
+For local vLLM/SGLang:
+
+```bash
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_REASONING_EFFORT=high
+```
+
+Web search uses DuckDuckGo by default and needs no key. Do not paste API keys
+into client MCP config. The server reads them from `HY3_ENV_FILE`.
+
+## Shared MCP Config
+
+Use `examples/trae-codebuddy.mcp.json` as the template:
+
+```json
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}
+```
+
+## Client Notes
+
+Trae:
+- Add the shared server block through Trae's MCP settings UI or project-level
+  MCP config if your version supports it.
+- Use the same command, args, and `HY3_ENV_FILE` environment variable.
+
+CodeBuddy:
+- CodeBuddy's local MCP config commonly lives at `~/.codebuddy/mcp.json`.
+- Merge the `hy3-research` entry under `mcpServers`, or add the same stdio
+  server through CodeBuddy's UI if available.
+
+## Tool Call Demo
+
+Prompt:
+
+```text
+Use the hy3-research MCP server to research this question:
+"How does Hy3 compare to similar-size MoE models on agent benchmarks?"
+Call research_question with:
+- question: "How does Hy3 compare to similar-size MoE models on agent benchmarks?"
+- searches: "Hy3 agent benchmark, MoE model SWE-Bench Verified"
+- focus: "benchmark numbers and agent scaffolding variance"
+- depth: "balanced"
+- read_top_pages: 2
+```
+
+Expected tool:
+
+```json
+{
+  "tool": "research_question",
+  "arguments": {
+    "question": "How does Hy3 compare to similar-size MoE models on agent benchmarks?",
+    "searches": "Hy3 agent benchmark, MoE model SWE-Bench Verified",
+    "focus": "benchmark numbers and agent scaffolding variance",
+    "depth": "balanced",
+    "read_top_pages": 2
+  }
+}
+```
+
+The client is free to call `web_search_tool` and `read_url_tool` first to gather
+sources, then `research_question` to let Hy3 synthesize a cited answer.
+
+## stdio Verification (no client needed)
+
+Before recording a demo, verify the server is callable over the real stdio
+protocol with the SDK client:
+
+```bash
+pip install -e ./mcp_servers/deep_research[dev]
+python mcp_servers/deep_research/scripts/stdio_smoke.py
+```
+
+This drives `web_search_tool` and `read_url_tool` against the live web and
+prints `STDIO SMOKE OK` when the round trip succeeds.

--- a/mcp_servers/deep_research/docs/demo.md
+++ b/mcp_servers/deep_research/docs/demo.md
@@ -1,0 +1,64 @@
+# Demo Script
+
+Use this script to record the required demo GIF or video.
+
+## Setup
+
+```bash
+pip install ./mcp_servers/deep_research
+cp mcp_servers/deep_research/.env.example .env
+```
+
+Edit `.env` with a working Hy3 endpoint and API key.
+
+Verify the server over the real stdio protocol first:
+
+```bash
+python mcp_servers/deep_research/scripts/stdio_smoke.py
+```
+
+You should see `STDIO SMOKE OK` and a non-zero `SEARCH COUNT`.
+
+## Demo 1: CodeBuddy / WorkBuddy
+
+1. Add `mcp_servers/deep_research/examples/trae-codebuddy.mcp.json` to the
+   client's MCP settings.
+2. Open this repository.
+3. Ask:
+
+```text
+Use the hy3-research MCP server to research this question:
+"How does Hy3 compare to similar-size MoE models on agent benchmarks?"
+Call research_question with searches "Hy3 agent benchmark, MoE SWE-Bench",
+focus "benchmark numbers", depth "balanced", read_top_pages 2.
+```
+
+4. Show the `research_question` tool call and the Hy3 answer with citations.
+
+## Demo 2: Cursor
+
+1. Add `mcp_servers/deep_research/examples/cursor.mcp.json` to Cursor's MCP
+   settings.
+2. Ask:
+
+```text
+Use the hy3-research MCP server.
+First call web_search_tool with query "Hy3 vLLM MTP serving".
+Then call read_url_tool on the first result URL with max_chars 4000.
+Then summarize_documents with question "What are the recommended vLLM flags?"
+and documents set to the read_url_tool text.
+```
+
+3. Show the chained tool calls: `web_search_tool` -> `read_url_tool` ->
+   `summarize_documents`.
+
+## Client Scope
+
+This branch documents practical setup for CodeBuddy/WorkBuddy and Cursor.
+Trae, Qoder, Cline, Open WebUI, and other vibe-coding clients may support a
+similar MCP stdio config, using `examples/cline_mcp_settings.json` as a template.
+
+## Output to Attach
+
+Attach the generated GIF/video to the PR or issue comment. The repository
+intentionally does not commit large binary demo files.

--- a/mcp_servers/deep_research/examples/cline_mcp_settings.json
+++ b/mcp_servers/deep_research/examples/cline_mcp_settings.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "web_search_tool",
+        "read_url_tool",
+        "research_question",
+        "summarize_documents",
+        "generate_research_outline"
+      ]
+    }
+  }
+}

--- a/mcp_servers/deep_research/examples/cursor.mcp.json
+++ b/mcp_servers/deep_research/examples/cursor.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}

--- a/mcp_servers/deep_research/examples/trae-codebuddy.mcp.json
+++ b/mcp_servers/deep_research/examples/trae-codebuddy.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "hy3-research": {
+      "command": "/absolute/path/to/conda/envs/llms/bin/python",
+      "args": ["-m", "hy3_research_mcp.server"],
+      "env": {
+        "HY3_ENV_FILE": "/absolute/path/to/Hy3/.env"
+      }
+    }
+  }
+}

--- a/mcp_servers/deep_research/pyproject.toml
+++ b/mcp_servers/deep_research/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hy3-research-mcp"
+version = "0.1.0"
+description = "A stdio MCP server that turns Hy3 into a deep research assistant with web search and page reading."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Tencent Hunyuan Hy3 contributors" }
+]
+dependencies = [
+  "mcp>=1.27,<2",
+  "openai>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8",
+  "pytest-asyncio>=0.23",
+]
+
+[project.scripts]
+hy3-research-mcp = "hy3_research_mcp.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hy3_research_mcp"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/mcp_servers/deep_research/scripts/stdio_smoke.py
+++ b/mcp_servers/deep_research/scripts/stdio_smoke.py
@@ -1,0 +1,76 @@
+"""End-to-end stdio smoke test against the real MCP server process.
+
+Drives the server with the official MCP Python SDK client over stdio.
+Exercises the tools that do NOT require a live Hy3 GPU endpoint
+(web_search_tool, read_url_tool) against the real web, proving the MCP
+server is callable from a real MCP client. Hy3-wrapped tools
+(research_question, summarize_documents, generate_research_outline) are
+unit-tested in tests/test_server.py because no live Hy3 endpoint is
+available in CI.
+
+Run:
+    python mcp_servers/deep_research/scripts/stdio_smoke.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(REPO_SRC))
+
+
+async def main() -> None:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    server_cmd = [sys.executable, "-m", "hy3_research_mcp.server"]
+    params = StdioServerParameters(
+        command=server_cmd[0], args=server_cmd[1:], env=os.environ.copy()
+    )
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            tool_names = sorted(t.name for t in tools.tools)
+            print("TOOLS:", tool_names)
+            expected = {
+                "web_search_tool",
+                "read_url_tool",
+                "research_question",
+                "summarize_documents",
+                "generate_research_outline",
+            }
+            assert expected <= set(tool_names), tool_names
+
+            # Real web search over stdio (no key, no Hy3).
+            res = await session.call_tool(
+                "web_search_tool", {"query": "Tencent Hy3 model", "max_results": 3}
+            )
+            payload = json.loads(res.content[0].text) if res.content else {}
+            print("SEARCH COUNT:", payload.get("count"))
+            print("SAMPLE RESULT:", (payload.get("results") or [{}])[0])
+            assert payload.get("count", 0) >= 0, payload
+            print("WEB_SEARCH SMOKE OK")
+
+            # Real page read over stdio (no key, no Hy3).
+            res2 = await session.call_tool(
+                "read_url_tool",
+                {"url": "https://raw.githubusercontent.com/Tencent-Hunyuan/Hy3/main/README.md", "max_chars": 1000},
+            )
+            payload2 = json.loads(res2.content[0].text) if res2.content else {}
+            print("READ_URL CHARS:", payload2.get("chars"))
+            sample_text = payload2.get("text", "")
+            print("READ SAMPLE:", sample_text[:120].replace(chr(10), " "))
+            assert payload2.get("chars", 0) > 0, payload2
+            print("READ_URL SMOKE OK")
+
+            print("STDIO SMOKE OK")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_servers/deep_research/src/hy3_research_mcp/__init__.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Hy3 deep research MCP server package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/mcp_servers/deep_research/src/hy3_research_mcp/config.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/config.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char == "#" and not in_single and not in_double:
+            if index == 0 or value[index - 1].isspace():
+                return value[:index].rstrip()
+    return value.strip()
+
+
+def _parse_env_value(raw_value: str) -> str:
+    value = _strip_inline_comment(raw_value.strip())
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value
+
+
+def load_dotenv_file(path: Path) -> None:
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key and not key.startswith("#"):
+            os.environ.setdefault(key, _parse_env_value(raw_value))
+
+
+def find_dotenv(start: Optional[Path] = None) -> Optional[Path]:
+    explicit = os.getenv("HY3_ENV_FILE")
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+
+    current = (start or Path.cwd()).resolve()
+    candidates = [current, *current.parents]
+    for directory in candidates:
+        env_file = directory / ".env"
+        if env_file.exists():
+            return env_file
+    return None
+
+
+def load_default_dotenv(start: Optional[Path] = None) -> Optional[Path]:
+    env_file = find_dotenv(start)
+    if env_file is None:
+        return None
+    load_dotenv_file(env_file)
+    return env_file
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    return default if value is None else float(value)
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None else int(value)
+
+
+def _api_key_for_base_url(base_url: str) -> str:
+    hy3_key = os.getenv("HY3_API_KEY")
+    if hy3_key and hy3_key != "EMPTY":
+        return hy3_key
+    if "openrouter.ai" in base_url:
+        return os.getenv("OPENROUTER_API_KEY") or hy3_key or "EMPTY"
+    if "hunyuan.cloud.tencent.com" in base_url:
+        return os.getenv("HUNYUAN_API_KEY") or hy3_key or "EMPTY"
+    return hy3_key or "EMPTY"
+
+
+@dataclass(frozen=True)
+class Hy3Settings:
+    base_url: str
+    api_key: str
+    model: str
+    temperature: float
+    top_p: float
+    max_tokens: int
+    reasoning_effort: str
+
+    @classmethod
+    def from_env(cls) -> "Hy3Settings":
+        base_url = os.getenv("HY3_BASE_URL", "http://127.0.0.1:8000/v1")
+        return cls(
+            base_url=base_url,
+            api_key=_api_key_for_base_url(base_url),
+            model=os.getenv("HY3_MODEL", "hy3"),
+            temperature=_float_env("HY3_TEMPERATURE", 0.9),
+            top_p=_float_env("HY3_TOP_P", 1.0),
+            max_tokens=_int_env("HY3_MAX_TOKENS", 2048),
+            reasoning_effort=os.getenv("HY3_REASONING_EFFORT", "high"),
+        )
+
+
+@dataclass(frozen=True)
+class ResearchSettings:
+    """Web data source settings. No key is required for the built-in search."""
+
+    search_api_key: Optional[str]
+    search_engine: str
+    max_search_results: int
+    page_timeout: float
+    max_page_chars: int
+    user_agent: str
+
+    @classmethod
+    def from_env(cls) -> "ResearchSettings":
+        return cls(
+            search_api_key=os.getenv("HY3_SEARCH_API_KEY")
+            or os.getenv("TAVILY_API_KEY")
+            or os.getenv("BRAVE_API_KEY"),
+            search_engine=os.getenv("HY3_SEARCH_ENGINE", "duckduckgo"),
+            max_search_results=_int_env("HY3_MAX_SEARCH_RESULTS", 5),
+            page_timeout=_float_env("HY3_PAGE_TIMEOUT", 15.0),
+            max_page_chars=_int_env("HY3_MAX_PAGE_CHARS", 8000),
+            user_agent=os.getenv(
+                "HY3_USER_AGENT",
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+            ),
+        )

--- a/mcp_servers/deep_research/src/hy3_research_mcp/hy3_client.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/hy3_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+from .config import Hy3Settings
+
+
+class Hy3Client:
+    """Thin wrapper over the OpenAI-compatible Hy3 chat completions API."""
+
+    def __init__(self, settings: Hy3Settings):
+        self.settings = settings
+
+    @classmethod
+    def from_env(cls) -> "Hy3Client":
+        return cls(Hy3Settings.from_env())
+
+    def _extra_body(self) -> Dict[str, Any]:
+        effort = self.settings.reasoning_effort
+        if not effort:
+            return {}
+        if "openrouter.ai" in self.settings.base_url:
+            mapped = "none" if effort == "no_think" else effort
+            return {"reasoning": {"effort": mapped}}
+        return {"chat_template_kwargs": {"reasoning_effort": effort}}
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "You are a meticulous research analyst. Synthesize evidence into clear, cited, and honest conclusions.",
+        prior_turns: Optional[Iterable[Dict[str, str]]] = None,
+    ) -> str:
+        from openai import OpenAI
+
+        messages: list[Dict[str, str]] = [{"role": "system", "content": system}]
+        if prior_turns:
+            messages.extend(prior_turns)
+        messages.append({"role": "user", "content": prompt})
+
+        client = OpenAI(base_url=self.settings.base_url, api_key=self.settings.api_key)
+        response = client.chat.completions.create(
+            model=self.settings.model,
+            messages=messages,
+            temperature=self.settings.temperature,
+            top_p=self.settings.top_p,
+            max_tokens=self.settings.max_tokens,
+            extra_body=self._extra_body(),
+        )
+        message = response.choices[0].message
+        content = message.content or getattr(message, "reasoning", None)
+        return content or ""

--- a/mcp_servers/deep_research/src/hy3_research_mcp/research.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/research.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+
+from .search import SearchResult
+
+
+class CompletionClient(Protocol):
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = ...,
+        prior_turns: Optional[Iterable[Dict[str, str]]] = None,
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """One piece of sourced evidence gathered for a research question."""
+
+    query: str
+    results: List[SearchResult]
+
+    def render(self) -> str:
+        if not self.results:
+            return f"Search '{self.query}' returned no usable results."
+        lines = [f"Search: {self.query}"]
+        for i, r in enumerate(self.results, 1):
+            lines.append(f"[{i}] {r.title}\n    URL: {r.url}")
+            if r.snippet:
+                lines.append(f"    {r.snippet}")
+        return "\n".join(lines)
+
+
+def render_evidence_block(evidence: Iterable[Evidence]) -> str:
+    blocks = [e.render() for e in evidence]
+    return "\n\n".join(blocks) if blocks else "No evidence was gathered."
+
+
+def build_research_prompt(
+    question: str,
+    evidence_block: str,
+    *,
+    focus: str = "",
+    depth: str = "balanced",
+) -> str:
+    focus_line = f"Focus: {focus}.\n" if focus else ""
+    return f"""Research question: {question}
+
+{focus_line}Depth: {depth}. Use the search evidence below as primary grounding.
+If evidence is missing or conflicts, state that explicitly instead of inventing facts.
+Cite sources by their [N] index and URL when making claims.
+
+Return concise markdown:
+1. Answer - the direct answer to the question
+2. Key findings - bullet list, each with a citation
+3. Confidence - high/medium/low and a one-line reason
+4. Gaps - what is still unknown or where evidence is weak
+
+Evidence:
+{evidence_block}
+"""
+
+
+def build_outline_prompt(question: str, evidence_block: str) -> str:
+    return f"""A researcher is investigating: {question}
+
+Below is raw search evidence. Produce a short research outline (markdown headings)
+that would organize a report answering the question. List 3 to 6 sections with a
+one-sentence purpose each. Do not write the full report.
+
+Evidence:
+{evidence_block}
+"""
+
+
+def build_summary_prompt(question: str, documents_block: str) -> str:
+    return f"""Summarize the documents below into a faithful, structured answer for this question:
+
+Question: {question}
+
+Rules:
+- Only use information present in the documents.
+- Quote or paraphrase with a document label (Doc A, Doc B, ...).
+- If the documents do not contain the answer, say so plainly.
+
+Documents:
+{documents_block}
+"""

--- a/mcp_servers/deep_research/src/hy3_research_mcp/search.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/search.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import html as html_module
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .config import ResearchSettings
+from .web_utils import fetch_html, resolve_relative
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"title": self.title, "url": self.url, "snippet": self.snippet}
+
+
+def web_search(query: str, settings: ResearchSettings) -> List[SearchResult]:
+    """Run a web search via the configured engine. Defaults to DuckDuckGo (no key)."""
+    engine = (settings.search_engine or "duckduckgo").lower()
+    if settings.search_api_key and engine in {"tavily", "brave"}:
+        if engine == "tavily":
+            return _tavily_search(query, settings)
+        if engine == "brave":
+            return _brave_search(query, settings)
+    return _duckduckgo_search(query, settings)
+
+
+def _duckduckgo_search(query: str, settings: ResearchSettings) -> List[SearchResult]:
+    """Parse DuckDuckGo Lite HTML results. Pure stdlib, no API key required.
+
+    Uses lite.duckduckgo.com, which returns server-rendered result HTML that is
+    reliable to parse without JavaScript. The public duckduckgo.com/html/ page
+    frequently serves a JS/redirect shell to non-browser clients.
+    """
+    import urllib.parse
+    import urllib.request
+
+    params = urllib.parse.urlencode({"q": query})
+    url = f"https://lite.duckduckgo.com/html/?{params}"
+    req = urllib.request.Request(url, headers={"User-Agent": settings.user_agent})
+    with urllib.request.urlopen(req, timeout=settings.page_timeout) as resp:
+        html = resp.read().decode("utf-8", "replace")
+
+    results: List[SearchResult] = []
+    # Match each <a ... class="result__a" ... href="...">title</a> independently,
+    # Match each result__a anchor regardless of attribute ORDER.
+    anchor_re = re.compile(r'<a\b[^>]*class="result__a"[^>]*>(.*?)</a>', re.DOTALL)
+    href_re = re.compile(r'href="([^"]+)"')
+    for m in anchor_re.finditer(html):
+        raw_href = href_re.search(m.group(0))
+        if not raw_href:
+            continue
+        href_value = html_module.unescape(raw_href.group(1))
+        actual = _unwrap_ddg_link(href_value) or resolve_relative("https://duckduckgo.com", href_value)
+        if not actual or not actual.startswith("http"):
+            continue
+        title = _strip_tags(m.group(1)) or actual
+        tail = html[m.end(): m.end() + 2000]
+        next_anchor = tail.find("result__a")
+        if next_anchor > 0:
+            tail = tail[:next_anchor]
+        snip = ""
+        snip_m = re.search(r'class="result__snippet"[^>]*>(.*?)</a>', tail, re.DOTALL)
+        if snip_m:
+            snip = _strip_tags(snip_m.group(1))
+        results.append(SearchResult(title=title.strip(), url=actual, snippet=snip.strip()))
+        if len(results) >= settings.max_search_results:
+            break
+    return results
+
+
+def _unwrap_ddg_link(href: str) -> Optional[str]:
+    import urllib.parse
+
+    parsed = urllib.parse.urlparse(href)
+    if "duckduckgo.com" in (parsed.netloc or "") and "/l/" in (parsed.path or ""):
+        qs = urllib.parse.parse_qs(parsed.query)
+        uddg = qs.get("uddg", [""])[0]
+        if uddg:
+            return html_module.unescape(uddg)
+    return None
+
+
+def _strip_tags(text: str) -> str:
+    return re.sub(r"<[^>]+>", "", text or "").strip()
+
+
+def _tavily_search(query: str, settings: ResearchSettings) -> List[SearchResult]:
+    import urllib.parse
+
+    payload = json.dumps(
+        {
+            "api_key": settings.search_api_key,
+            "query": query,
+            "max_results": settings.max_search_results,
+        }
+    ).encode("utf-8")
+    req = urllib.parse.Request(
+        "https://api.tavily.com/search",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": settings.user_agent,
+        },
+        method="POST",
+    )
+    import urllib.request
+
+    with urllib.request.urlopen(req, timeout=settings.page_timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    return [
+        SearchResult(
+            title=item.get("title", ""),
+            url=item.get("url", ""),
+            snippet=item.get("content", ""),
+        )
+        for item in data.get("results", [])[: settings.max_search_results]
+    ]
+
+
+def _brave_search(query: str, settings: ResearchSettings) -> List[SearchResult]:
+    import urllib.parse
+
+    params = urllib.parse.urlencode({"q": query, "count": settings.max_search_results})
+    req = urllib.parse.Request(
+        f"https://api.search.brave.com/res/v1/web/search?{params}",
+        headers={
+            "Accept": "application/json",
+            "X-Subscription-Token": settings.search_api_key or "",
+            "User-Agent": settings.user_agent,
+        },
+    )
+    import urllib.request
+
+    with urllib.request.urlopen(req, timeout=settings.page_timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    results: List[SearchResult] = []
+    for item in data.get("results", []) or []:
+        results.append(
+            SearchResult(
+                title=item.get("title", ""),
+                url=item.get("url", ""),
+                snippet=item.get("description", ""),
+            )
+        )
+    return results[: settings.max_search_results]

--- a/mcp_servers/deep_research/src/hy3_research_mcp/server.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/server.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import ResearchSettings, load_default_dotenv
+from .hy3_client import Hy3Client
+from .research import (
+    CompletionClient,
+    Evidence,
+    build_outline_prompt,
+    build_research_prompt,
+    build_summary_prompt,
+    render_evidence_block,
+)
+from .search import SearchResult, web_search
+from .web_utils import read_url_text
+
+
+mcp = FastMCP("Hy3 Deep Research MCP", json_response=True)
+
+
+def _research_settings() -> ResearchSettings:
+    load_default_dotenv()
+    return ResearchSettings.from_env()
+
+
+def _client() -> CompletionClient:
+    load_default_dotenv()
+    return Hy3Client.from_env()
+
+
+@mcp.tool()
+def web_search_tool(query: str, max_results: Optional[int] = None) -> Dict[str, Any]:
+    """Search the web for sources on a query and return titles, URLs, and snippets.
+
+    Uses the configured search engine (DuckDuckGo by default, no API key required).
+    When HY3_SEARCH_API_KEY and HY3_SEARCH_ENGINE=tavily|brave are set, that engine is used.
+
+    Args:
+        query: The search query.
+        max_results: Optional override for the number of results (default 5).
+    """
+    settings = _research_settings()
+    if max_results is not None and max_results > 0:
+        settings = ResearchSettings(
+            search_api_key=settings.search_api_key,
+            search_engine=settings.search_engine,
+            max_search_results=max_results,
+            page_timeout=settings.page_timeout,
+            max_page_chars=settings.max_page_chars,
+            user_agent=settings.user_agent,
+        )
+    results = web_search(query, settings)
+    return {
+        "query": query,
+        "results": [r.to_dict() for r in results],
+        "count": len(results),
+    }
+
+
+@mcp.tool()
+def read_url_tool(url: str, max_chars: Optional[int] = None) -> Dict[str, Any]:
+    """Fetch a web page and return its readable plain text.
+
+    Args:
+        url: Absolute http or https URL to read.
+        max_chars: Optional character budget for the returned text.
+    """
+    settings = _research_settings()
+    text = read_url_text(url, settings, max_chars=max_chars)
+    return {"url": url, "text": text, "chars": len(text)}
+
+
+@mcp.tool()
+def research_question(
+    question: str,
+    searches: str = "",
+    focus: str = "",
+    depth: str = "balanced",
+    read_top_pages: int = 0,
+) -> Dict[str, Any]:
+    """Answer a research question by searching the web, reading sources, then asking Hy3 to synthesize.
+
+    Args:
+        question: The research question to answer.
+        searches: Optional comma- or newline-separated sub-queries. When omitted, the question itself is used as one search.
+        focus: Optional focus lens, e.g. "security", "cost", "recent changes since 2025".
+        depth: Analysis depth: shallow, balanced, or deep (controls Hy3 reasoning).
+        read_top_pages: Number of top URLs from searches to read into evidence (0-3 recommended).
+    """
+    settings = _research_settings()
+    extra = {"balanced": "", "shallow": "Keep it brief.", "deep": "Be thorough and exhaustive."}
+    focus_line = focus.strip()
+
+    queries = [q.strip() for q in (searches or question).replace("\n", ",").split(",") if q.strip()]
+    if not queries:
+        queries = [question]
+
+    evidence: List[Evidence] = []
+    top_urls: List[str] = []
+    for q in queries:
+        results = web_search(q, settings)
+        evidence.append(Evidence(query=q, results=results))
+        for r in results:
+            if r.url not in top_urls:
+                top_urls.append(r.url)
+
+    page_texts: List[Dict[str, str]] = []
+    for url in top_urls[: max(0, min(read_top_pages, 3))]:
+        try:
+            page_texts.append({"url": url, "text": read_url_text(url, settings)})
+        except RuntimeError as exc:
+            page_texts.append({"url": url, "error": str(exc)})
+
+    evidence_block = render_evidence_block(evidence)
+    if page_texts:
+        pages = "\n\n".join(
+            f"Page {chr(ord('A') + i)} - {p['url']}:\n{(p.get('text') or p.get('error'))[:settings.max_page_chars]}"
+            for i, p in enumerate(page_texts)
+        )
+        evidence_block += "\n\nFull page excerpts:\n" + pages
+
+    depth_hint = extra.get(depth, "")
+    prompt = build_research_prompt(
+        question,
+        evidence_block,
+        focus=focus_line,
+        depth=depth,
+    ) + (f"\n\nDepth hint: {depth_hint}" if depth_hint else "")
+
+    answer = _client().complete(prompt)
+    return {
+        "question": question,
+        "queries": queries,
+        "search_results": {e.query: [r.to_dict() for r in e.results] for e in evidence},
+        "pages_read": page_texts,
+        "answer": answer,
+    }
+
+
+@mcp.tool()
+def summarize_documents(
+    question: str,
+    documents: List[str],
+) -> Dict[str, Any]:
+    """Summarize one or more pasted documents into a cited answer to a question.
+
+    Args:
+        question: The question to answer from the documents.
+        documents: List of document texts (long strings). Each becomes a labeled Doc A, Doc B, ...
+    """
+    if not documents:
+        raise ValueError("documents must contain at least one non-empty string.")
+    documents_block = "\n\n".join(
+        f"Doc {chr(ord('A') + i)}:\n{doc}" for i, doc in enumerate(documents) if doc
+    )
+    prompt = build_summary_prompt(question, documents_block)
+    summary = _client().complete(prompt)
+    return {
+        "question": question,
+        "document_count": len([d for d in documents if d]),
+        "summary": summary,
+    }
+
+
+@mcp.tool()
+def generate_research_outline(question: str, searches: str = "") -> Dict[str, Any]:
+    """Generate a structured research outline (sections + purpose) for a question.
+
+    Args:
+        question: The topic or question to outline.
+        searches: Optional sub-queries to ground the outline in live evidence.
+    """
+    settings = _research_settings()
+    queries = [q.strip() for q in (searches or question).replace("\n", ",").split(",") if q.strip()] or [question]
+    evidence = [Evidence(query=q, results=web_search(q, settings)) for q in queries]
+    evidence_block = render_evidence_block(evidence)
+    prompt = build_outline_prompt(question, evidence_block)
+    outline = _client().complete(prompt)
+    return {
+        "question": question,
+        "queries": queries,
+        "search_results": {e.query: [r.to_dict() for r in e.results] for e in evidence},
+        "outline": outline,
+    }
+
+
+def main() -> None:
+    load_default_dotenv()
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_servers/deep_research/src/hy3_research_mcp/web_utils.py
+++ b/mcp_servers/deep_research/src/hy3_research_mcp/web_utils.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from .config import ResearchSettings
+
+
+def _build_opener(settings: ResearchSettings):
+    import urllib.request
+
+    opener = urllib.request.build_opener()
+    opener.addheaders = [("User-Agent", settings.user_agent)]
+    return opener
+
+
+def fetch_html(url: str, settings: ResearchSettings) -> str:
+    """Fetch raw HTML for a URL with a timeout. Raises on HTTP errors."""
+    import urllib.error
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Only http/https URLs are supported: {url}")
+
+    opener = _build_opener(settings)
+    try:
+        with opener.open(url, timeout=settings.page_timeout) as response:
+            raw = response.read(settings.max_page_chars + 4096)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} fetching {url}") from exc
+    except Exception as exc:  # noqa: BLE001 - surface any fetch failure to the tool caller
+        raise RuntimeError(f"Failed to fetch {url}: {exc}") from exc
+
+    charset = "utf-8"
+    if hasattr(response, "headers") and response.headers.get("Content-Type"):
+        for part in response.headers.get("Content-Type", "").split(";"):
+            part = part.strip()
+            if part.startswith("charset="):
+                charset = part[len("charset=") :]
+    try:
+        return raw.decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        return raw.decode("utf-8", errors="replace")
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_SCRIPT_STYLE_RE = re.compile(
+    r"<(script|style|noscript)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL
+)
+
+
+def html_to_text(html: str, max_chars: int) -> str:
+    """Crude but dependency-free HTML -> text extraction for research snippets."""
+    text = _SCRIPT_STYLE_RE.sub(" ", html)
+    text = text.replace("<br>", "\n").replace("<br/>", "\n").replace("<br />", "\n")
+    text = text.replace("</p>", "\n\n").replace("</li>", "\n").replace("</h", "\n")
+    text = _TAG_RE.sub("", text)
+    import html as html_module
+
+    text = html_module.unescape(text)
+    lines = [ln.strip() for ln in text.splitlines()]
+    text = _WS_RE.sub(" ", "\n".join(ln for ln in lines if ln)).strip()
+    if max_chars > 0 and len(text) > max_chars:
+        return text[:max_chars] + "\n\n[truncated]"
+    return text
+
+
+def read_url_text(url: str, settings: ResearchSettings, max_chars: Optional[int] = None) -> str:
+    """Fetch a URL and return readable text bounded by max_chars."""
+    limit = max_chars if max_chars is not None else settings.max_page_chars
+    html = fetch_html(url, settings)
+    return html_to_text(html, limit)
+
+
+def resolve_relative(base: str, href: str) -> Optional[str]:
+    if not href or href.startswith(("#", "mailto:", "javascript:")):
+        return None
+    return urljoin(base, href)

--- a/mcp_servers/deep_research/tests/test_config.py
+++ b/mcp_servers/deep_research/tests/test_config.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from hy3_research_mcp.config import Hy3Settings, ResearchSettings, load_dotenv_file
+
+
+def test_load_dotenv_file_sets_missing_values_without_overriding_existing(monkeypatch, tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "HY3_BASE_URL=https://from-dotenv.example/v1",
+                "HY3_API_KEY=from-dotenv",
+                "HY3_MODEL='hy3-dotenv'",
+                "HY3_MAX_TOKENS=4096 # inline comment",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HY3_API_KEY", "from-shell")
+    monkeypatch.delenv("HY3_BASE_URL", raising=False)
+    monkeypatch.delenv("HY3_MODEL", raising=False)
+    monkeypatch.delenv("HY3_MAX_TOKENS", raising=False)
+
+    load_dotenv_file(env_file)
+
+    settings = Hy3Settings.from_env()
+    assert settings.base_url == "https://from-dotenv.example/v1"
+    assert settings.api_key == "from-shell"
+    assert settings.model == "hy3-dotenv"
+    assert settings.max_tokens == 4096
+
+
+def test_settings_defaults_match_local_hy3(monkeypatch):
+    for key in [
+        "HY3_BASE_URL",
+        "HY3_API_KEY",
+        "HY3_MODEL",
+        "HY3_TEMPERATURE",
+        "HY3_TOP_P",
+        "HY3_MAX_TOKENS",
+        "HY3_REASONING_EFFORT",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    settings = Hy3Settings.from_env()
+    assert settings.base_url == "http://127.0.0.1:8000/v1"
+    assert settings.api_key == "EMPTY"
+    assert settings.model == "hy3"
+    assert settings.temperature == 0.9
+    assert settings.top_p == 1.0
+    assert settings.max_tokens == 2048
+    assert settings.reasoning_effort == "high"
+
+
+def test_openrouter_settings_fall_back_to_openrouter_api_key(monkeypatch):
+    monkeypatch.setenv("HY3_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("HY3_API_KEY", "EMPTY")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter")
+    assert Hy3Settings.from_env().api_key == "sk-openrouter"
+
+
+def test_tencent_settings_fall_back_to_hunyuan_api_key(monkeypatch):
+    monkeypatch.setenv("HY3_BASE_URL", "https://api.hunyuan.cloud.tencent.com/v1")
+    monkeypatch.setenv("HY3_API_KEY", "EMPTY")
+    monkeypatch.setenv("HUNYUAN_API_KEY", "sk-hunyuan")
+    assert Hy3Settings.from_env().api_key == "sk-hunyuan"
+
+
+def test_research_settings_defaults_need_no_key(monkeypatch):
+    for key in [
+        "HY3_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "BRAVE_API_KEY",
+        "HY3_SEARCH_ENGINE",
+        "HY3_MAX_SEARCH_RESULTS",
+        "HY3_PAGE_TIMEOUT",
+        "HY3_MAX_PAGE_CHARS",
+        "HY3_USER_AGENT",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    r = ResearchSettings.from_env()
+    assert r.search_engine == "duckduckgo"
+    assert r.search_api_key is None
+    assert r.max_search_results == 5

--- a/mcp_servers/deep_research/tests/test_research.py
+++ b/mcp_servers/deep_research/tests/test_research.py
@@ -1,0 +1,65 @@
+from hy3_research_mcp.research import (
+    Evidence,
+    build_outline_prompt,
+    build_research_prompt,
+    build_summary_prompt,
+    render_evidence_block,
+)
+from hy3_research_mcp.search import SearchResult
+
+
+class FakeCompletionClient:
+    def __init__(self, text: str = "fake answer"):
+        self.text = text
+        self.last_prompt = ""
+        self.calls = 0
+
+    def complete(self, prompt, *, system="", prior_turns=None):  # noqa: D401
+        self.calls += 1
+        self.last_prompt = prompt
+        return self.text
+
+
+def _settings_for() -> None:
+    return None
+
+
+def test_evidence_render_for_empty_results():
+    e = Evidence(query="q", results=[])
+    assert "no usable results" in e.render()
+
+
+def test_evidence_render_lists_results_with_indices():
+    r = SearchResult(title="T", url="https://example.com", snippet="S")
+    out = Evidence(query="q", results=[r]).render()
+    assert "[1]" in out
+    assert "T" in out
+    assert "https://example.com" in out
+    assert "S" in out
+
+
+def test_render_evidence_block_joins_multiple():
+    a = Evidence(query="a", results=[SearchResult("A", "https://a", "x")])
+    b = Evidence(query="b", results=[SearchResult("B", "https://b", "y")])
+    out = render_evidence_block([a, b])
+    assert "Search: a" in out
+    assert "Search: b" in out
+
+
+def test_build_research_prompt_includes_question_and_focus():
+    prompt = build_research_prompt("Why X?", "EVIDENCE", focus="cost", depth="deep")
+    assert "Why X?" in prompt
+    assert "EVIDENCE" in prompt
+    assert "cost" in prompt
+
+
+def test_build_outline_prompt_asks_for_outline_not_report():
+    prompt = build_outline_prompt("topic", "EVIDENCE")
+    assert "outline" in prompt.lower()
+    assert "sections" in prompt.lower()
+
+
+def test_build_summary_prompt_references_documents_label():
+    prompt = build_summary_prompt("Q", "Doc A:\nbody")
+    assert "Doc A" in prompt
+    assert "Q" in prompt

--- a/mcp_servers/deep_research/tests/test_server.py
+++ b/mcp_servers/deep_research/tests/test_server.py
@@ -1,0 +1,103 @@
+import asyncio
+import os
+
+from hy3_research_mcp import server
+
+
+def test_server_exposes_five_research_tools():
+    tools = asyncio.run(server.mcp.list_tools())
+    names = {tool.name for tool in tools}
+    assert names == {
+        "web_search_tool",
+        "read_url_tool",
+        "research_question",
+        "summarize_documents",
+        "generate_research_outline",
+    }
+    assert all(tool.description for tool in tools)
+    assert all(tool.inputSchema is not None for tool in tools)
+
+
+
+
+def test_web_search_tool_requires_query_schema():
+    tools = asyncio.run(server.mcp.list_tools())
+    tool = next(t for t in tools if t.name == "web_search_tool")
+    props = tool.inputSchema.get("properties", {})
+    assert "query" in props
+    assert "max_results" in props
+    required = tool.inputSchema.get("required", [])
+    assert "query" in required
+
+
+def test_research_question_tool_schema_documents_inputs():
+    tools = asyncio.run(server.mcp.list_tools())
+    tool = next(t for t in tools if t.name == "research_question")
+    props = tool.inputSchema.get("properties", {})
+    for name in ["question", "searches", "focus", "depth", "read_top_pages"]:
+        assert name in props
+    assert "question" in tool.inputSchema.get("required", [])
+
+class FakeClient:
+    def __init__(self, text="HY3-SAYS"):
+        self.text = text
+        self.last_prompt = ""
+
+    def complete(self, prompt, *, system="", prior_turns=None):
+        self.last_prompt = prompt
+        return self.text
+
+
+def test_research_question_uses_hy3_client_and_search(monkeypatch):
+    fake = FakeClient("## Answer\nHy3 synthesized.")
+
+    def fake_client():
+        return fake
+
+    def fake_web_search(query, settings):
+        from hy3_research_mcp.search import SearchResult
+
+        return [SearchResult(title=query, url=f"https://example.com/{query}", snippet="snip")]
+
+    monkeypatch.setattr(server, "_client", fake_client)
+    monkeypatch.setattr(server, "web_search", fake_web_search)
+
+    env = dict(os.environ)
+    os.environ.pop("HY3_API_KEY", None)
+    os.environ.pop("HY3_BASE_URL", None)
+    result = server.research_question(
+        question="What is Hy3?",
+        searches="Hy3 model",
+        depth="balanced",
+    )
+    os.environ.clear()
+    os.environ.update(env)
+
+    assert result["question"] == "What is Hy3?"
+    assert "Hy3 model" in result["queries"]
+    assert result["answer"] == "## Answer\nHy3 synthesized."
+    assert "Hy3 synthesized." in fake.last_prompt or "Hy3 model" in fake.last_prompt
+
+
+def test_summarize_documents_requires_documents():
+    try:
+        server.summarize_documents(question="q", documents=[])
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for empty documents")
+
+
+def test_generate_research_outline_returns_outline(monkeypatch):
+    fake = FakeClient("## Outline\n1. Intro\n2. Body")
+
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    def fake_web_search(query, settings):
+        from hy3_research_mcp.search import SearchResult
+
+        return [SearchResult(title="t", url="https://e.com", snippet="s")]
+
+    monkeypatch.setattr(server, "web_search", fake_web_search)
+    result = server.generate_research_outline(question="topic")
+    assert result["outline"] == "## Outline\n1. Intro\n2. Body"
+    assert "topic" in fake.last_prompt

--- a/mcp_servers/deep_research/tests/test_web_utils.py
+++ b/mcp_servers/deep_research/tests/test_web_utils.py
@@ -1,0 +1,41 @@
+from hy3_research_mcp.config import ResearchSettings
+from hy3_research_mcp.web_utils import html_to_text, resolve_relative
+
+
+def test_html_to_text_strips_tags_and_keeps_text():
+    html = "<html><body><script>var x=1</script><h1>Title</h1><p>Hello <b>world</b>.</p></body></html>"
+    text = html_to_text(html, max_chars=0)
+    assert "Title" in text
+    assert "Hello world" in text
+    assert "var x=1" not in text
+
+
+def test_html_to_text_truncates_with_marker():
+    html = "<p>" + ("a" * 100) + "</p>"
+    text = html_to_text(html, max_chars=10)
+    assert text.endswith("[truncated]")
+    assert text.startswith("aaaaaaaaaa")
+
+
+def test_html_to_text_unescapes_entities():
+    assert "&amp;" not in html_to_text("<p>Tom &amp; Jerry</p>", max_chars=0)
+    assert "Tom & Jerry" in html_to_text("<p>Tom &amp; Jerry</p>", max_chars=0)
+
+
+def test_resolve_relative_handles_common_cases():
+    assert resolve_relative("https://example.com/", "https://other.com/x") == "https://other.com/x"
+    assert resolve_relative("https://example.com/page", "/x") == "https://example.com/x"
+    assert resolve_relative("https://example.com/", "mailto:a@b.com") is None
+    assert resolve_relative("https://example.com/", "#frag") is None
+    assert resolve_relative("https://example.com/", "") is None
+
+
+def test_fetch_html_rejects_non_http(monkeypatch):
+    from hy3_research_mcp.web_utils import fetch_html
+
+    settings = ResearchSettings.from_env()
+    try:
+        fetch_html("file:///etc/passwd", settings)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for non-http scheme")


### PR DESCRIPTION
Closes #3


## Problem

The brief asks for an open-source, pluggable MCP Server that wraps Hy3 for a
chosen scenario and can be installed by any MCP client with no extra client
development. A code-review server already exists (#10); this contribution adds a
**deep research assistant** scenario (web search + page reading + Hy3
synthesis) as a distinct, self-contained package under `mcp_servers/`.

## Scenario

A user asks a research question inside any MCP client. The client is free to:

1. call `web_search_tool` to gather sources (DuckDuckGo, no API key),
2. call `read_url_tool` to read a page,
3. call `research_question` so Hy3 synthesizes a cited answer, or
4. call `summarize_documents` / `generate_research_outline` for follow-ups.

Hy3 is the core reasoning engine; the web is the external data source. The
server targets the OpenAI-compatible Hy3 endpoint documented in the repo README
(vLLM/SGLang, OpenRouter, Tencent Cloud Hunyuan).

## What changed

New package `mcp_servers/deep_research/`:

| File | Role |
| --- | --- |
| `pyproject.toml` | hatchling build, `hy3-research-mcp` console script, deps `mcp` + `openai` |
| `src/hy3_research_mcp/config.py` | env/dotenv loader, `Hy3Settings` + `ResearchSettings`, no hardcoded keys |
| `src/hy3_research_mcp/hy3_client.py` | OpenAI-compatible Hy3 chat client, `reasoning_effort` mapped per backend |
| `src/hy3_research_mcp/search.py` | DuckDuckGo Lite parser (no key) + optional Tavily/Brave backends |
| `src/hy3_research_mcp/web_utils.py` | stdlib HTML fetch + plain-text extractor with bounded `max_chars` |
| `src/hy3_research_mcp/research.py` | prompt builders for answer synthesis, outline, document summary |
| `src/hy3_research_mcp/server.py` | FastMCP stdio server exposing 5 tools + `main()` entrypoint |
| `tests/` | 22 unit tests (config, web_utils, research, server tool surface) |
| `README.md`, `.env.example` | install, Hy3 + web env config, 5 tool examples, safety notes |
| `docs/clients/`, `examples/` | Trae/CodeBuddy + Cursor + Cline configs, demo script |
| `scripts/stdio_smoke.py` | end-to-end stdio verification with the official MCP SDK client |

No existing repository files were changed.

## Tools (5, exceeds the 3-tool minimum)

| Tool | Purpose | Key parameters |
| --- | --- | --- |
| `web_search_tool` | Search the web; returns titles, URLs, snippets. No API key. | `query`, `max_results` |
| `read_url_tool` | Fetch a page and return readable plain text. | `url`, `max_chars` |
| `research_question` | Search -> optional page reads -> Hy3 synthesis with citations. | `question`, `searches`, `focus`, `depth`, `read_top_pages` |
| `summarize_documents` | Hy3-summarize pasted documents into a cited answer. | `question`, `documents` |
| `generate_research_outline` | Hy3-generate a report outline grounded in search evidence. | `question`, `searches` |

## Requirements checklist

- [x] MCP Python SDK, FastMCP, stdio transport
- [x] >= 3 tools with clear name, parameters, description (5 provided)
- [x] Hy3 API powers core reasoning (`hy3_client.py`, OpenAI-compatible)
- [x] 1-2 external data sources (web search + page fetch, stdlib, no key required)
- [x] stdio only; no public deployment
- [x] no hardcoded API keys — env vars / `.env` only (`HY3_*`)
- [x] one-key install: `pip install ./mcp_servers/deep_research`
- [x] full README with install, config, examples
- [x] client config examples for Trae/CodeBuddy, Cursor, Cline + demo script
- [ ] demo GIF/video: to be attached to the issue comment (repo does not commit
      large binaries, per the existing `code_review` server's convention)

## Verification

No live Hy3 GPU endpoint is available in CI, so Hy3-wrapped tools are covered by
unit tests with an injected client and are not claimed as live-verified. The MCP
transport and the web data sources are verified end-to-end:

```bash
pip install -e ./mcp_servers/deep_research[dev]
python -m py_compile mcp_servers/deep_research/src/hy3_research_mcp/*.py
PYTHONPATH=mcp_servers/deep_research/src pytest -q mcp_servers/deep_research/tests
python mcp_servers/deep_research/scripts/stdio_smoke.py
```

Concrete results from this environment:

- 22 unit tests pass (`22 passed in 0.33s`)
- `python -m py_compile` clean
- `stdio_smoke.py` drives the real server process with the official MCP SDK
  client over stdio:
  - `tools/list` returns all 5 expected tool names
  - `tools/call web_search_tool` over the live web returns 3 real results, first
    hit `https://github.com/Tencent-Hunyuan/Hy3` with a live snippet
  - `tools/call read_url_tool` on
    `https://raw.githubusercontent.com/Tencent-Hunyuan/Hy3/main/README.md`
    returns 1013 chars of real page text
  - prints `STDIO SMOKE OK`

The DuckDuckGo parser anchors on `result__a` links and unwraps the `l/?uddg=`
redirect; the default User-Agent is a realistic browser string because DDG serves
a JS shell to `compatible` bot tokens (this was diagnosed against the live
endpoint during development).

## Design notes

- No new dependencies beyond `mcp` and `openai`; web I/O uses the stdlib so the
  server works the moment a Hy3 endpoint is configured, with no extra key.
- Env/dotenv contract mirrors the existing `code_review` server for consistency.
- `read_url_tool` extracts plain text from static HTML; JS-rendered pages
  (e.g. some GitHub views) may return little text, documented in the README.
- API keys are read from env/`.env`, never logged, and never returned by tools.
- stdio server does not write to stdout during normal operation.

## Rhino-bird

This PR is part of the 犀牛鸟开源人才培养计划, targeting the `rhinobird2026`
branch. The issue will be claimed in its comment thread.