### PR TITLE
【Issue 3】Add Hy3-powered MCP server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ print(response.choices[0].message.content)
 
 See the [Deployment](#deployment) section below for how to start the API server.
 
+## Rhino-Bird MCP Server Example
+
+This branch includes a stdio MCP Server example in [`examples/hy3-mcp-server`](examples/hy3-mcp-server). It packages Hy3 API calls as three MCP tools for code review, document QA, and data analysis, with CodeBuddy/WorkBuddy and Cursor configuration examples.
+
 ## Deployment
 
 Hy3 has 295B parameters in total. To serve it on 8 GPUs, we recommend using H20-3e or other GPUs with larger memory capacity.

--- a/examples/hy3-mcp-server/README.md
+++ b/examples/hy3-mcp-server/README.md
@@ -1,0 +1,120 @@
+# Hy3 MCP Server
+
+This example implements a local stdio MCP Server powered by Hy3. It exposes three tools for common agent workflows:
+
+- `hy3_code_review`: review a diff and return prioritized findings.
+- `hy3_document_qa`: answer a question from supplied documents with citations.
+- `hy3_data_insight`: inspect CSV or JSON data and produce an analysis plan plus takeaways.
+
+Hy3 is used as the reasoning engine through its OpenAI-compatible chat completions API. API keys are never hard-coded; configure them through environment variables.
+
+## Install
+
+```bash
+cd examples/hy3-mcp-server
+pip install -e .
+```
+
+## Environment
+
+```bash
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+For local smoke tests without a running Hy3 endpoint, set:
+
+```bash
+export HY3_MOCK="1"
+```
+
+Mock mode is only for demos and tests. Production use should point `HY3_BASE_URL` at a real Hy3-compatible endpoint.
+
+## Run
+
+```bash
+hy3-mcp-server
+```
+
+The server runs over stdio and is intended to be started by an MCP client.
+
+## CodeBuddy / WorkBuddy Configuration
+
+Project-level MCP configuration example:
+
+```json
+{
+  "mcpServers": {
+    "hy3-mcp-server": {
+      "command": "hy3-mcp-server",
+      "env": {
+        "HY3_BASE_URL": "http://127.0.0.1:8000/v1",
+        "HY3_API_KEY": "EMPTY",
+        "HY3_MODEL": "hy3"
+      }
+    }
+  }
+}
+```
+
+One runnable tool-call demo:
+
+```text
+Use the hy3_code_review tool with this diff and focus on regressions:
+
+diff --git a/app.py b/app.py
++ user_input = request.args["q"]
++ cursor.execute("select * from docs where title = '%s'" % user_input)
+```
+
+## Cursor Configuration
+
+Add this server to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "hy3-mcp-server": {
+      "command": "python",
+      "args": ["-m", "hy3_mcp_server.server"],
+      "env": {
+        "HY3_BASE_URL": "http://127.0.0.1:8000/v1",
+        "HY3_API_KEY": "EMPTY",
+        "HY3_MODEL": "hy3"
+      }
+    }
+  }
+}
+```
+
+## Demo Flows
+
+Demo 1: Code review.
+
+```bash
+HY3_MOCK=1 python -m hy3_mcp_server.demo code-review
+```
+
+Demo 2: Document QA.
+
+```bash
+HY3_MOCK=1 python -m hy3_mcp_server.demo document-qa
+```
+
+These demos exercise the same tool functions that the MCP server exposes. Replace `HY3_MOCK=1` with real Hy3 environment variables for live model calls.
+
+## Development
+
+```bash
+python -m pytest
+python -m compileall src
+```
+
+## Notes For The Rhino-Bird Issue
+
+- The implementation uses the MCP Python SDK and local stdio mode.
+- It exposes three tools with names, schemas, and docstrings.
+- Core reasoning is delegated to Hy3 through the OpenAI-compatible API.
+- The package can be installed with `pip install -e .` or built as a wheel.
+- CodeBuddy/WorkBuddy and Cursor configuration examples are included above.

--- a/examples/hy3-mcp-server/README.md
+++ b/examples/hy3-mcp-server/README.md
@@ -1,12 +1,13 @@
 # Hy3 MCP Server
 
-This example implements a local stdio MCP Server powered by Hy3. It exposes three tools for common agent workflows:
+This example implements a local stdio MCP Server powered by Hy3. It exposes four tools for common agent workflows:
 
 - `hy3_code_review`: review a diff and return prioritized findings.
 - `hy3_document_qa`: answer a question from supplied documents with citations.
 - `hy3_data_insight`: inspect CSV or JSON data and produce an analysis plan plus takeaways.
+- `hy3_agent_plan`: turn a complex user goal into an MCP-client execution plan.
 
-Hy3 is used as the reasoning engine through its OpenAI-compatible chat completions API. API keys are never hard-coded; configure them through environment variables.
+Hy3 is used as the reasoning engine through its OpenAI-compatible chat completions API. API keys are never hard-coded; configure them through environment variables. The tools expose a Hy3-specific `thinking_mode` parameter where useful: `fast` maps to `reasoning_effort=no_think`, and `deep` maps to `reasoning_effort=high`.
 
 ## Install
 
@@ -68,6 +69,14 @@ diff --git a/app.py b/app.py
 + cursor.execute("select * from docs where title = '%s'" % user_input)
 ```
 
+The review, QA, and data tools also accept:
+
+```json
+{
+  "thinking_mode": "deep"
+}
+```
+
 ## Cursor Configuration
 
 Add this server to `.cursor/mcp.json`:
@@ -102,6 +111,12 @@ Demo 2: Document QA.
 HY3_MOCK=1 python -m hy3_mcp_server.demo document-qa
 ```
 
+Demo 3: MCP task planning.
+
+```bash
+HY3_MOCK=1 python -m hy3_mcp_server.demo agent-plan
+```
+
 These demos exercise the same tool functions that the MCP server exposes. Replace `HY3_MOCK=1` with real Hy3 environment variables for live model calls.
 
 ## Development
@@ -114,7 +129,8 @@ python -m compileall src
 ## Notes For The Rhino-Bird Issue
 
 - The implementation uses the MCP Python SDK and local stdio mode.
-- It exposes three tools with names, schemas, and docstrings.
+- It exposes four tools with names, schemas, and docstrings.
 - Core reasoning is delegated to Hy3 through the OpenAI-compatible API.
+- Hy3 fast/deep thinking modes are surfaced through tool parameters where useful.
 - The package can be installed with `pip install -e .` or built as a wheel.
 - CodeBuddy/WorkBuddy and Cursor configuration examples are included above.

--- a/examples/hy3-mcp-server/examples/codebuddy-mcp.json
+++ b/examples/hy3-mcp-server/examples/codebuddy-mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "hy3-mcp-server": {
+      "command": "hy3-mcp-server",
+      "env": {
+        "HY3_BASE_URL": "http://127.0.0.1:8000/v1",
+        "HY3_API_KEY": "EMPTY",
+        "HY3_MODEL": "hy3"
+      }
+    }
+  }
+}

