### PR TITLE
docs: 补充 Hy3 在 Codex CLI / Aider / Claude Code / Continue / Open WebUI 中的接入指南

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,68 @@
+# Hy3 主流 AI 产品接入指南
+
+本目录面向终端用户，说明如何在常见 AI 产品、IDE、CLI 工具、VS Code 插件和自托管平台中使用 Hy3，并给出一个基于 Hy3 的小作品 demo 方案。
+
+## 通用配置
+
+Hy3 提供 OpenAI Compatible 接口，只要工具支持自定义 OpenAI 兼容服务，一般都可以按以下方式配置。
+
+| 配置项 | 本地 vLLM/SGLang | OpenRouter | 腾讯云 TokenHub |
+| --- | --- | --- | --- |
+| Base URL | `http://127.0.0.1:8000/v1` | `https://openrouter.ai/api/v1` | `https://tokenhub.tencentmaas.com/v1` |
+| Model | `hy3` | `tencent/hy3-295b-a21b` | `hy3-preview` |
+| Protocol | OpenAI Compatible | OpenAI Compatible | OpenAI Compatible |
+| API Key | `EMPTY` 或任意 | OpenRouter Key | TokenHub Key |
+
+> 建议把 API Key 配置为本地环境变量，避免写进截图、配置文件或公开仓库。
+>
+> ```bash
+> export HY3_API_KEY="your-api-key"
+> export HY3_BASE_URL="https://openrouter.ai/api/v1"
+> ```
+>
+> Windows PowerShell:
+> ```powershell
+> $env:HY3_API_KEY="your-api-key"
+> $env:HY3_BASE_URL="https://openrouter.ai/api/v1"
+> ```
+
+## 工具指南
+
+### 本 PR 新增（聚焦 CLI / 自托管工具）
+
+| 工具 | 类型 | 指南 |
+| --- | --- | --- |
+| Codex CLI | AI 工具（OpenAI 官方 CLI） | [codex-cli.md](./codex-cli.md) |
+| Aider | AI 结对编程 CLI | [aider.md](./aider.md) |
+| Claude Code | Anthropic 官方 AI CLI | [claude-code.md](./claude-code.md) |
+| Continue | VS Code 插件 | [continue.md](./continue.md) |
+| Open WebUI | 自托管大模型 Web 界面 | [open-webui.md](./open-webui.md) |
+
+### 相关参考
+
+社区中还有其他同学贡献了不同工具的接入方案，可互为补充：
+
+- OpenRouter / Cursor / CodeBuddy / WorkBuddy / Cline / Roo Code / Dify：参见 PR #19
+- CLine / CodeBuddy IDE / OpenRouter / Roo Code / ClaudeCode：参见 PR #33
+
+## 小作品 Demo
+
+示例小作品是一个基于 Hy3 的科普动画生成网站 **Vibemotion**：输入任意科普主题，Hy3 生成一段生动的解说词和一段可在浏览器中运行的 p5.js 动画。
+
+- 独立仓库：[xy200303/hy3-vibemotion](https://github.com/xy200303/hy3-vibemotion)
+- 核心能力：推理 + 长文生成
+- 开发工具：Aider + Hy3（呼应本目录中的 Aider 接入指南）
+- 运行方式：见仓库 README
+
+## 使用建议
+
+1. **先通后精**：第一次接入时先做一个最小对话请求，确认 API Key、Base URL 和模型名无误。
+2. **协议选择**：如果工具中有 “OpenAI Compatible”、“Custom OpenAI”、“OpenAI API Compatible” 等选项，优先选择这些模式。
+3. **Base URL 不要重复 `/v1`**：如果工具默认自动追加 `/v1`，不要重复填写成 `/v1/v1`。
+4. **模型名与服务商对齐**：本地部署一般用 `hy3`；OpenRouter 用 `tencent/hy3-295b-a21b`；TokenHub 用 `hy3-preview`。
+5. **开启流式输出**：大部分工具默认开启 `stream`，如果手动关闭，长回复可能超时。
+6. **Reasoning 模式**：复杂任务（代码、数学、推理）可在 `extra_body` 或工具高级设置里设置 `reasoning_effort` 为 `high`；普通对话用 `no_think`。
+7. ** troubleshooting**：
+   - `401`：检查 API Key 是否正确，以及是否多写了 `Bearer ` 前缀（多数工具会自动加）。
+   - `404`：检查 Base URL 是否多写或少写 `/v1`。
+   - `429`：触发限流或配额限制，降低并发或稍后重试。

--- a/docs/integrations/aider.md
+++ b/docs/integrations/aider.md
@@ -1,0 +1,117 @@
+# 在 Aider 中使用 Hy3
+
+[Aider](https://aider.chat/) 是一款流行的 AI 结对编程 CLI，支持 OpenAI、Anthropic、OpenAI-compatible 等多种后端。本文介绍如何把 Aider 的后端切换到 Hy3，实现本地或云端 Hy3 辅助编码。
+
+## 1. 安装与版本要求
+
+- **Python**：≥ 3.10
+- **Aider**：推荐最新稳定版
+  ```bash
+  pip install -U aider-chat
+  ```
+- **Git**：Aider 依赖 Git 跟踪改动。
+- **网络**：能访问本地 vLLM/SGLang、OpenRouter 或 TokenHub。
+
+验证安装：
+
+```bash
+aider --version
+```
+
+## 2. 核心配置项
+
+Aider 通过环境变量或命令行参数指定模型。最简洁的方式是设置环境变量：
+
+```bash
+export OPENAI_API_BASE="https://openrouter.ai/api/v1"
+export OPENAI_API_KEY="sk-or-v1-..."
+```
+
+然后启动 Aider 并指定模型：
+
+```bash
+aider --model openai/tencent/hy3-295b-a21b
+```
+
+| 配置项 | 说明 |
+| --- | --- |
+| `OPENAI_API_BASE` | OpenAI-compatible Base URL，例如 `https://openrouter.ai/api/v1` |
+| `OPENAI_API_KEY` | 对应服务商 API Key |
+| `--model` | Aider 使用 `openai/<model-name>` 格式指定 OpenAI-compatible 模型 |
+
+如果使用本地 vLLM/SGLang：
+
+```bash
+export OPENAI_API_BASE="http://127.0.0.1:8000/v1"
+export OPENAI_API_KEY="EMPTY"
+aider --model openai/hy3
+```
+
+Windows PowerShell：
+
+```powershell
+$env:OPENAI_API_BASE="https://openrouter.ai/api/v1"
+$env:OPENAI_API_KEY="sk-or-v1-..."
+aider --model openai/tencent/hy3-295b-a21b
+```
+
+## 3. 第一次对话测试
+
+进入任意 Git 仓库目录，启动 Aider：
+
+```bash
+aider --model openai/tencent/hy3-295b-a21b
+```
+
+输入最小测试 Prompt：
+
+```text
+/hello，请用一句话介绍 Hy3，并输出数字 1
+```
+
+预期结果：Aider 正常显示 Hy3 的回复。
+
+![Aider + Hy3 示意图](./assets/aider.svg)
+
+## 4. 端到端实战 Demo：为现有项目添加单元测试
+
+假设项目已有 `calculator.py`，希望 Hy3 为其生成单元测试：
+
+```bash
+aider --model openai/tencent/hy3-295b-a21b calculator.py
+```
+
+在 Aider 中输入：
+
+```text
+请为 calculator.py 编写 pytest 单元测试，覆盖所有公开函数，并处理边界情况。测试文件命名为 tests/test_calculator.py。
+```
+
+操作步骤：
+
+1. Aider 读取 `calculator.py` 内容并作为上下文。
+2. Hy3 生成测试代码。
+3. Aider 自动将改动写入 `tests/test_calculator.py`。
+4. 运行 `pytest tests/test_calculator.py` 验证。
+
+示例输出（Aider 会话节选）：
+
+```markdown
+> Add tests/test_calculator.py
+Added tests/test_calculator.py to the chat
+
+#### 请为 calculator.py 编写 pytest 单元测试...
+
+我将为 calculator.py 生成完整的 pytest 测试。...
+
+(Applied edit to tests/test_calculator.py)
+```
+
+## 5. 常见注意事项
+
+1. **模型名格式**：Aider 要求 OpenAI-compatible 模型写成 `openai/<model-name>`。OpenRouter 上 Hy3 的完整模型名为 `tencent/hy3-295b-a21b`，因此命令为 `openai/tencent/hy3-295b-a21b`。
+2. **编辑模式**：Aider 默认使用“diff”编辑模式，需要模型稳定输出可解析的代码 diff。Hy3 的工具调用和格式遵循能力较强，通常可直接使用；如不稳定，可加上 `--edit-format whole`。
+3. **上下文大小**：Aider 会自动添加项目文件到上下文。Hy3 支持 256K 上下文，但如果项目文件过多，仍建议用 `/add` 手动指定相关文件，避免上下文浪费。
+4. **Stream 模式**：Aider 默认开启流式输出，不建议关闭，否则长回复可能超时。
+5. **本地部署需开启工具解析**：如果使用本地 vLLM/SGLang，部署时需要 `--tool-call-parser hy_v3` / `hunyuan` 与 `--reasoning-parser hy_v3` / `hunyuan`，否则 Aider 的部分 Agent 功能可能异常。
+6. **费用控制**：OpenRouter 按 token 计费，建议在 Aider 配置中设置 `weak_model` 为 cheaper 模型，仅把 `model` 指定为 Hy3，用于核心编码任务。

--- a/docs/integrations/assets/aider.svg
+++ b/docs/integrations/assets/aider.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#f6f8fa"/>
+  <rect x="72" y="50" width="816" height="440" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="104" y="100" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#24292f">Aider + Hy3</text>
+  <rect x="104" y="136" width="752" height="72" rx="8" fill="#f0f7ff" stroke="#0969da"/>
+  <text x="130" y="180" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Model: openai/tencent/hy3-295b-a21b | API Base: openrouter.ai/api/v1</text>
+  <rect x="104" y="244" width="752" height="170" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="132" y="288" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#24292f">Generate unit tests</text>
+  <text x="132" y="326" font-family="Arial, sans-serif" font-size="15" fill="#57606a">$ aider --model openai/tencent/hy3-295b-a21b calculator.py</text>
+  <text x="132" y="356" font-family="Arial, sans-serif" font-size="15" fill="#57606a">&gt; 请为 calculator.py 编写 pytest 单元测试...</text>
+  <rect x="104" y="374" width="752" height="2" fill="#d0d7de"/>
+  <text x="132" y="406" font-family="Arial, sans-serif" font-size="14" fill="#1a7f37">✓ Applied edit to tests/test_calculator.py</text>
+</svg>

--- a/docs/integrations/assets/claude-code.svg
+++ b/docs/integrations/assets/claude-code.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#f6f8fa"/>
+  <rect x="72" y="50" width="816" height="440" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="104" y="100" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#24292f">Claude Code + Hy3</text>
+  <rect x="104" y="136" width="752" height="72" rx="8" fill="#f0f7ff" stroke="#0969da"/>
+  <text x="130" y="180" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Override: OPENAI_BASE_URL + ANTHROPIC_MODEL=tencent/hy3-295b-a21b</text>
+  <rect x="104" y="244" width="752" height="170" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="132" y="288" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#24292f">Analyze project dependencies</text>
+  <text x="132" y="326" font-family="Arial, sans-serif" font-size="15" fill="#57606a">$ claude</text>
+  <text x="132" y="356" font-family="Arial, sans-serif" font-size="15" fill="#57606a">&gt; 请分析当前项目的依赖文件，列出 3 个升级建议...</text>
+  <rect x="104" y="374" width="752" height="2" fill="#d0d7de"/>
+  <text x="132" y="406" font-family="Arial, sans-serif" font-size="14" fill="#1a7f37">✓ Hy3 returns structured dependency review</text>
+</svg>

--- a/docs/integrations/assets/codex-cli.svg
+++ b/docs/integrations/assets/codex-cli.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#f6f8fa"/>
+  <rect x="72" y="50" width="816" height="440" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="104" y="100" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#24292f">Codex CLI + Hy3</text>
+  <rect x="104" y="136" width="752" height="72" rx="8" fill="#f0f7ff" stroke="#0969da"/>
+  <text x="130" y="180" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Provider: OpenAI Compatible | Model: tencent/hy3-295b-a21b</text>
+  <rect x="104" y="244" width="752" height="170" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="132" y="288" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#24292f">Review git diff task</text>
+  <text x="132" y="326" font-family="Arial, sans-serif" font-size="15" fill="#57606a">$ codex "请 review 当前仓库的未提交改动..."</text>
+  <text x="132" y="356" font-family="Arial, sans-serif" font-size="15" fill="#57606a">Hy3 输出：3 个按风险排序的改进点</text>
+  <rect x="104" y="374" width="752" height="2" fill="#d0d7de"/>
+  <text x="132" y="406" font-family="Arial, sans-serif" font-size="14" fill="#1a7f37">✓ Connected to OpenRouter / local vLLM</text>
+</svg>

--- a/docs/integrations/assets/continue.svg
+++ b/docs/integrations/assets/continue.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#f6f8fa"/>
+  <rect x="72" y="50" width="816" height="440" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="104" y="100" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#24292f">Continue + Hy3</text>
+  <rect x="104" y="136" width="752" height="72" rx="8" fill="#f0f7ff" stroke="#0969da"/>
+  <text x="130" y="180" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Provider: openai | Model: tencent/hy3-295b-a21b | apiBase: /v1</text>
+  <rect x="104" y="244" width="752" height="170" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="132" y="288" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#24292f">Explain &amp; refactor selected code</text>
+  <text x="132" y="326" font-family="Arial, sans-serif" font-size="15" fill="#57606a">1. Select function in VS Code</text>
+  <text x="132" y="356" font-family="Arial, sans-serif" font-size="15" fill="#57606a">2. Continue panel: "请解释并重构这段代码"</text>
+  <rect x="104" y="374" width="752" height="2" fill="#d0d7de"/>
+  <text x="132" y="406" font-family="Arial, sans-serif" font-size="14" fill="#1a7f37">✓ Apply refactored code with one click</text>
+</svg>

--- a/docs/integrations/assets/open-webui.svg
+++ b/docs/integrations/assets/open-webui.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#f6f8fa"/>
+  <rect x="72" y="50" width="816" height="440" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="104" y="100" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#24292f">Open WebUI + Hy3</text>
+  <rect x="104" y="136" width="752" height="72" rx="8" fill="#f0f7ff" stroke="#0969da"/>
+  <text x="130" y="180" font-family="Arial, sans-serif" font-size="18" fill="#24292f">Connection: OpenAI API | URL: https://openrouter.ai/api/v1</text>
+  <rect x="104" y="244" width="752" height="170" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="132" y="288" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#24292f">Team-shared Hy3 Code Reviewer</text>
+  <text x="132" y="326" font-family="Arial, sans-serif" font-size="15" fill="#57606a">1. Admin panel → OpenAI API connection</text>
+  <text x="132" y="356" font-family="Arial, sans-serif" font-size="15" fill="#57606a">2. Create custom model with system prompt</text>
+  <rect x="104" y="374" width="752" height="2" fill="#d0d7de"/>
+  <text x="132" y="406" font-family="Arial, sans-serif" font-size="14" fill="#1a7f37">✓ Browser-based shared chat for the whole team</text>
+</svg>

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,120 @@
+# 在 Claude Code 中使用 Hy3
+
+[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) 是 Anthropic 发布的 AI 编程 Agent CLI。虽然它原生面向 Claude 系列模型，但通过环境变量覆盖其 OpenAI-compatible 调用路径后，也可以把后端切换为 Hy3。本文介绍在 Claude Code 中接入 Hy3 的方法。
+
+> 注意：Claude Code 对非 Claude 模型的兼容性取决于其内部调用方式。以下方法基于 OpenAI-compatible 覆盖实现，适用于 Claude Code 支持 `OPENAI_BASE_URL` 的版本或后续社区 fork。
+
+## 1. 安装与版本要求
+
+- **Node.js**：≥ 18
+- **Claude Code**：通过 npm 安装
+  ```bash
+  npm install -g @anthropics/claude-code
+  ```
+- **网络**：能访问本地 vLLM/SGLang、OpenRouter 或 TokenHub。
+- **账号**：已有 Hy3 可用的 API Key。
+
+验证安装：
+
+```bash
+claude --version
+```
+
+## 2. 核心配置项
+
+Claude Code 读取 Anthropic 相关环境变量。要切换到 OpenAI-compatible 后端，可设置以下环境变量：
+
+```bash
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export OPENAI_API_KEY="sk-or-v1-..."
+export ANTHROPIC_MODEL="tencent/hy3-295b-a21b"
+```
+
+然后启动：
+
+```bash
+claude
+```
+
+| 配置项 | 说明 |
+| --- | --- |
+| `OPENAI_BASE_URL` | OpenAI-compatible Base URL |
+| `OPENAI_API_KEY` | 对应服务商 API Key |
+| `ANTHROPIC_MODEL` | 模型名覆盖，填 Hy3 模型名 |
+
+如果使用本地 vLLM/SGLang：
+
+```bash
+export OPENAI_BASE_URL="http://127.0.0.1:8000/v1"
+export OPENAI_API_KEY="EMPTY"
+export ANTHROPIC_MODEL="hy3"
+```
+
+Windows PowerShell：
+
+```powershell
+$env:OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+$env:OPENAI_API_KEY="sk-or-v1-..."
+$env:ANTHROPIC_MODEL="tencent/hy3-295b-a21b"
+```
+
+> 若 Claude Code 当前版本不接受 `ANTHROPIC_MODEL` 指向 OpenAI-compatible 模型，可尝试社区版 `claude-code` fork，或使用本文档介绍的 [Codex CLI](./codex-cli.md)、[Aider](./aider.md) 作为替代 CLI。
+
+## 3. 第一次对话测试
+
+在项目目录下启动：
+
+```bash
+claude
+```
+
+输入最小测试 Prompt：
+
+```text
+请用一句话介绍 Hy3，并输出数字 1
+```
+
+预期结果：Claude Code 收到 Hy3 的回复并展示在终端中。
+
+![Claude Code + Hy3 示意图](./assets/claude-code.svg)
+
+## 4. 端到端实战 Demo：分析项目依赖并给出升级建议
+
+进入任意 Python 项目目录，启动 Claude Code 后输入：
+
+```text
+请分析当前项目的依赖文件（requirements.txt 或 pyproject.toml），列出 3 个建议升级的依赖，并说明升级理由与潜在风险。
+```
+
+操作步骤：
+
+1. Claude Code 读取项目文件。
+2. 调用 Hy3 进行依赖分析。
+3. 输出结构化建议。
+
+示例输出：
+
+```markdown
+1. **requests 2.28.1 → 2.32.0**
+   - 理由：修复了 CVE-2024-XXXX 安全漏洞。
+   - 风险：SSL 验证行为微调，需验证内部 CA 配置。
+
+2. **pydantic 1.10 → 2.7**
+   - 理由：性能提升约 5-10 倍，且 Hy3 生成的代码更偏向 v2 语法。
+   - 风险：迁移成本较高，需重写验证器装饰器。
+
+3. **pytest 7.4 → 8.2**
+   - 理由：支持更简洁的 fixture 作用域语法。
+   - 风险：低，向后兼容。
+```
+
+## 5. 常见注意事项
+
+1. **协议兼容性**：Claude Code 默认使用 Anthropic Messages API。通过 `OPENAI_BASE_URL` 切换到 OpenAI-compatible 后端时，需要 Claude Code 版本本身支持该覆盖方式；否则会出现请求格式错误。
+2. **工具调用**：Claude Code 的 Agent 能力依赖工具调用。Hy3 支持工具调用，但本地部署时需要开启 `--tool-call-parser`。
+3. **多模态**：如果 Claude Code 尝试发送图片等多模态内容，而 Hy3 当前版本为文本模型，会报错。此时应避免在 Claude Code 中使用图片相关功能。
+4. **Reasoning 输出**：Hy3 的 reasoning 内容可能以特定标签输出。Claude Code 若无法识别，会显示为普通文本，不影响使用。
+5. **网络超时**：Claude Code 默认等待时间较短，若 Hy3 后端响应慢，可在环境变量中调大超时：
+   ```bash
+   export ANTHROPIC_TIMEOUT_MS=120000
+   ```

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -1,0 +1,100 @@
+# 在 Codex CLI 中使用 Hy3
+
+[Codex CLI](https://github.com/openai/codex) 是 OpenAI 发布的官方编码 Agent CLI，支持通过 `--provider` / `--model` 参数切换任意 OpenAI-compatible 端点。本文介绍如何把 Codex CLI 的后端换成 Hy3。
+
+## 1. 安装与版本要求
+
+- **Node.js**：≥ 20（Codex CLI 基于 Node.js 发布）
+- **Codex CLI**：通过 npm 安装最新版
+  ```bash
+  npm install -g @openai/codex
+  ```
+- **网络**：能访问本地 vLLM/SGLang、OpenRouter 或 TokenHub。
+- **账号**：已有 Hy3 可用的 API Key。
+
+验证安装：
+
+```bash
+codex --version
+```
+
+## 2. 核心配置项
+
+Codex CLI 通过环境变量指定 OpenAI-compatible 端点：
+
+```bash
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export OPENAI_API_KEY="sk-or-v1-..."
+export CODEX_MODEL="tencent/hy3-295b-a21b"
+```
+
+Windows PowerShell：
+
+```powershell
+$env:OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+$env:OPENAI_API_KEY="sk-or-v1-..."
+$env:CODEX_MODEL="tencent/hy3-295b-a21b"
+```
+
+| 配置项 | 说明 |
+| --- | --- |
+| `OPENAI_BASE_URL` | Hy3 的 OpenAI-compatible Base URL，例如 OpenRouter `https://openrouter.ai/api/v1` |
+| `OPENAI_API_KEY` | 对应服务商的 API Key |
+| `CODEX_MODEL` | 模型名，OpenRouter 填 `tencent/hy3-295b-a21b`，本地部署填 `hy3` |
+
+> 如果只想临时切换模型，也可以运行时指定：
+> ```bash
+> codex --model tencent/hy3-295b-a21b
+> ```
+
+## 3. 第一次对话测试
+
+在项目目录下启动 Codex：
+
+```bash
+codex
+```
+
+输入最小测试 Prompt：
+
+```text
+请用一句话介绍 Hy3 模型，并输出数字 1
+```
+
+预期结果：Codex 能正常收到 Hy3 的回复，并显示思考与最终答案。
+
+![Codex CLI + Hy3 示意图](./assets/codex-cli.svg)
+
+## 4. 端到端实战 Demo：让 Hy3  review 当前 git diff
+
+Codex CLI 支持 `/git` 等快捷指令读取仓库上下文。结合 Hy3 的推理能力，可以用一条自然语言指令完成代码审查：
+
+```bash
+codex "请 review 当前仓库的未提交改动，列出 3 个最重要的改进点，并按风险从高到低排序"
+```
+
+操作步骤：
+
+1. 进入一个 Git 仓库。
+2. 执行 `git diff` 确认有未提交改动。
+3. 运行上述 Codex 指令。
+4. Hy3 会自动读取 `git diff` 上下文，并给出结构化 review 结果。
+
+示例输出：
+
+```markdown
+1. **高风险**：`payment.py` 中缺少对 `amount` 的负数校验，可能导致重复退款。
+2. **中风险**：`database.py` 未关闭连接池，高并发下可能耗尽连接。
+3. **低风险**：`utils.py` 的日志格式不统一，建议统一使用 JSON 结构化日志。
+```
+
+## 5. 常见注意事项
+
+1. **模型参数映射**：Codex CLI 默认使用 OpenAI 协议字段。如果后端是本地 vLLM/SGLang，需要确认其支持 `tools`、`stream` 和 `reasoning` 相关字段；Hy3 的 vLLM/SGLang 部署需开启 `--tool-call-parser` 与 `--reasoning-parser`。
+2. **Context Window**：Codex CLI 会把当前项目文件作为上下文发送。Hy3 支持 256K 上下文，但 Codex 默认 tokens 上限较低，可在 `~/.codex/config.yaml` 中调大 `max_tokens`。
+3. **全屏交互模式**：Codex CLI 默认进入全屏 TUI。如果只想单次执行，使用 `--quiet` 或管道输入：
+   ```bash
+   echo "解释这段代码" | codex --quiet
+   ```
+4. **Rate limit**：OpenRouter 免费模型有 RPM 限制，复杂任务建议降低并发或升级套餐。
+5. **Reasoning effort**：Codex CLI 目前对 `extra_body` 支持有限，如需强制开启/关闭 Hy3 推理，建议通过本地 vLLM/SGLang 的默认模板参数控制，或在外部脚本中直接调用 API。

--- a/docs/integrations/continue.md
+++ b/docs/integrations/continue.md
@@ -1,0 +1,132 @@
+# 在 Continue 中使用 Hy3
+
+[Continue](https://www.continue.dev/) 是一款开源的 AI 编程助手，支持 VS Code、JetBrains 和任意文本编辑器。它原生支持 OpenAI-compatible 自定义模型，因此接入 Hy3 非常直接。
+
+## 1. 安装与版本要求
+
+- **VS Code**：≥ 1.80（Continue 同时支持 JetBrains，本文以 VS Code 为例）
+- **Continue 插件**：在 VS Code 扩展商店搜索 `Continue` 并安装
+- **网络**：能访问本地 vLLM/SGLang、OpenRouter 或 TokenHub
+- **账号**：已有 Hy3 可用的 API Key
+
+验证安装：安装完成后，VS Code 左侧边栏会出现 Continue 图标，快捷键 `Ctrl+L`（Windows/Linux）或 `Cmd+L`（macOS）可打开聊天面板。
+
+## 2. 核心配置项
+
+打开 Continue 配置文件：
+
+- 点击 Continue 面板左下角的齿轮图标，选择 **Open config.json**。
+- 或使用命令面板（`Ctrl+Shift+P`）搜索 `Continue: Open config.json`。
+
+在 `models` 数组中添加 Hy3 配置：
+
+```json
+{
+  "title": "Hy3 (OpenRouter)",
+  "provider": "openai",
+  "model": "tencent/hy3-295b-a21b",
+  "apiKey": "${OPENROUTER_API_KEY}",
+  "apiBase": "https://openrouter.ai/api/v1",
+  "completionOptions": {
+    "temperature": 0.9,
+    "topP": 1.0,
+    "maxTokens": 4096
+  }
+}
+```
+
+如果使用本地 vLLM/SGLang：
+
+```json
+{
+  "title": "Hy3 (Local)",
+  "provider": "openai",
+  "model": "hy3",
+  "apiKey": "EMPTY",
+  "apiBase": "http://127.0.0.1:8000/v1",
+  "completionOptions": {
+    "temperature": 0.9,
+    "topP": 1.0,
+    "maxTokens": 4096
+  }
+}
+```
+
+| 配置项 | 说明 |
+| --- | --- |
+| `provider` | 必须填 `openai`，表示使用 OpenAI-compatible 协议 |
+| `model` | 模型名，OpenRouter 填 `tencent/hy3-295b-a21b`，本地填 `hy3` |
+| `apiBase` | Base URL，注意保留 `/v1` |
+| `apiKey` | 对应服务商 API Key；本地部署可填 `EMPTY` |
+
+> 建议不要把真实 API Key 写进 `config.json`。Continue 支持环境变量引用 `${VAR_NAME}`，把 Key 配置进系统环境变量更安全。
+
+## 3. 第一次对话测试
+
+1. 打开任意代码文件。
+2. 按 `Ctrl+L` 打开 Continue 侧边栏。
+3. 在模型下拉框中选择 **Hy3 (OpenRouter)**。
+4. 输入：
+   ```text
+   请用一句话介绍 Hy3，并输出数字 1
+   ```
+
+预期结果：Continue 面板显示 Hy3 的回复。
+
+![Continue + Hy3 示意图](./assets/continue.svg)
+
+## 4. 端到端实战 Demo：解释并重构选中代码
+
+1. 在编辑器中选中一段复杂函数。
+2. 按 `Ctrl+L` 打开 Continue，输入：
+   ```text
+   请解释这段代码的功能，指出潜在问题，然后给出一个更简洁、可维护的重构版本。
+   ```
+3. Continue 会自动把当前选中的代码作为上下文发送给 Hy3。
+4. Hy3 返回解释、问题列表和重构后的代码。
+5. 点击 Continue 面板中的 **Apply** 按钮，可直接将重构代码写入文件。
+
+示例输出：
+
+```markdown
+### 功能
+该函数读取 CSV 文件并按日期聚合销售额。
+
+### 潜在问题
+1. 未处理文件不存在的情况。
+2. 日期解析依赖系统 locale，可能因环境不同而失败。
+3. 内存占用随 CSV 行数线性增长。
+
+### 重构版本
+```python
+import pandas as pd
+from pathlib import Path
+
+def aggregate_sales(csv_path: Path) -> pd.DataFrame:
+    if not csv_path.exists():
+        raise FileNotFoundError(csv_path)
+    df = pd.read_csv(csv_path, parse_dates=["date"], dayfirst=False)
+    return df.groupby("date")["amount"].sum().reset_index()
+```
+```
+
+## 5. 常见注意事项
+
+1. **`apiBase` 末尾 `/v1`**：Continue 使用 OpenAI SDK，需要完整的 `/v1` 路径。如果填 `https://openrouter.ai/api` 会报 404。
+2. **模型下拉框未出现**：保存 `config.json` 后，点击 Continue 面板顶部模型名刷新列表。
+3. **Tab 自动补全**：Continue 的 Tab 自动补全默认使用 `tabAutocompleteModel`。如需使用 Hy3 补全，可单独配置：
+   ```json
+   "tabAutocompleteModel": {
+     "title": "Hy3 Autocomplete",
+     "provider": "openai",
+     "model": "tencent/hy3-295b-a21b",
+     "apiKey": "${OPENROUTER_API_KEY}",
+     "apiBase": "https://openrouter.ai/api/v1"
+   }
+   ```
+4. **上下文长度**：Continue 默认发送的上下文较小。如需利用 Hy3 的 256K 长上下文，可在 `config.json` 中调大 `contextLength`：
+   ```json
+   "contextLength": 128000
+   ```
+5. **流式输出**：Continue 默认开启流式，不建议关闭。
+6. **本地部署工具调用**：如需在 Continue 中使用 Hy3 的 Agent 能力，本地 vLLM/SGLang 必须开启 `--tool-call-parser`。

--- a/docs/integrations/open-webui.md
+++ b/docs/integrations/open-webui.md
@@ -1,0 +1,91 @@
+# 在 Open WebUI 中使用 Hy3
+
+[Open WebUI](https://github.com/open-webui/open-webui) 是一个可自托管的 LLM Web 界面，支持 OpenAI-compatible API。通过把 Hy3 的本地或云端端点接入 Open WebUI，可以在浏览器中与家人、团队共享一个 Hy3 聊天界面。
+
+## 1. 安装与版本要求
+
+- **Docker**（推荐）或 Python ≥ 3.11
+- **Open WebUI**：通过 Docker 一键启动
+  ```bash
+  docker run -d -p 3000:8080 \
+    -v open-webui:/app/backend/data \
+    --name open-webui \
+    ghcr.io/open-webui/open-webui:main
+  ```
+- **Hy3 后端**：本地 vLLM/SGLang 或 OpenRouter/TokenHub 账号
+- **网络**：Open WebUI 容器能访问 Hy3 后端地址
+
+安装完成后，打开 `http://localhost:3000` 注册第一个管理员账号。
+
+## 2. 核心配置项
+
+1. 登录 Open WebUI 后，点击右上角头像 → **管理员面板** → **设置** → **外部连接**（或 **Connections**）。
+2. 点击 **OpenAI API** 标签页。
+3. 填写以下信息：
+
+| 配置项 | 值 |
+| --- | --- |
+| API URL | `https://openrouter.ai/api/v1` 或 `http://host.docker.internal:8000/v1` |
+| API Key | 对应服务商 Key；本地可填 `EMPTY` |
+| 模型 ID | 可选，留空会自动拉取；手动填写 `tencent/hy3-295b-a21b` 或 `hy3` |
+
+4. 点击保存，然后刷新页面。
+
+> 如果 Hy3 部署在宿主机上的 vLLM/SGLang，而 Open WebUI 运行在 Docker 中，请使用 `http://host.docker.internal:8000/v1`（Windows/macOS）或 Docker 容器可访问的宿主机 IP（Linux）。
+
+## 3. 第一次对话测试
+
+1. 在 Open WebUI 首页，顶部模型选择器应能看到 `tencent/hy3-295b-a21b` 或 `hy3`。
+2. 选择 Hy3 模型。
+3. 输入：
+   ```text
+   请用一句话介绍 Hy3，并输出数字 1
+   ```
+
+预期结果：Open WebUI 显示 Hy3 的流式回复。
+
+![Open WebUI + Hy3 示意图](./assets/open-webui.svg)
+
+## 4. 端到端实战 Demo：团队共享的代码审查助手
+
+场景：开发团队在内网部署 Open WebUI + 本地 Hy3，作为统一的代码审查问答入口。
+
+操作步骤：
+
+1. 在 Open WebUI 中新建一个 **模型**（Models → Create Model）。
+2. 选择基础模型为 Hy3。
+3. 在系统提示词中写入：
+   ```text
+   你是一位资深代码审查助手。用户会粘贴代码片段或 diff，请：
+   1. 先说明代码意图；
+   2. 列出潜在 bug、性能问题和安全风险；
+   3. 给出具体修改建议。
+   ```
+4. 保存并命名模型为 **Hy3 Code Reviewer**。
+5. 在聊天中粘贴一段代码或 git diff，即可获得结构化 review。
+
+示例输出：
+
+```markdown
+### 代码意图
+该函数用于计算订单折扣。
+
+### 问题
+1. **精度问题**：直接使用浮点数比较金额，可能产生精度误差。
+2. **权限问题**：未校验用户是否有权应用该折扣码。
+3. **边界问题**：当 `quantity` 为 0 时会返回异常折扣。
+
+### 建议
+- 金额统一使用 Decimal。
+- 在计算折扣前加入权限校验。
+- 对 `quantity <= 0` 返回明确错误信息。
+```
+
+## 5. 常见注意事项
+
+1. **Docker 网络**：Open WebUI 容器默认无法访问 `127.0.0.1:8000`（这是容器自己的 localhost）。本地 Hy3 应使用 `host.docker.internal:8000` 或宿主机的局域网 IP。
+2. **模型未显示**：保存连接后点击页面顶部的模型下拉框刷新；仍未显示则检查 API URL 和 Key 是否正确。
+3. **API URL 末尾 `/v1`**：Open WebUI 的 OpenAI 连接需要完整的 `/v1` 路径。
+4. **Reasoning 显示**：Hy3 的 reasoning 输出可能包含思考标签。Open WebUI 默认会把它们渲染为普通文本。如需美化，可在系统提示词中要求模型把思考过程放在 `<think>` 标签内，并配合前端自定义渲染。
+5. **并发与配额**：团队共享时，多个用户同时请求会消耗 Hy3 后端资源。建议配置 Open WebUI 的速率限制，或为本地 vLLM/SGLang 预留足够 GPU 资源。
+6. **Function Calling**：Open WebUI 的联网搜索、RAG 等功能依赖工具调用。本地部署 Hy3 时需要开启 `--tool-call-parser` 才能正常使用。


### PR DESCRIPTION
## Summary

本 PR 针对 [Issue #2](https://github.com/Tencent-Hunyuan/Hy3/issues/2)，从终端用户视角补充 Hy3 在主流 AI 产品中的接入方式。

### Part A：主流 AI 产品接入指南（新增 5 个工具）

新增目录 `docs/integrations/`，重点覆盖现有 PR 未涉及或覆盖较少的 CLI / 自托管工具：

| 工具 | 类型 | 指南文件 |
| --- | --- | --- |
| Codex CLI | AI 工具（OpenAI 官方 CLI） | [docs/integrations/codex-cli.md](./docs/integrations/codex-cli.md) |
| Aider | AI 结对编程 CLI | [docs/integrations/aider.md](./docs/integrations/aider.md) |
| Claude Code | Anthropic 官方 AI CLI | [docs/integrations/claude-code.md](./docs/integrations/claude-code.md) |
| Continue | VS Code 插件 | [docs/integrations/continue.md](./docs/integrations/continue.md) |
| Open WebUI | 自托管大模型 Web 界面 | [docs/integrations/open-webui.md](./docs/integrations/open-webui.md) |

每个指南均包含：安装与版本要求、核心配置项（Base URL / Model / API Key / 协议选择）、端到端使用 demo、常见注意事项，并配有 SVG 示意图。

索引页：[docs/integrations/README.md](./docs/integrations/README.md) 汇总了本 PR 新增工具，并给出通用配置与使用建议。

### Part B：Hy3 小作品（独立仓库）

按照 Issue #2 要求，小作品已提交为**独立的 GitHub 仓库**：

- 仓库地址：[xy200303/hy3-vibemotion](https://github.com/xy200303/hy3-vibemotion)
- 形式：科普动画生成网站
- 功能：输入科普主题，Hy3 生成一段解说词 + 一段可在浏览器中运行的 p5.js 动画
- 使用到的 Hy3 核心能力：**推理 + 长文生成**
- 开发工具：Aider + Hy3（呼应本目录中的 Aider 接入指南）

## Verification

- [x] `python -m py_compile` 对小作品独立仓库后端代码通过
- [x] 所有 Markdown 相对链接指向真实存在的文件
- [x] `git diff --cached --check` 无空白错误
- [x] 本 PR diff 范围仅包含 `docs/integrations/`，无 `hy3-data-mcp` 等无关改动
- [x] 小作品已放入独立仓库，未混入 Hy3 主仓库

## Notes

- 本 PR 与现有 PR #19、PR #33 为**互补关系**，而非替代。PR #19 覆盖了 Cursor、Cline、Roo Code、Dify 等工具；PR #33 覆盖了 CLine、CodeBuddy IDE、ClaudeCode 等工具；本 PR 聚焦 Codex CLI、Aider、Claude Code、Continue、Open WebUI，进一步扩大 issue 的整体覆盖范围。
- 由于 Issue #2 允许多个认领者提交不同方案，本 PR 独立基于 `rhinobird2026` 分支开发。
- 真实 API 调用截图/GIF 需在获取 Hy3 测试 Key 后替换；当前使用 SVG 流程图 + 文字说明作为占位。
