### PR TITLE
docs: add Hy3 integration guides for OpenRouter, WorkBuddy, CodeBuddy, Claude Code, Dify with SVG diagrams and knowledge-graph showcase

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,68 @@
+# Hy3 集成指南
+
+在主流 AI 产品中使用 Tencent Hy3 模型的实战配置指南。本目录面向终端用户，每个指南均包含：安装与版本要求 → 核心配置 → 第一次对话测试 → 端到端实战 Demo → 常见注意事项。
+
+## 工具清单
+
+| 类别 | 工具 | 指南 | 类型 |
+|------|------|------|------|
+| 聚合 API | [OpenRouter](./openrouter.md) | 统一 API 网关 | API 代理 |
+| AI IDE 插件 | [WorkBuddy](./workbuddy.md) | AI 辅助开发 | VS Code / JetBrains |
+| AI IDE 插件 | [CodeBuddy](./codebuddy.md) | AI 编程助手 | VS Code / JetBrains |
+| Agent CLI | [Claude Code](./claude-code.md) | AI 编程 Agent CLI | 终端 |
+| 低代码平台 | [Dify](./dify.md) | 可视化 AI 应用搭建 | Web / Docker |
+
+## 通用配置
+
+Hy3 提供 OpenAI Compatible 接口，协议统一，仅 Base URL / 模型名 / API Key 因服务商而异：
+
+| 部署模式 | Base URL | 模型名 | API Key |
+|----------|----------|--------|---------|
+| **TokenHub（国内）** | `https://tokenhub.tencentmaas.com/v1` | `hy3` | TokenHub Key |
+| **TokenHub（海外）** | `https://tokenhub-intl.tencentmaas.com/v1` | `hy3` | TokenHub Key |
+| **OpenRouter** | `https://openrouter.ai/api/v1` | `tencent/hy3` | OpenRouter Key |
+| **本地部署** | `http://127.0.0.1:8000/v1` | `hy3` | `EMPTY` |
+
+> **区域选择**：TokenHub 使用区域专属域名，必须与 API Key 创建区域一致。
+
+## 推理模式
+
+通过 `chat_template_kwargs.reasoning_effort` 控制快慢双模式：
+
+| 模式 | 值 | 说明 | 适用场景 |
+|------|-----|------|---------|
+| 直接回复 | `no_think` | 快速响应，无推理过程 | 翻译、简单问答 |
+| 轻度推理 | `low` | 平衡模式，有简短推理 | 代码生成、文档分析 |
+| 深度推理 | `high` | 完整深度思考链 | 数学证明、复杂逻辑、代码审查 |
+
+## 与其他贡献的关系
+
+社区中多位同学已贡献了不同工具的接入方案，本指南与以下 PR 为互补关系：
+
+| PR | 贡献者 | 覆盖工具 | 亮点 |
+|----|--------|----------|------|
+| [#19](https://github.com/Tencent-Hunyuan/Hy3/pull/19) | tlyssd | OpenRouter, Cursor, CodeBuddy, WorkBuddy, Cline, Roo Code, Dify | Dify 需求助手小作品 |
+| [#33](https://github.com/Tencent-Hunyuan/Hy3/pull/33) | dredgeship | CLine, CodeBuddy IDE, OpenRouter, Roo Code, ClaudeCode | 产品能力总览展示 |
+| [#37](https://github.com/Tencent-Hunyuan/Hy3/pull/37) | xy200303 | Codex CLI, Aider, Claude Code, Continue, Open WebUI | Vibemotion 科普动画小作品 |
+| 本 PR | lazypool | OpenRouter, CodeBuddy, WorkBuddy, Claude Code, Dify | 知识图谱小作品 + SVG 流程图解 |
+
+## 演示项目
+
+[Hy3 Showcase](https://github.com/lazypool/hy3-showcase) 是一个基于 Hy3 的交互式知识图谱展示应用：
+
+- **核心能力**：推理 + 工具调用 + 知识图谱构建
+- **双界面**：CLI + Web（Streamlit）
+- **Mock/真实 API 自动切换**：无需 Key 即可体验
+- **19 项自动化测试**：覆盖推理、工具调用、图谱构建等
+
+## 使用建议
+
+1. **先通后精**：第一次接入时先做最小对话测试，确认 API Key、Base URL 和模型名无误
+2. **协议选择**：优先选择 "OpenAI Compatible"、"Custom OpenAI" 等模式
+3. **Base URL**：注意工具是否自动追加 `/v1`，避免重复
+4. **模型名**：与服务商对齐（本地 `hy3` / OpenRouter `tencent/hy3` / TokenHub `hy3`）
+5. **流式输出**：大部分工具默认开启 `stream`，关闭后长回复可能超时
+6. **Troubleshooting**：
+   - 401 → 检查 API Key 和是否多写 `Bearer` 前缀
+   - 404 → 检查 Base URL 是否多/少 `/v1`
+   - 429 → 触发限流，降低并发或稍后重试

--- a/docs/integrations/assets/claude-code-flow.svg
+++ b/docs/integrations/assets/claude-code-flow.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="#f1f5f9" rx="12"/>
+  <rect x="20" y="20" width="920" height="500" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="20" y="20" width="920" height="56" rx="10" fill="url(#headerGrad)"/>
+  <rect x="20" y="66" width="920" height="10" fill="url(#headerGrad)"/>
+  <text x="40" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">Claude Code + Hy3</text>
+  <rect x="740" y="34" width="180" height="28" rx="14" fill="#22c55e"/>
+  <text x="830" y="53" text-anchor="middle" font-family="monospace" font-size="13" font-weight="600" fill="#ffffff">&#9679; Agent Ready</text>
+  <rect x="40" y="86" width="250" height="420" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="165" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#475569">Setup Flow</text>
+  <rect x="60" y="130" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="153" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">1. npm install -g @anthropic-ai/claude-code</text>
+  <polygon points="165,170 155,182 175,182" fill="#94a3b8"/>
+  <rect x="60" y="190" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">2. Set ANTHROPIC_BASE_URL</text>
+  <polygon points="165,230 155,242 175,242" fill="#94a3b8"/>
+  <rect x="60" y="250" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">3. Set ANTHROPIC_API_KEY</text>
+  <polygon points="165,290 155,302 175,302" fill="#94a3b8"/>
+  <rect x="60" y="310" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">4. Launch Interactive Mode</text>
+  <polygon points="165,350 155,362 175,362" fill="#94a3b8"/>
+  <rect x="60" y="370" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="393" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">5. Agent Auto-Programming</text>
+  <rect x="310" y="86" width="610" height="420" rx="8" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <circle cx="340" cy="108" r="6" fill="#ff5f56"/>
+  <circle cx="362" cy="108" r="6" fill="#ffbd2e"/>
+  <circle cx="384" cy="108" r="6" fill="#27c93f"/>
+  <text x="610" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">claude</text>
+  <text x="330" y="148" font-family="monospace" font-size="13" fill="#7ee787">$ claude</text>
+  <text x="330" y="172" font-family="monospace" font-size="13" fill="#58a6ff">&gt;</text>
+  <text x="346" y="172" font-family="monospace" font-size="13" fill="#e6edf3">创建一个 Flask TODO 应用，包含 SQLite 数据库</text>
+  <text x="330" y="196" font-family="monospace" font-size="13" fill="#8b949e">Claude Code is processing your request...</text>
+  <text x="330" y="220" font-family="monospace" font-size="13" fill="#e6edf3">---</text>
+  <text x="330" y="244" font-family="monospace" font-size="13" fill="#ffa657">Creating project structure...</text>
+  <text x="362" y="268" font-family="monospace" font-size="13" fill="#e6edf3">app.py</text>
+  <text x="362" y="288" font-family="monospace" font-size="13" fill="#e6edf3">models.py</text>
+  <text x="362" y="308" font-family="monospace" font-size="13" fill="#e6edf3">templates/index.html</text>
+  <text x="362" y="328" font-family="monospace" font-size="13" fill="#e6edf3">requirements.txt</text>
+  <text x="330" y="352" font-family="monospace" font-size="13" fill="#7ee787">✓ Files created successfully</text>
+  <text x="330" y="376" font-family="monospace" font-size="13" fill="#58a6ff">&gt;</text>
+  <text x="346" y="376" font-family="monospace" font-size="13" fill="#e6edf3">添加用户认证功能</text>
+  <text x="330" y="400" font-family="monospace" font-size="13" fill="#8b949e">Hy3 reasoning: high (generating auth logic...)</text>
+  <rect x="40" y="496" width="880" height="24" rx="4" fill="#f1f5f9"/>
+  <text x="165" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">https://tokenhub.tencentmaas.com/v1</text>
+  <text x="480" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">model: hy3</text>
+  <text x="780" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">auth: TokenHub API Key</text>
+</svg>

--- a/docs/integrations/assets/codebuddy-flow.svg
+++ b/docs/integrations/assets/codebuddy-flow.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="#f1f5f9" rx="12"/>
+  <rect x="20" y="20" width="920" height="500" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="20" y="20" width="920" height="56" rx="10" fill="url(#headerGrad)"/>
+  <rect x="20" y="66" width="920" height="10" fill="url(#headerGrad)"/>
+  <text x="40" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">CodeBuddy + Hy3</text>
+  <rect x="740" y="34" width="180" height="28" rx="14" fill="#22c55e"/>
+  <text x="830" y="53" text-anchor="middle" font-family="monospace" font-size="13" font-weight="600" fill="#ffffff">&#9679; IDE Ready</text>
+  <rect x="40" y="86" width="250" height="420" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="165" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#475569">Setup Flow</text>
+  <rect x="60" y="130" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="153" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">1. Install CodeBuddy Plugin</text>
+  <polygon points="165,170 155,182 175,182" fill="#94a3b8"/>
+  <rect x="60" y="190" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">2. Open Settings</text>
+  <polygon points="165,230 155,242 175,242" fill="#94a3b8"/>
+  <rect x="60" y="250" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">3. Custom OpenAI Compatible</text>
+  <polygon points="165,290 155,302 175,302" fill="#94a3b8"/>
+  <rect x="60" y="310" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">4. Generate Tests</text>
+  <polygon points="165,350 155,362 175,362" fill="#94a3b8"/>
+  <rect x="60" y="370" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="393" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">5. Explain / Refactor Code</text>
+  <rect x="310" y="86" width="610" height="420" rx="8" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <circle cx="340" cy="108" r="6" fill="#ff5f56"/>
+  <circle cx="362" cy="108" r="6" fill="#ffbd2e"/>
+  <circle cx="384" cy="108" r="6" fill="#27c93f"/>
+  <text x="610" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">VS Code - CodeBuddy Panel</text>
+  <text x="330" y="148" font-family="monospace" font-size="13" fill="#58a6ff">[CodeBuddy]</text>
+  <text x="330" y="172" font-family="monospace" font-size="13" fill="#8b949e">────────────────────────</text>
+  <text x="330" y="196" font-family="monospace" font-size="13" fill="#7ee787">&#9654; Hy3 connected</text>
+  <text x="330" y="220" font-family="monospace" font-size="13" fill="#58a6ff">&gt;</text>
+  <text x="346" y="220" font-family="monospace" font-size="13" fill="#e6edf3">为 calculator.py 生成 pytest 单元测试</text>
+  <text x="330" y="244" font-family="monospace" font-size="13" fill="#8b949e">Reading calculator.py...</text>
+  <text x="330" y="268" font-family="monospace" font-size="13" fill="#e6edf3">---</text>
+  <text x="330" y="292" font-family="monospace" font-size="13" fill="#ffa657">Generating test cases...</text>
+  <text x="362" y="316" font-family="monospace" font-size="13" fill="#e6edf3">test_calculator.py created</text>
+  <text x="362" y="336" font-family="monospace" font-size="13" fill="#7ee787">&#10003; test_add()</text>
+  <text x="362" y="356" font-family="monospace" font-size="13" fill="#7ee787">&#10003; test_divide()</text>
+  <text x="362" y="376" font-family="monospace" font-size="13" fill="#7ee787">&#10003; test_edge_cases()</text>
+  <text x="330" y="400" font-family="monospace" font-size="13" fill="#7ee787">✓ All tests generated &amp; applied</text>
+  <rect x="40" y="496" width="880" height="24" rx="4" fill="#f1f5f9"/>
+  <text x="165" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">https://tokenhub.tencentmaas.com/v1/chat/completions</text>
+  <text x="480" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">model: hy3</text>
+  <text x="780" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">auth: TokenHub API Key</text>
+</svg>

--- a/docs/integrations/assets/dify-flow.svg
+++ b/docs/integrations/assets/dify-flow.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="#f1f5f9" rx="12"/>
+  <rect x="20" y="20" width="920" height="500" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="20" y="20" width="920" height="56" rx="10" fill="url(#headerGrad)"/>
+  <rect x="20" y="66" width="920" height="10" fill="url(#headerGrad)"/>
+  <text x="40" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">Dify + Hy3</text>
+  <rect x="740" y="34" width="180" height="28" rx="14" fill="#22c55e"/>
+  <text x="830" y="53" text-anchor="middle" font-family="monospace" font-size="13" font-weight="600" fill="#ffffff">&#9679; Platform Ready</text>
+  <rect x="40" y="86" width="250" height="420" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="165" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#475569">Setup Flow</text>
+  <rect x="60" y="130" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="153" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">1. Settings → Model Provider</text>
+  <polygon points="165,170 155,182 175,182" fill="#94a3b8"/>
+  <rect x="60" y="190" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">2. Add OpenAI-API-compatible</text>
+  <polygon points="165,230 155,242 175,242" fill="#94a3b8"/>
+  <rect x="60" y="250" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">3. Config Base URL / Key</text>
+  <polygon points="165,290 155,302 175,302" fill="#94a3b8"/>
+  <rect x="60" y="310" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">4. Create Chat App</text>
+  <polygon points="165,350 155,362 175,362" fill="#94a3b8"/>
+  <rect x="60" y="370" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="393" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">5. Deploy &amp; Test</text>
+  <rect x="310" y="86" width="610" height="420" rx="8" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <circle cx="340" cy="108" r="6" fill="#ff5f56"/>
+  <circle cx="362" cy="108" r="6" fill="#ffbd2e"/>
+  <circle cx="384" cy="108" r="6" fill="#27c93f"/>
+  <text x="610" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">Dify Chat Interface</text>
+  <text x="330" y="148" font-family="monospace" font-size="13" fill="#58a6ff">[Dify - Hy3 Chat App]</text>
+  <text x="330" y="172" font-family="monospace" font-size="13" fill="#8b949e">────────────────────────</text>
+  <text x="330" y="196" font-family="monospace" font-size="13" fill="#e6edf3">System:</text>
+  <text x="346" y="196" font-family="monospace" font-size="13" fill="#8b949e">你是一个数据分析助手。当用户要求计算时，</text>
+  <text x="346" y="216" font-family="monospace" font-size="13" fill="#8b949e">使用计算器工具。</text>
+  <text x="330" y="244" font-family="monospace" font-size="13" fill="#e6edf3">User:</text>
+  <text x="346" y="244" font-family="monospace" font-size="13" fill="#e6edf3">分析这份 CSV 中第一季度和第二季度的</text>
+  <text x="346" y="264" font-family="monospace" font-size="13" fill="#e6edf3">销售趋势差异</text>
+  <text x="330" y="292" font-family="monospace" font-size="13" fill="#ffa657">Hy3:</text>
+  <text x="346" y="292" font-family="monospace" font-size="13" fill="#ffa657">&lt;think&gt;</text>
+  <text x="362" y="312" font-family="monospace" font-size="13" fill="#e6edf3">用户需要趋势分析，先读取 CSV 文件，然后</text>
+  <text x="362" y="332" font-family="monospace" font-size="13" fill="#e6edf3">计算 Q1 (Jan-Mar) 和 Q2 (Apr-Jun) 的</text>
+  <text x="362" y="352" font-family="monospace" font-size="13" fill="#e6edf3">聚合指标，使用计算器工具...</text>
+  <text x="330" y="376" font-family="monospace" font-size="13" fill="#7ee787">&#9654; Calling tool: calculator</text>
+  <text x="330" y="400" font-family="monospace" font-size="13" fill="#7ee787">✓ Analysis complete</text>
+  <rect x="40" y="496" width="880" height="24" rx="4" fill="#f1f5f9"/>
+  <text x="165" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">https://tokenhub.tencentmaas.com/v1</text>
+  <text x="480" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">model: hy3</text>
+  <text x="780" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">auth: TokenHub API Key</text>
+</svg>

--- a/docs/integrations/assets/openrouter-flow.svg
+++ b/docs/integrations/assets/openrouter-flow.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+    <linearGradient id="accentBar" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="#f1f5f9" rx="12"/>
+  <rect x="20" y="20" width="920" height="500" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="20" y="20" width="920" height="56" rx="10" fill="url(#headerGrad)"/>
+  <rect x="20" y="66" width="920" height="10" fill="url(#headerGrad)"/>
+  <text x="40" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">OpenRouter + Hy3</text>
+  <rect x="740" y="34" width="180" height="28" rx="14" fill="#22c55e"/>
+  <text x="830" y="53" text-anchor="middle" font-family="monospace" font-size="13" font-weight="600" fill="#ffffff">&#9679; Online</text>
+  <rect x="40" y="86" width="250" height="420" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="165" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#475569">Setup Flow</text>
+  <rect x="60" y="130" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="153" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">1. Register at OpenRouter</text>
+  <polygon points="165,170 155,182 175,182" fill="#94a3b8"/>
+  <rect x="60" y="190" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">2. Create API Key</text>
+  <polygon points="165,230 155,242 175,242" fill="#94a3b8"/>
+  <rect x="60" y="250" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">3. Select tencent/hy3</text>
+  <polygon points="165,290 155,302 175,302" fill="#94a3b8"/>
+  <rect x="60" y="310" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">4. Configure Reasoning</text>
+  <polygon points="165,350 155,362 175,362" fill="#94a3b8"/>
+  <rect x="60" y="370" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="393" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">5. Call API</text>
+  <rect x="310" y="86" width="610" height="420" rx="8" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <circle cx="340" cy="108" r="6" fill="#ff5f56"/>
+  <circle cx="362" cy="108" r="6" fill="#ffbd2e"/>
+  <circle cx="384" cy="108" r="6" fill="#27c93f"/>
+  <text x="610" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">Terminal</text>
+  <text x="330" y="148" font-family="monospace" font-size="13" fill="#58a6ff">$</text>
+  <text x="346" y="148" font-family="monospace" font-size="13" fill="#e6edf3">curl -X POST https://openrouter.ai/api/v1/chat/completions \</text>
+  <text x="330" y="172" font-family="monospace" font-size="13" fill="#e6edf3">  -H "Authorization: Bearer $OPENROUTER_API_KEY" \</text>
+  <text x="330" y="196" font-family="monospace" font-size="13" fill="#e6edf3">  -d '{"model":"tencent/hy3","messages":</text>
+  <text x="330" y="220" font-family="monospace" font-size="13" fill="#e6edf3">        [{"role":"user","content":"24点：3,3,8,8"}]}'</text>
+  <text x="330" y="250" font-family="monospace" font-size="13" fill="#7ee787">✓ 200 OK</text>
+  <text x="330" y="274" font-family="monospace" font-size="13" fill="#e6edf3">{</text>
+  <text x="346" y="294" font-family="monospace" font-size="13" fill="#e6edf3">"choices":[{"message":{</text>
+  <text x="362" y="314" font-family="monospace" font-size="13" fill="#e6edf3">"reasoning":"8÷(3-8÷3)=24</text>
+  <text x="362" y="334" font-family="monospace" font-size="13" fill="#ffa657">&lt;think&gt;...</text>
+  <text x="330" y="358" font-family="monospace" font-size="13" fill="#e6edf3">}},</text>
+  <text x="330" y="378" font-family="monospace" font-size="13" fill="#e6edf3">"usage":{"total_tokens":312}}</text>
+  <rect x="40" y="496" width="880" height="24" rx="4" fill="#f1f5f9"/>
+  <text x="165" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">https://openrouter.ai/api/v1</text>
+  <text x="480" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">model: tencent/hy3</text>
+  <text x="780" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">auth: OpenRouter API Key</text>
+</svg>

--- a/docs/integrations/assets/workbuddy-flow.svg
+++ b/docs/integrations/assets/workbuddy-flow.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="#f1f5f9" rx="12"/>
+  <rect x="20" y="20" width="920" height="500" rx="10" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="20" y="20" width="920" height="56" rx="10" fill="url(#headerGrad)"/>
+  <rect x="20" y="66" width="920" height="10" fill="url(#headerGrad)"/>
+  <text x="40" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">WorkBuddy + Hy3</text>
+  <rect x="740" y="34" width="180" height="28" rx="14" fill="#22c55e"/>
+  <text x="830" y="53" text-anchor="middle" font-family="monospace" font-size="13" font-weight="600" fill="#ffffff">&#9679; IDE Ready</text>
+  <rect x="40" y="86" width="250" height="420" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="165" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#475569">Setup Flow</text>
+  <rect x="60" y="130" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="153" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">1. Install WorkBuddy Plugin</text>
+  <polygon points="165,170 155,182 175,182" fill="#94a3b8"/>
+  <rect x="60" y="190" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">2. Open Model Config</text>
+  <polygon points="165,230 155,242 175,242" fill="#94a3b8"/>
+  <rect x="60" y="250" width="210" height="36" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="165" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">3. OpenAI Compatible</text>
+  <polygon points="165,290 155,302 175,302" fill="#94a3b8"/>
+  <rect x="60" y="310" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">4. Code Generation</text>
+  <polygon points="165,350 155,362 175,362" fill="#94a3b8"/>
+  <rect x="60" y="370" width="210" height="36" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="165" y="393" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#166534">5. Review &amp; Refactor</text>
+  <rect x="310" y="86" width="610" height="420" rx="8" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <circle cx="340" cy="108" r="6" fill="#ff5f56"/>
+  <circle cx="362" cy="108" r="6" fill="#ffbd2e"/>
+  <circle cx="384" cy="108" r="6" fill="#27c93f"/>
+  <text x="610" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">WorkBuddy Chat</text>
+  <text x="330" y="148" font-family="monospace" font-size="13" fill="#58a6ff">[WorkBuddy]</text>
+  <text x="330" y="172" font-family="monospace" font-size="13" fill="#8b949e">────────────────────────</text>
+  <text x="330" y="196" font-family="monospace" font-size="13" fill="#7ee787">&#9654; Hy3 model connected</text>
+  <text x="330" y="220" font-family="monospace" font-size="13" fill="#58a6ff">&gt;</text>
+  <text x="346" y="220" font-family="monospace" font-size="13" fill="#e6edf3">生成 Flask RESTful API，包含 CRUD 和 SQLite</text>
+  <text x="330" y="244" font-family="monospace" font-size="13" fill="#8b949e">Processing with Hy3 (reasoning: low)...</text>
+  <text x="330" y="268" font-family="monospace" font-size="13" fill="#e6edf3">---</text>
+  <text x="330" y="292" font-family="monospace" font-size="13" fill="#ffa657">from flask import Flask, request, jsonify</text>
+  <text x="362" y="316" font-family="monospace" font-size="13" fill="#e6edf3">app = Flask(__name__)</text>
+  <text x="362" y="336" font-family="monospace" font-size="13" fill="#e6edf3">@app.route('/api/items', methods=['GET'])</text>
+  <text x="362" y="356" font-family="monospace" font-size="13" fill="#e6edf3">def list_items():</text>
+  <text x="378" y="376" font-family="monospace" font-size="13" fill="#e6edf3">return jsonify(Item.query.all())</text>
+  <text x="330" y="400" font-family="monospace" font-size="13" fill="#7ee787">✓ Code generated. Apply? [Y/n]</text>
+  <rect x="40" y="496" width="880" height="24" rx="4" fill="#f1f5f9"/>
+  <text x="165" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">https://tokenhub.tencentmaas.com/v1</text>
+  <text x="480" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">model: hy3</text>
+  <text x="780" y="512" text-anchor="middle" font-family="monospace" font-size="11" fill="#64748b">auth: TokenHub API Key</text>
+</svg>

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,119 @@
+# Claude Code 集成指南
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 是 Anthropic 官方的 AI 编程 CLI 工具。通过环境变量覆盖可切换后端为 Hy3，实现 Agent 自动编程。
+
+## 安装与版本要求
+
+- **Node.js**：≥ 18
+- **Claude Code**：通过 npm 全局安装
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+- **Git**：Claude Code 依赖 Git 跟踪代码改动
+- **网络**：能访问 TokenHub 或 OpenRouter
+
+验证安装：
+
+```bash
+claude --version
+```
+
+## 核心配置
+
+通过环境变量指定 Hy3 作为后端：
+
+```bash
+export ANTHROPIC_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+export ANTHROPIC_API_KEY="your-tokenhub-key"
+```
+
+| 配置项 | 说明 |
+|--------|------|
+| `ANTHROPIC_BASE_URL` | Hy3 API 端点（OpenAI 兼容） |
+| `ANTHROPIC_API_KEY` | 对应服务商的 API Key |
+
+### 各部署模式配置
+
+| 模式 | Base URL | 推荐场景 |
+|------|----------|----------|
+| TokenHub（国内） | `https://tokenhub.tencentmaas.com/v1` | 国内用户首选 |
+| TokenHub（海外） | `https://tokenhub-intl.tencentmaas.com/v1` | 海外用户 |
+| OpenRouter | `https://openrouter.ai/api/v1` | 已有 OpenRouter 账号 |
+| 本地 vLLM/SGLang | `http://127.0.0.1:8000/v1` | 本地部署开发测试 |
+
+### 项目级配置（推荐）
+
+在项目根目录创建 `.env`：
+
+```
+ANTHROPIC_BASE_URL=https://tokenhub.tencentmaas.com/v1
+ANTHROPIC_API_KEY=sk-xxx
+```
+
+> Claude Code 默认使用 Anthropic 消息格式。设置 `ANTHROPIC_BASE_URL` 指向 OpenAI 兼容端点后，CLI 会自动适配协议。
+
+## 第一次对话测试
+
+```bash
+claude -p "用 Python 写一个快速排序，并输出数字 1"
+```
+
+**预期结果**：终端显示 Hy3 生成的快速排序代码和数字 1。
+
+![Claude Code + Hy3 示意图](./assets/claude-code-flow.svg)
+
+## 端到端实战 Demo：创建 Flask TODO 应用
+
+### 场景
+
+在交互模式下，让 Hy3 基于 Agent 能力自动创建一个完整的 Web 应用。
+
+### 操作步骤
+
+1. 进入空目录：
+```bash
+mkdir hy3-todo-demo && cd hy3-todo-demo
+git init
+```
+
+2. 启动 Claude Code：
+```bash
+claude
+```
+
+3. 输入 Prompt：
+```
+创建一个 Flask TODO 应用，包含 SQLite 数据库，支持添加/删除/标记完成。需要前端界面。
+```
+
+4. 观察 Claude Code 自动：
+   - 创建 `app.py`、`models.py`、`templates/` 等文件
+   - 安装依赖
+   - 输出完整项目结构
+
+5. 运行验证：
+```bash
+python app.py
+```
+
+### 预期输出
+
+```
+Creating project structure...
+  ✓ app.py
+  ✓ models.py
+  ✓ templates/index.html
+  ✓ requirements.txt
+✓ Files created successfully
+```
+
+## 常见注意事项
+
+1. **权限确认**：首次运行需确认执行命令和读写文件的权限
+2. **工具调用**：本地部署需要 `--tool-call-parser hy_v3` 开启工具解析
+3. **Reasoning 模式**：可通过交互模式的 `/thinking` 命令切换
+4. **多模态限制**：Hy3 当前为文本模型，避免发送图片内容
+5. **超时设置**：如后端响应慢，可加大超时：`export ANTHROPIC_TIMEOUT_MS=120000`
+6. **独立项目**：Claude Code 会主动读写文件，建议在独立项目目录中使用

--- a/docs/integrations/codebuddy.md
+++ b/docs/integrations/codebuddy.md
@@ -1,0 +1,85 @@
+# CodeBuddy 集成指南
+
+[CodeBuddy](https://codebuddy.ai) 是一款 AI 编程助手，支持 VS Code 和 JetBrains IDE 插件。本文档覆盖 **IDE 插件版**（区别于 CLI 版）。
+
+## 安装与版本要求
+
+- **VS Code** 1.85+ 或 **JetBrains IDE** 2023.2+
+- **CodeBuddy 插件** 2.0+
+
+安装方式：
+- **VS Code**：扩展市场搜索 "CodeBuddy" 安装
+- **JetBrains**：`File → Settings → Plugins` → 搜索 "CodeBuddy"
+
+## 核心配置
+
+### 1. 打开设置
+
+右键点击状态栏 CodeBuddy 图标 → **Settings**。
+
+### 2. 添加自定义提供商
+
+| 字段 | 值 |
+|------|-----|
+| Provider | Custom OpenAI Compatible |
+| API URL | `https://tokenhub.tencentmaas.com/v1/chat/completions` |
+| API Key | `sk-xxx`（从 TokenHub 获取） |
+| Model | `hy3` |
+
+### 各部署模式配置
+
+| 模式 | API URL | 模型名 | 延迟 |
+|------|---------|--------|------|
+| TokenHub（国内推荐） | `https://tokenhub.tencentmaas.com/v1/chat/completions` | `hy3` | 低 |
+| TokenHub（海外） | `https://tokenhub-intl.tencentmaas.com/v1/chat/completions` | `hy3` | 低 |
+| OpenRouter | `https://openrouter.ai/api/v1/chat/completions` | `tencent/hy3` | 中等 |
+| 本地 vLLM/SGLang | `http://127.0.0.1:8000/v1/chat/completions` | `hy3` | 最低 |
+
+## 第一次对话测试
+
+选中任意代码片段，右键 → **CodeBuddy → Explain Code**。
+
+或打开 CodeBuddy 聊天面板，输入：
+
+```
+Hello? 用一句话介绍 Hy3
+```
+
+**预期结果**：CodeBuddy 面板显示 Hy3 的回复内容。
+
+![CodeBuddy + Hy3 示意图](./assets/codebuddy-flow.svg)
+
+## 端到端实战 Demo：生成单元测试
+
+### 场景
+
+为一个 `calculator.py` 文件自动生成 pytest 单元测试，覆盖所有公开函数和边界情况。
+
+### 操作步骤
+
+1. 在 IDE 中打开包含 `calculator.py` 的项目
+2. 选中 `calculator.py` 文件
+3. 右键 → **CodeBuddy → Generate Tests**
+4. 或直接在聊天面板输入：
+```
+为 calculator.py 编写 pytest 单元测试，覆盖所有公开函数（add, subtract, multiply, divide），包含边界情况如除以零。
+```
+
+### 预期输出
+
+CodeBuddy 会自动生成 `test_calculator.py` 文件，包含：
+
+```
+✓ test_add()
+✓ test_divide()
+✓ test_divide_by_zero()
+✓ test_edge_cases()
+```
+
+## 常见注意事项
+
+1. **API URL 格式**：必须包含完整路径 `/v1/chat/completions`（不是 Base URL）
+2. **IDE 区别**：CodeBuddy 在 VS Code 和 JetBrains 中的配置路径略有不同
+3. **深度集成限制**：自定义模式下部分 IDE 深度集成功能（实时诊断、内联建议）可能受限
+4. **Reasoning 配置**：需要在请求中通过 `extra_body` 传递 `chat_template_kwargs`；CodeBuddy 自定义提供商可能不支持此参数，建议使用默认模式
+5. **网络要求**：自部署或使用国内 TokenHub 时需确保 IDE 能访问对应端点

--- a/docs/integrations/dify.md
+++ b/docs/integrations/dify.md
@@ -1,0 +1,101 @@
+# Dify 集成指南
+
+[Dify](https://dify.ai) 是一个开源低代码 LLM 应用开发平台，支持可视化搭建聊天机器人、Agent 和工作流。通过配置 OpenAI 兼容接口即可接入 Hy3。
+
+## 安装与版本要求
+
+- **Dify**：开源版 0.6+ 或 Dify Cloud 账号
+- **部署方式**：Docker 自部署或使用 [Dify Cloud](https://cloud.dify.ai)
+- **网络**：Dify 服务器能访问 TokenHub/OpenRouter 端点
+
+## 核心配置
+
+### 1. 添加 Hy3 模型
+
+管理后台 → **Settings → Model Provider** → **Add Model** → 选择 **OpenAI-API-compatible**：
+
+| 字段 | 值 |
+|------|-----|
+| Model Name | `hy3` |
+| Base URL | `https://tokenhub.tencentmaas.com/v1` |
+| API Key | `sk-xxx`（从 TokenHub 获取） |
+| Type | `LLM` |
+
+### 2. 创建应用
+
+1. **Create Application** → 选择 "Chat App" 或 "Agent"
+2. 在模型选择中选 `hy3`
+
+### 各部署模式配置
+
+| 模式 | Base URL | 模型名 | 适用场景 |
+|------|----------|--------|----------|
+| TokenHub（国内推荐） | `https://tokenhub.tencentmaas.com/v1` | `hy3` | 国内 Dify 部署 |
+| TokenHub（海外） | `https://tokenhub-intl.tencentmaas.com/v1` | `hy3` | 海外 Dify 部署 |
+| OpenRouter | `https://openrouter.ai/api/v1` | `tencent/hy3` | 已有 OpenRouter 账号 |
+| 本地 vLLM/SGLang | `http://127.0.0.1:8000/v1` | `hy3` | 本地开发测试 |
+
+## 第一次对话测试
+
+创建应用后，在预览界面发送消息：
+
+```
+你好！请用一句话介绍 Hy3，并输出数字 1
+```
+
+**预期结果**：Dify 返回 Hy3 的回复内容。
+
+![Dify + Hy3 示意图](./assets/dify-flow.svg)
+
+## 端到端实战 Demo：数据分析 Agent
+
+### 场景
+
+构建一个 Agent 应用，用户上传 CSV 文件后，Hy3 自动分析数据并生成报告。
+
+### 操作步骤
+
+1. 创建 **Agent** 类型应用
+2. 选择 `hy3` 模型
+3. 开启 **Function Calling**
+4. 添加计算器工具
+5. 设置系统 Prompt：
+```
+你是一个数据分析助手。当用户要求计算时，使用计算器工具进行分析。
+当用户上传文件时，读取文件内容给出结构化分析报告。
+```
+6. 上传一个示例 CSV，输入：
+```
+分析这份 CSV 中第一季度和第二季度的销售趋势差异
+```
+
+### 预期行为
+
+- Hy3 通过工具调用读取 CSV
+- 分析 Q1（Jan-Mar）和 Q2（Apr-Jun）的聚合指标
+- 输出结构化报告
+
+## 推理模式配置
+
+在 LLM 节点的 **参数重写** 中填入：
+
+| 参数路径 | 值 |
+|----------|-----|
+| `chat_template_kwargs.reasoning_effort` | `high` |
+
+### 各模式推荐场景
+
+| 模式 | Dify 配置值 | 推荐场景 |
+|------|------------|---------|
+| 直接回复 | `no_think` | 客服问答、翻译 |
+| 轻度推理 | `low` | 代码辅助、文档总结 |
+| 深度推理 | `high` | 数据分析、复杂推理 |
+
+## 常见注意事项
+
+1. **Base URL 格式**：Dify 的 OpenAI 兼容接口要求 Base URL 以 `/v1` 结尾
+2. **函数调用**：Hy3 支持 Function Calling，简单工具调用已验证可用
+3. **知识库**：知识库检索质量取决于 Embedding 模型，建议配合专用 Embedding 模型使用
+4. **区域匹配**：TokenHub 区域域名必须与 API Key 创建区域一致，广州 Key 不能用新加坡端点
+5. **网络连通**：自部署 Dify 需确保网络能访问 TokenHub/OpenRouter 端点
+6. **Dify Cloud**：使用 Dify Cloud 时推荐用 OpenRouter（公网可达），TokenHub 可能受地域限制

--- a/docs/integrations/openrouter.md
+++ b/docs/integrations/openrouter.md
@@ -1,0 +1,107 @@
+# OpenRouter 集成指南
+
+[OpenRouter](https://openrouter.ai) 是一个统一的 LLM API 网关，提供多种模型的访问入口。通过 OpenRouter 可使用 Hy3 而无需本地部署。
+
+## 安装与版本要求
+
+- **无额外安装**：通过 HTTP API 调用，任何语言/工具均可
+- **网络**：能访问 `https://openrouter.ai`
+- **账号**：注册 OpenRouter 并创建 API Key
+
+## 核心配置
+
+| 配置项 | 值 |
+|--------|-----|
+| Base URL | `https://openrouter.ai/api/v1` |
+| 模型 ID | `tencent/hy3` |
+| 协议 | OpenAI Compatible |
+| API Key | OpenRouter Key（格式 `sk-or-xxx`） |
+
+环境变量推荐：
+
+```bash
+export OPENROUTER_API_KEY="sk-or-xxx"
+export HY3_BASE_URL="https://openrouter.ai/api/v1"
+export HY3_MODEL="tencent/hy3"
+```
+
+### 各部署模式对比
+
+| 模式 | Base URL | 模型名 | API Key | 延迟 |
+|------|----------|--------|---------|------|
+| OpenRouter | `https://openrouter.ai/api/v1` | `tencent/hy3` | OpenRouter Key | 中等（经网关转发）|
+| TokenHub（国内推荐） | `https://tokenhub.tencentmaas.com/v1` | `hy3` | TokenHub Key | 低（直连腾讯）|
+| TokenHub（海外） | `https://tokenhub-intl.tencentmaas.com/v1` | `hy3` | TokenHub Key | 低（新加坡节点）|
+| 本地 vLLM/SGLang | `http://127.0.0.1:8000/v1` | `hy3` | `EMPTY` | 最低（本地）|
+
+## 第一次对话测试
+
+使用 curl 测试连通性：
+
+```bash
+curl https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tencent/hy3",
+    "messages": [{"role":"user","content":"用一句话介绍 Hy3，并输出数字 1"}]
+  }'
+```
+
+**预期结果**：返回 200 OK，包含 Hy3 的回复内容。
+
+![OpenRouter + Hy3 示意图](./assets/openrouter-flow.svg)
+
+## 端到端实战 Demo：24 点游戏求解
+
+### 场景
+
+用户给出 4 个数字（如 3, 3, 8, 8），Hy3 通过深度推理计算 24 点。
+
+### Python 示例
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://openrouter.ai/api/v1",
+    api_key="sk-or-xxx",
+)
+
+response = client.chat.completions.create(
+    model="tencent/hy3",
+    messages=[{"role": "user", "content": "24点：3,3,8,8"}],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+
+print(response.choices[0].message.content)
+```
+
+### 预期输出
+
+Hy3 会输出包含 `8 ÷ (3 - 8 ÷ 3) = 24` 的推理过程和最终答案。
+
+### 验证步骤
+
+1. 保存上述代码为 `test_hy3.py`
+2. 替换 `api_key` 为你的 Key
+3. 运行 `python test_hy3.py`
+4. 看到包含 `24` 的结果即成功
+
+## 推理模式配置
+
+通过 `chat_template_kwargs.reasoning_effort` 控制：
+
+| 模式 | 值 | 适用场景 |
+|------|-----|---------|
+| 直接回复 | `no_think` | 简单问答、翻译 |
+| 轻度推理 | `low` | 代码生成、分析 |
+| 深度推理 | `high` | 数学、复杂逻辑 |
+
+## 常见注意事项
+
+1. **费用**：OpenRouter 收取约 10-20% 服务费，直接使用 TokenHub 更省
+2. **速率限制**：免费用户 20 RPM，付费用户更高
+3. **流式输出**：默认启用 `stream: true`，建议保持
+4. **Base URL**：不要重复写 `/v1`（OpenRouter 已包含）
+5. **模型名**：必须用 `tencent/hy3`（含提供商前缀）

--- a/docs/integrations/workbuddy.md
+++ b/docs/integrations/workbuddy.md
@@ -1,0 +1,95 @@
+# WorkBuddy 集成指南
+
+[WorkBuddy](https://workbuddy.ai) 是一款面向开发者的 AI 辅助工具，支持代码生成、审查、重构和文档编写，可作为 IDE 插件使用。
+
+## 安装与版本要求
+
+- **VS Code** 1.85+ 或 **JetBrains IDE** 2023.2+
+- **WorkBuddy 插件** 1.5+
+
+安装方式：
+- **VS Code**：扩展市场搜索 "WorkBuddy" 安装
+- **JetBrains**：`File → Settings → Plugins` → 搜索 "WorkBuddy"
+
+## 核心配置
+
+### 1. 打开模型配置
+
+WorkBuddy 设置 → **模型配置**。
+
+### 2. 添加自定义模型
+
+| 字段 | 值 |
+|------|-----|
+| Provider | OpenAI Compatible |
+| Base URL | `https://tokenhub.tencentmaas.com/v1` |
+| API Key | `sk-xxx`（从 TokenHub 获取） |
+| Model | `hy3` |
+
+### 各部署模式配置
+
+| 模式 | Base URL | 模型名 | 推荐场景 |
+|------|----------|--------|----------|
+| TokenHub（国内推荐） | `https://tokenhub.tencentmaas.com/v1` | `hy3` | 国内用户首选 |
+| TokenHub（海外） | `https://tokenhub-intl.tencentmaas.com/v1` | `hy3` | 海外用户 |
+| OpenRouter | `https://openrouter.ai/api/v1` | `tencent/hy3` | 已有 OpenRouter |
+| 本地 vLLM/SGLang | `http://127.0.0.1:8000/v1` | `hy3` | 本地测试 |
+
+## 第一次对话测试
+
+在 WorkBuddy 聊天窗口输入：
+
+```
+你好，用 Python 写一个二分查找，并输出数字 1
+```
+
+**预期结果**：WorkBuddy 显示 Hy3 生成的二分查找代码和数字 1。
+
+![WorkBuddy + Hy3 示意图](./assets/workbuddy-flow.svg)
+
+## 端到端实战 Demo：生成 Flask RESTful API
+
+### 场景
+
+使用 WorkBuddy 的代码生成能力，让 Hy3 创建一个完整的 RESTful API 项目。
+
+### 操作步骤
+
+1. 在 IDE 中新建文件 `app.py`
+2. 打开 WorkBuddy 聊天面板
+3. 输入以下 Prompt：
+```
+生成一个 Flask RESTful API，包含 CRUD 操作和 SQLite 数据库，需要以下端点：
+- GET /api/items - 列出所有项目
+- POST /api/items - 创建新项目
+- PUT /api/items/<id> - 更新项目
+- DELETE /api/items/<id> - 删除项目
+```
+
+### 预期输出
+
+WorkBuddy 会生成完整的 Flask 应用代码，可以直接保存和运行：
+
+```python
+from flask import Flask, request, jsonify
+app = Flask(__name__)
+# ... CRUD operations ...
+```
+
+### 验证
+
+在聊天窗口中继续输入：
+
+```
+审查上面生成的代码，指出潜在的安全问题
+```
+
+Hy3 会分析代码并给出安全建议（如 SQL 注入防护、输入验证等）。
+
+## 常见注意事项
+
+1. **Base URL 格式**：必须以 `/v1` 结尾（不要加 `/chat/completions`）
+2. **区域匹配**：TokenHub 区域域名必须与 API Key 创建区域一致
+3. **高级功能限制**：自定义模型模式下部分高级功能（代码库索引、语义搜索）可能受限
+4. **流式输出**：WorkBuddy 默认开启流式输出，建议保持
+5. **Reasoning 配置**：如需深度推理，在 WorkBuddy 的高级设置中通过 `extra_body` 传递 `chat_template_kwargs.reasoning_effort`


### PR DESCRIPTION
## Summary

Add Hy3 integration index under `docs/integrations/` with 5 tool guides, SVG flow diagrams, and cross-reference to complementary PRs.

## Integration Guides (5 tools)

| Tool | Category | Highlights |
|------|----------|------------|
| **OpenRouter** | API Gateway | 24-point game reasoning demo, curl + Python |
| **WorkBuddy** | IDE Plugin (VS Code/JetBrains) | Flask RESTful API generation, code review |
| **CodeBuddy** | IDE Plugin (VS Code/JetBrains) | Unit test generation with pytest |
| **Claude Code** | Agent CLI | Flask TODO app auto-creation agent demo |
| **Dify** | Low-code Platform | Data analysis agent with tool calling |

Each guide covers: installation → config (3 deployment modes: local/OpenRouter/TokenHub) → first test → end-to-end demo → common notes.

## SVG Diagrams

Redesigned 960×540 hybrid layout (flowchart sidebar + terminal mockup), distinct from existing PRs.

## Showcase

[**hy3-showcase**](https://github.com/lazypool/hy3-showcase) — interactive knowledge-graph demo app powered by Hy3:
- CLI + Web (Streamlit) dual interface
- Mock/real API auto-switch
- 19 automated tests (reasoning, tool calling, graph construction)

## Relationship to other PRs

This PR is complementary to [#19](https://github.com/Tencent-Hunyuan/Hy3/pull/19) (tlyssd), [#33](https://github.com/Tencent-Hunyuan/Hy3/pull/33) (dredgeship), and [#37](https://github.com/Tencent-Hunyuan/Hy3/pull/37) (xy200303). The README includes a full cross-reference table.