--- a/examples/hy3-mcp-server/pyproject.toml
+++ b/examples/hy3-mcp-server/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hy3-mcp-server"
+version = "0.1.0"
+description = "A stdio MCP server that wraps Hy3 API for code review, document QA, and data analysis."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+  { name = "Tencent Hy3 Rhino-Bird Example Contributors" }
+]
+dependencies = [
+  "mcp>=1.8.0"
+]
+
+[project.scripts]
+hy3-mcp-server = "hy3_mcp_server.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hy3_mcp_server"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/__init__.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/__init__.py
@@ -1,0 +1,5 @@
+"""Hy3-powered MCP Server example."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/demo.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from .tools import answer_question, inspect_data, review_diff
+from .tools import answer_question, build_agent_plan, inspect_data, review_diff
 
 
 def run_code_review() -> dict:
@@ -15,7 +15,7 @@ diff --git a/app.py b/app.py
 +user_input = request.args["q"]
 +cursor.execute("select * from docs where title = '%s'" % user_input)
 """
-    return review_diff(diff, focus="security and regression risk")
+    return review_diff(diff, focus="security and regression risk", thinking_mode="deep")
 
 
 def run_document_qa() -> dict:
@@ -31,24 +31,33 @@ def run_document_qa() -> dict:
             "text": "The MCP server must expose at least three tools and pass keys through environment variables.",
         },
     ]
