### PR TITLE
Hy3 Research Assistant - 基于腾讯混元 Hy3 的论文知识管理助手

### DIFF
--- a/projects/ResForge2/README.md
+++ b/projects/ResForge2/README.md
@@ -1,0 +1,31 @@
+# Hy3 Research Assistant
+
+基于腾讯混元 Hy3 的个人深度研究助手 — 论文摄入、多源搜索、知识图谱、自动总结与引用生成。
+
+Resolves: issue#4
+
+## 仓库地址
+https://github.com/wangyue377/ResForge2
+
+## 项目简介
+面向科研场景的个人深度研究助手，围绕论文阅读、文献调研、知识管理场景设计。用户可输入论文 PDF、ArXiv ID 或搜索关键词，系统自动完成论文摄入、语义分块、向量化索引、知识图谱构建、多源文献搜索、论文总结和引用生成等完整科研工作流。
+
+## Hy3 在系统中承担的角色
+| 角色 | 模型 | 用途 |
+|------|------|------|
+| 主模型 | hy3 (TokenHub) | 论文总结、工具调用决策、搜索融合、引用生成 |
+| 嵌入模型 | kinfra-text-embedding-0.6b (TokenHub) | 论文向量化、语义检索 |
+
+全程通过 TokenHub API 调用，无本地训练/微调。
+
+## 功能
+- 论文摄入（ArXiv / 本地 PDF / 28+ 格式）
+- 多源论文搜索（ArXiv + Semantic Scholar + OpenAlex + DBLP + Web）
+- 本地三通道融合检索（向量 + 关键词 + 知识图谱）
+- Neo4j 知识图谱与方法实体关系抽取
+- 论文总结 + BibTeX + 代码查找
+- Web Chat 浏览器端交互 + Dashboard 可视化看板
+- 全部推理由 Hy3 完成
+
+## Demo 演示
+https://github.com/wangyue377/ResForge2/blob/rhinobird2026/media/demo/demo.mp4


### PR DESCRIPTION
# Hy3 Research Assistant

> 基于腾讯混元 Hy3 的个人深度研究助手 — 论文摄入、多源搜索、知识图谱、自动总结与引用生成。
> Resolves: issue#4

## 仓库地址
https://github.com/wangyue377/ResForge2

## 项目简介
面向科研场景的个人深度研究助手，围绕论文阅读、文献调研、知识管理场景设计。用户可输入论文 PDF、ArXiv ID 或搜索关键词，系统基于 Hy3 自动完成论文摄入、语义分块、向量化索引、知识图谱构建、多源文献搜索、论文总结和引用生成等完整科研工作流。

## Hy3 在系统中承担的角色
| 角色 | 模型 | 用途 |
|------|------|------|
| 主模型 | hy3 (TokenHub) | 论文总结、工具调用决策、搜索融合、引用生成 |
| 嵌入模型 | kinfra-text-embedding-0.6b (TokenHub) | 论文向量化、语义检索 |

全程通过 TokenHub API 调用，无本地训练/微调。

## 功能
- 论文摄入（ArXiv / 本地 PDF / 28+ 格式）
- 多源论文搜索（ArXiv + Semantic Scholar + OpenAlex + DBLP + Web）
- 本地三通道融合检索（向量 + 关键词 + 知识图谱）
- Neo4j 知识图谱与方法实体关系抽取
- 论文总结 + BibTeX 引用生成 + 代码仓库查找
- Web Chat 浏览器端交互界面 + Dashboard 可视化看板
- 全部推理由 Hy3 完成

## Demo 演示

### Demo 1：论文摄入 → 自动总结 → 生成引用
```
用户: 帮我把这个 PDF 导进去，顺便总结下它讲了啥：C:\path\to\sood-mcl.pdf
  → Hy3 读取本地 PDF，自动提取元数据、分块、向量化
  → 存入 PostgreSQL + 构建 Neo4j 知识图谱

用户: 给我这篇论文的引用格式，要 BibTeX 那种
  → Hy3 通过 Semantic Scholar API 获取论文信息
  → 生成 BibTeX 引用格式
```

### Demo 2：多源论文搜索 → 代码查找
```
用户: 帮我找找关于半监督目标检测的论文，联网搜一下
  → 四源并行搜索（ArXiv + Semantic Scholar + OpenAlex + DBLP）+ Web
  → Hy3 融合排序、去重
  → 返回带引用数和代码链接的结果

用户: 这篇论文有官方代码实现吗？
  → 搜索 GitHub + PapersWithCode
  → 返回论文官方代码仓库
```

### Demo 3：论文知识库 + 知识图谱问答
```
用户: 我导进去的这些论文里，哪些用了 Soft Teacher 框架？它们之间啥关系？
  → Hy3 在向量知识库里做语义检索（向量 + 关键词 + 图谱三通道 RRF 融合）
  → 再从 Neo4j 拉取方法/数据集/指标实体关系
  → 返回相关论文清单 + 关系说明

用户: 帮我把关于主动学习的工作整理一下，画个方法对比关系图
  → 知识库语义检索聚合同主题论文
  → 知识图谱抽取各方法的上下游依赖
  → 生成综述要点 + 方法演进/对比关系图
```

📺 演示视频位置：`media/demo/demo.mp4`（GitHub 网页不支持直接预览 | [B站在线播放](https://www.bilibili.com/video/BV135Nw6gEnC/)）

## 项目结构
```
ResForge2/
├── main.py                     # 主入口
├── agent/                      # Agent 核心引擎
├── research/                   # 科研子系统（摄入/搜索/图谱/检索）
├── bootstrap/                  # 应用编排与工具注册
├── static/chat/                # Web Chat 前端
├── static/dashboard/           # Dashboard 前端
├── plugins/research/           # 科研插件入口
└── docker/                     # Docker 编排（PG/Neo4j/Redis）
```