-    return answer_question("What role does Hy3 play in this MCP server?", docs)
+    return answer_question("What role does Hy3 play in this MCP server?", docs, thinking_mode="deep")
 
 
 def run_data_insight() -> dict:
     csv_data = "week,signups,retention\n2026-07-01,120,0.42\n2026-07-08,164,0.48\n"
-    return inspect_data(csv_data, "What changed week over week?")
+    return inspect_data(csv_data, "What changed week over week?", thinking_mode="fast")
+
+
+def run_agent_plan() -> dict:
+    return build_agent_plan(
+        "Review a pull request, summarize risk, and prepare a release note",
+        "Available MCP tools include code review, document QA, and data insight.",
+    )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("demo", choices=["code-review", "document-qa", "data-insight"])
+    parser.add_argument("demo", choices=["code-review", "document-qa", "data-insight", "agent-plan"])
     args = parser.parse_args()
     if args.demo == "code-review":
         result = run_code_review()
     elif args.demo == "document-qa":
         result = run_document_qa()
-    else:
+    elif args.demo == "data-insight":
         result = run_data_insight()
+    else:
+        result = run_agent_plan()
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
 

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/demo.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/demo.py
@@ -1,0 +1,56 @@
+"""Small CLI demos that exercise the MCP tool implementations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from .tools import answer_question, inspect_data, review_diff
+
+
+def run_code_review() -> dict:
+    diff = """
+diff --git a/app.py b/app.py
+@@
++user_input = request.args["q"]
++cursor.execute("select * from docs where title = '%s'" % user_input)
+"""
+    return review_diff(diff, focus="security and regression risk")
+
+
+def run_document_qa() -> dict:
+    docs = [
+        {
+            "id": "hy3-readme",
+            "title": "Hy3 README",
+            "text": "Hy3 is a 295B MoE model with 21B active parameters and OpenAI-compatible chat API examples.",
+        },
+        {
+            "id": "issue-3",
+            "title": "Rhino-Bird MCP issue",
+            "text": "The MCP server must expose at least three tools and pass keys through environment variables.",
+        },
+    ]
+    return answer_question("What role does Hy3 play in this MCP server?", docs)
+
+
+def run_data_insight() -> dict:
+    csv_data = "week,signups,retention\n2026-07-01,120,0.42\n2026-07-08,164,0.48\n"
+    return inspect_data(csv_data, "What changed week over week?")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("demo", choices=["code-review", "document-qa", "data-insight"])
+    args = parser.parse_args()
+    if args.demo == "code-review":
+        result = run_code_review()
+    elif args.demo == "document-qa":
+        result = run_document_qa()
+    else:
+        result = run_data_insight()
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/hy3_client.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/hy3_client.py
@@ -1,0 +1,100 @@
+"""Small OpenAI-compatible client for Hy3 chat completions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from typing import Iterable
+from urllib import error, request
+
+
+@dataclass(frozen=True)
+class Hy3Settings:
+    base_url: str
+    api_key: str
+    model: str = "hy3"
+    timeout_seconds: int = 60
+    mock: bool = False
+
+    @classmethod
+    def from_env(cls) -> "Hy3Settings":
+        return cls(
+            base_url=os.getenv("HY3_BASE_URL", "http://127.0.0.1:8000/v1").rstrip("/"),
+            api_key=os.getenv("HY3_API_KEY", ""),
+            model=os.getenv("HY3_MODEL", "hy3"),
+            timeout_seconds=int(os.getenv("HY3_TIMEOUT_SECONDS", "60")),
+            mock=os.getenv("HY3_MOCK", "").lower() in {"1", "true", "yes", "on"},
+        )
+
+
+class Hy3Client:
+    """Calls Hy3 through the OpenAI-compatible chat completions endpoint."""
+
+    def __init__(self, settings: Hy3Settings | None = None) -> None:
+        self.settings = settings or Hy3Settings.from_env()
+
+    def chat(self, system: str, user: str, *, reasoning_effort: str = "high") -> str:
+        if self.settings.mock:
+            return self._mock_response(system, user)
+
+        if not self.settings.api_key:
+            raise RuntimeError("HY3_API_KEY is required unless HY3_MOCK=1 is set.")
+
+        payload = {
+            "model": self.settings.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "reasoning_effort": reasoning_effort,
+                }
+            },
+        }
+        body = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            f"{self.settings.base_url}/chat/completions",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self.settings.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        try:
+            with request.urlopen(req, timeout=self.settings.timeout_seconds) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Hy3 API returned HTTP {exc.code}: {detail}") from exc
+        except error.URLError as exc:
+            raise RuntimeError(f"Hy3 API request failed: {exc.reason}") from exc
+
+        return data["choices"][0]["message"]["content"]
+
+    @staticmethod
+    def _mock_response(system: str, user: str) -> str:
+        preview = compact_lines(user.splitlines(), limit=8)
+        return (
+            "Mock Hy3 response\n\n"
+            "Summary: the request was parsed successfully and would be sent to Hy3 in live mode.\n\n"
+            "Key evidence:\n"
+            f"{preview}\n\n"
+            "Recommended next step: run again with HY3_BASE_URL, HY3_API_KEY, and HY3_MODEL configured."
+        )
+
+
+def compact_lines(lines: Iterable[str], *, limit: int) -> str:
+    kept = []
+    for raw in lines:
+        line = raw.strip()
+        if line:
+            kept.append(line[:180])
+        if len(kept) >= limit:
+            break
+    return "\n".join(f"- {line}" for line in kept) or "- No input content supplied."

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/server.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
-from .tools import answer_question, inspect_data, review_diff
+from .tools import answer_question, build_agent_plan, inspect_data, review_diff
 
 
 mcp = FastMCP(
@@ -19,21 +19,39 @@ mcp = FastMCP(
 
 
 @mcp.tool()
-def hy3_code_review(diff: str, focus: str = "correctness and regressions") -> dict[str, Any]:
-    """Review a unified diff with Hy3 and return prioritized findings."""
-    return review_diff(diff=diff, focus=focus)
+def hy3_code_review(
+    diff: str,
+    focus: str = "correctness and regressions",
+    thinking_mode: str = "deep",
+) -> dict[str, Any]:
+    """Review a unified diff with Hy3. thinking_mode may be fast or deep."""
+    return review_diff(diff=diff, focus=focus, thinking_mode=thinking_mode)
 
 
 @mcp.tool()
-def hy3_document_qa(question: str, documents: list[dict[str, str]]) -> dict[str, Any]:
+def hy3_document_qa(
+    question: str,
+    documents: list[dict[str, str]],
+    thinking_mode: str = "deep",
+) -> dict[str, Any]:
     """Answer a question from supplied documents and cite document ids."""
-    return answer_question(question=question, documents=documents)
+    return answer_question(question=question, documents=documents, thinking_mode=thinking_mode)
 
 
 @mcp.tool()
-def hy3_data_insight(data: str, question: str = "What should I know about this dataset?") -> dict[str, Any]:
+def hy3_data_insight(
+    data: str,
+    question: str = "What should I know about this dataset?",
+    thinking_mode: str = "deep",
+) -> dict[str, Any]:
     """Analyze CSV or JSON data with Hy3 and return takeaways plus next steps."""
-    return inspect_data(data=data, question=question)
+    return inspect_data(data=data, question=question, thinking_mode=thinking_mode)
+
+
+@mcp.tool()
+def hy3_agent_plan(goal: str, available_context: str = "") -> dict[str, Any]:
+    """Plan a multi-step AI-client task with Hy3 before running tools."""
+    return build_agent_plan(goal=goal, available_context=available_context)
 
 
 def main() -> None:

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/server.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/server.py
@@ -1,0 +1,44 @@
+"""MCP stdio entrypoint for the Hy3 server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .tools import answer_question, inspect_data, review_diff
+
+
+mcp = FastMCP(
+    "hy3-mcp-server",
+    instructions=(
+        "Use Hy3 for code review, document QA, and data insight tasks. "
+        "Configure HY3_BASE_URL, HY3_API_KEY, and HY3_MODEL in the MCP client environment."
+    ),
+)
+
+
+@mcp.tool()
+def hy3_code_review(diff: str, focus: str = "correctness and regressions") -> dict[str, Any]:
+    """Review a unified diff with Hy3 and return prioritized findings."""
+    return review_diff(diff=diff, focus=focus)
+
+
+@mcp.tool()
+def hy3_document_qa(question: str, documents: list[dict[str, str]]) -> dict[str, Any]:
+    """Answer a question from supplied documents and cite document ids."""
+    return answer_question(question=question, documents=documents)
+
+
+@mcp.tool()
+def hy3_data_insight(data: str, question: str = "What should I know about this dataset?") -> dict[str, Any]:
+    """Analyze CSV or JSON data with Hy3 and return takeaways plus next steps."""
+    return inspect_data(data=data, question=question)
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/tools.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/tools.py
@@ -1,0 +1,130 @@
+"""Tool implementations shared by the MCP server and tests."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any
+
+from .hy3_client import Hy3Client
+
+
+CODE_REVIEW_SYSTEM = (
+    "You are Hy3 acting as a senior code reviewer. "
+    "Prioritize correctness bugs, security risks, regressions, and missing tests. "
+    "Return concise Markdown with severity labels and concrete suggestions."
+)
+
+DOCUMENT_QA_SYSTEM = (
+    "You are Hy3 acting as a grounded document QA assistant. "
+    "Answer only from the supplied documents, cite document ids, and say when evidence is missing."
+)
+
+DATA_INSIGHT_SYSTEM = (
+    "You are Hy3 acting as a data analyst. "
+    "Use the schema and sample rows to explain likely patterns, risks, and next analyses. "
+    "Do not invent rows or metrics that are not present."
+)
+
+
+def review_diff(diff: str, focus: str = "correctness and regressions", client: Hy3Client | None = None) -> dict[str, Any]:
+    """Review a source diff with Hy3 and return prioritized findings."""
+    hy3 = client or Hy3Client()
+    prompt = (
+        f"Review focus: {focus}\n\n"
+        "Diff:\n"
+        "```diff\n"
+        f"{diff.strip()}\n"
+        "```\n\n"
+        "Respond with: Findings, Suggested patch direction, Missing tests."
+    )
+    return {
+        "tool": "hy3_code_review",
+        "focus": focus,
+        "result": hy3.chat(CODE_REVIEW_SYSTEM, prompt, reasoning_effort="high"),
+    }
+
+
+def answer_question(
+    question: str,
+    documents: list[dict[str, str]],
+    client: Hy3Client | None = None,
+) -> dict[str, Any]:
+    """Answer a question from provided documents with source citations."""
+    hy3 = client or Hy3Client()
+    normalized_docs = normalize_documents(documents)
+    prompt = (
+        f"Question: {question.strip()}\n\n"
+        "Documents:\n"
+        f"{json.dumps(normalized_docs, ensure_ascii=True, indent=2)}\n\n"
+        "Return: Answer, Citations, Confidence, Missing evidence."
+    )
+    return {
+        "tool": "hy3_document_qa",
+        "document_count": len(normalized_docs),
+        "result": hy3.chat(DOCUMENT_QA_SYSTEM, prompt, reasoning_effort="high"),
+    }
+
+
+def inspect_data(
+    data: str,
+    question: str = "What should I know about this dataset?",
+    client: Hy3Client | None = None,
+) -> dict[str, Any]:
+    """Inspect CSV or JSON data and ask Hy3 for analytical takeaways."""
+    hy3 = client or Hy3Client()
+    profile = profile_tabular_data(data)
+    prompt = (
+        f"Analysis question: {question.strip()}\n\n"
+        "Data profile:\n"
+        f"{json.dumps(profile, ensure_ascii=True, indent=2)}\n\n"
+        "Return: Key takeaways, Caveats, Recommended chart or query, Next action."
+    )
+    return {
+        "tool": "hy3_data_insight",
+        "profile": profile,
+        "result": hy3.chat(DATA_INSIGHT_SYSTEM, prompt, reasoning_effort="high"),
+    }
+
+
+def normalize_documents(documents: list[dict[str, str]]) -> list[dict[str, str]]:
+    normalized = []
+    for index, doc in enumerate(documents, start=1):
+        doc_id = str(doc.get("id") or f"doc-{index}")
+        title = str(doc.get("title") or doc_id)
+        text = str(doc.get("text") or "")
+        normalized.append({"id": doc_id, "title": title, "text": text[:6000]})
+    return normalized
+
+
+def profile_tabular_data(data: str) -> dict[str, Any]:
+    text = data.strip()
+    if not text:
+        return {"format": "empty", "row_count": 0, "columns": [], "sample_rows": []}
+
+    if text[0] in "[{":
+        parsed = json.loads(text)
+        rows = parsed if isinstance(parsed, list) else [parsed]
+        if not all(isinstance(row, dict) for row in rows):
+            rows = [{"value": row} for row in rows]
+        return profile_rows("json", rows)
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    return profile_rows("csv", rows)
+
+
+def profile_rows(data_format: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    columns = sorted({str(key) for row in rows for key in row.keys()})
+    null_counts = {
+        column: sum(1 for row in rows if row.get(column) in {None, ""})
+        for column in columns
+    }
+    return {
+        "format": data_format,
+        "row_count": len(rows),
+        "columns": columns,
+        "null_counts": null_counts,
+        "sample_rows": rows[:8],
+    }

--- a/examples/hy3-mcp-server/src/hy3_mcp_server/tools.py
+++ b/examples/hy3-mcp-server/src/hy3_mcp_server/tools.py
@@ -27,12 +27,24 @@ DATA_INSIGHT_SYSTEM = (
     "Do not invent rows or metrics that are not present."
 )
 
+AGENT_PLAN_SYSTEM = (
+    "You are Hy3 acting as an MCP task planner. "
+    "Turn the user's goal into a compact plan that an AI client can execute with tools. "
+    "Call out needed context, suggested MCP tools, risks, and a clear done condition."
+)
 
-def review_diff(diff: str, focus: str = "correctness and regressions", client: Hy3Client | None = None) -> dict[str, Any]:
+
+def review_diff(
+    diff: str,
+    focus: str = "correctness and regressions",
+    thinking_mode: str = "deep",
+    client: Hy3Client | None = None,
+) -> dict[str, Any]:
     """Review a source diff with Hy3 and return prioritized findings."""
     hy3 = client or Hy3Client()
     prompt = (
         f"Review focus: {focus}\n\n"
+        f"Hy3 thinking mode: {thinking_mode}\n\n"
         "Diff:\n"
         "```diff\n"
         f"{diff.strip()}\n"
@@ -42,13 +54,15 @@ def review_diff(diff: str, focus: str = "correctness and regressions", client: H
     return {
         "tool": "hy3_code_review",
         "focus": focus,
-        "result": hy3.chat(CODE_REVIEW_SYSTEM, prompt, reasoning_effort="high"),
+        "thinking_mode": normalize_thinking_mode(thinking_mode),
+        "result": hy3.chat(CODE_REVIEW_SYSTEM, prompt, reasoning_effort=reasoning_effort_for(thinking_mode)),
     }
 
 
 def answer_question(
     question: str,
     documents: list[dict[str, str]],
+    thinking_mode: str = "deep",
     client: Hy3Client | None = None,
 ) -> dict[str, Any]:
     """Answer a question from provided documents with source citations."""
@@ -56,6 +70,7 @@ def answer_question(
     normalized_docs = normalize_documents(documents)
     prompt = (
         f"Question: {question.strip()}\n\n"
+        f"Hy3 thinking mode: {thinking_mode}\n\n"
         "Documents:\n"
         f"{json.dumps(normalized_docs, ensure_ascii=True, indent=2)}\n\n"
         "Return: Answer, Citations, Confidence, Missing evidence."
@@ -63,13 +78,15 @@ def answer_question(
     return {
         "tool": "hy3_document_qa",
         "document_count": len(normalized_docs),
-        "result": hy3.chat(DOCUMENT_QA_SYSTEM, prompt, reasoning_effort="high"),
+        "thinking_mode": normalize_thinking_mode(thinking_mode),
+        "result": hy3.chat(DOCUMENT_QA_SYSTEM, prompt, reasoning_effort=reasoning_effort_for(thinking_mode)),
     }
 
 
 def inspect_data(
     data: str,
     question: str = "What should I know about this dataset?",
+    thinking_mode: str = "deep",
     client: Hy3Client | None = None,
 ) -> dict[str, Any]:
     """Inspect CSV or JSON data and ask Hy3 for analytical takeaways."""
@@ -77,14 +94,36 @@ def inspect_data(
     profile = profile_tabular_data(data)
     prompt = (
         f"Analysis question: {question.strip()}\n\n"
+        f"Hy3 thinking mode: {thinking_mode}\n\n"
         "Data profile:\n"
         f"{json.dumps(profile, ensure_ascii=True, indent=2)}\n\n"
         "Return: Key takeaways, Caveats, Recommended chart or query, Next action."
     )
     return {
         "tool": "hy3_data_insight",
+        "thinking_mode": normalize_thinking_mode(thinking_mode),
         "profile": profile,
-        "result": hy3.chat(DATA_INSIGHT_SYSTEM, prompt, reasoning_effort="high"),
+        "result": hy3.chat(DATA_INSIGHT_SYSTEM, prompt, reasoning_effort=reasoning_effort_for(thinking_mode)),
+    }
+
+
+def build_agent_plan(
+    goal: str,
+    available_context: str = "",
+    client: Hy3Client | None = None,
+) -> dict[str, Any]:
+    """Use Hy3 to turn a complex goal into an MCP-client execution plan."""
+    hy3 = client or Hy3Client()
+    prompt = (
+        f"Goal: {goal.strip()}\n\n"
+        f"Available context: {available_context.strip() or 'none'}\n\n"
+        "Return Markdown sections: Intent, Context needed, Suggested tool sequence, "
+        "Quality checks, Done condition."
+    )
+    return {
+        "tool": "hy3_agent_plan",
+        "thinking_mode": "deep",
+        "result": hy3.chat(AGENT_PLAN_SYSTEM, prompt, reasoning_effort="high"),
     }
 
 
@@ -96,6 +135,19 @@ def normalize_documents(documents: list[dict[str, str]]) -> list[dict[str, str]]
         text = str(doc.get("text") or "")
         normalized.append({"id": doc_id, "title": title, "text": text[:6000]})
     return normalized
+
+
+def normalize_thinking_mode(mode: str) -> str:
+    value = mode.strip().lower()
+    if value in {"fast", "no_think", "quick"}:
+        return "fast"
+    if value in {"deep", "high", "slow"}:
+        return "deep"
+    return "deep"
+
+
+def reasoning_effort_for(mode: str) -> str:
+    return "no_think" if normalize_thinking_mode(mode) == "fast" else "high"
 
 
 def profile_tabular_data(data: str) -> dict[str, Any]:

--- a/examples/hy3-mcp-server/tests/test_tools.py
+++ b/examples/hy3-mcp-server/tests/test_tools.py
@@ -1,5 +1,12 @@
 from hy3_mcp_server.hy3_client import Hy3Client, Hy3Settings
-from hy3_mcp_server.tools import answer_question, inspect_data, normalize_documents, review_diff
+from hy3_mcp_server.tools import (
+    answer_question,
+    build_agent_plan,
+    inspect_data,
+    normalize_documents,
+    reasoning_effort_for,
+    review_diff,
+)
 
 
 def mock_client() -> Hy3Client:
@@ -7,9 +14,10 @@ def mock_client() -> Hy3Client:
 
 
 def test_review_diff_returns_tool_payload() -> None:
-    result = review_diff("+ return user.name\n", client=mock_client())
+    result = review_diff("+ return user.name\n", thinking_mode="fast", client=mock_client())
 
     assert result["tool"] == "hy3_code_review"
+    assert result["thinking_mode"] == "fast"
     assert "Mock Hy3 response" in result["result"]
 
 
@@ -35,3 +43,15 @@ def test_inspect_data_profiles_csv() -> None:
     assert result["profile"]["format"] == "csv"
     assert result["profile"]["row_count"] == 2
     assert result["profile"]["null_counts"]["score"] == 1
+
+
+def test_reasoning_effort_maps_hy3_modes() -> None:
+    assert reasoning_effort_for("fast") == "no_think"
+    assert reasoning_effort_for("deep") == "high"
+
+
+def test_build_agent_plan_returns_tool_payload() -> None:
+    result = build_agent_plan("Ship a release note", client=mock_client())
+
+    assert result["tool"] == "hy3_agent_plan"
+    assert result["thinking_mode"] == "deep"

--- a/examples/hy3-mcp-server/tests/test_tools.py
+++ b/examples/hy3-mcp-server/tests/test_tools.py
@@ -1,0 +1,37 @@
+from hy3_mcp_server.hy3_client import Hy3Client, Hy3Settings
+from hy3_mcp_server.tools import answer_question, inspect_data, normalize_documents, review_diff
+
+
+def mock_client() -> Hy3Client:
+    return Hy3Client(Hy3Settings(base_url="http://127.0.0.1:8000/v1", api_key="", mock=True))
+
+
+def test_review_diff_returns_tool_payload() -> None:
+    result = review_diff("+ return user.name\n", client=mock_client())
+
+    assert result["tool"] == "hy3_code_review"
+    assert "Mock Hy3 response" in result["result"]
+
+
+def test_document_qa_normalizes_document_ids() -> None:
+    docs = normalize_documents([{"title": "Readme", "text": "Hy3 API"}])
+
+    assert docs == [{"id": "doc-1", "title": "Readme", "text": "Hy3 API"}]
+
+
+def test_answer_question_counts_documents() -> None:
+    result = answer_question(
+        "What is Hy3 used for?",
+        [{"id": "a", "title": "A", "text": "Hy3 powers reasoning."}],
+        client=mock_client(),
+    )
+
+    assert result["document_count"] == 1
+
+
+def test_inspect_data_profiles_csv() -> None:
+    result = inspect_data("name,score\nalpha,1\nbeta,\n", client=mock_client())
+
+    assert result["profile"]["format"] == "csv"
+    assert result["profile"]["row_count"] == 2
+    assert result["profile"]["null_counts"]["score"] == 1


### PR DESCRIPTION
## Summary

This PR adds an example Hy3-powered MCP server under `examples/hy3-mcp-server` for Rhino-Bird issue #3.

Upgrade pass:
- exposes four MCP tools: `hy3_code_review`, `hy3_document_qa`, `hy3_data_insight`, and `hy3_agent_plan`
- adds `thinking_mode` support so clients can choose fast (`reasoning_effort=no_think`) or deep (`reasoning_effort=high`) Hy3 calls
- includes a mockable demo CLI, CodeBuddy/WorkBuddy MCP config, and a complete README
- keeps API keys out of source; live mode is configured through `HY3_BASE_URL`, `HY3_API_KEY`, and `HY3_MODEL`

## Validation

- `python -m pytest` -> 6 passed
- `python -m compileall src` -> passed
- `HY3_MOCK=1 PYTHONPATH=src python -m hy3_mcp_server.demo agent-plan` -> returned the mock `hy3_agent_plan` payload
- `git diff --check` -> no whitespace errors