### PR TITLE
docs: add Hy3 API quickstart guide and 6 runnable examples

### DIFF
--- a/examples/01_basic_chat.md
+++ b/examples/01_basic_chat.md
@@ -1,0 +1,215 @@
+# 01 基础对话 / Basic Chat
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例展示如何使用 Hy3 API 进行基础对话，包括**单轮对话**和**多轮对话**。
+
+### 单轮对话
+
+最简单的场景：发送一条消息，获取模型回复。
+
+#### 请求
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "用一句话解释什么是大语言模型。"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+)
+```
+
+#### 响应解析
+
+```python
+# 获取回复内容
+content = response.choices[0].message.content
+print(content)
+
+# 获取使用统计
+print(f"Prompt tokens: {response.usage.prompt_tokens}")
+print(f"Completion tokens: {response.usage.completion_tokens}")
+print(f"Total tokens: {response.usage.total_tokens}")
+
+# 获取结束原因
+print(f"Finish reason: {response.choices[0].finish_reason}")  # "stop" 表示正常结束
+```
+
+#### 示例输出
+
+```
+大语言模型（LLM）是基于 Transformer 架构、在海量文本上训练的深度学习模型，能够理解和生成自然语言，执行问答、翻译、写作、编程等多种任务。
+
+Prompt tokens: 28
+Completion tokens: 65
+Total tokens: 93
+Finish reason: stop
+```
+
+---
+
+### 多轮对话
+
+将历史对话消息传入 `messages` 列表，模型会基于上下文进行回复。
+
+#### 请求
+
+```python
+messages = [
+    {"role": "system", "content": "你是一位友好的Python编程助手。"},
+    {"role": "user", "content": "Python的列表和元组有什么区别？"},
+]
+
+# 第一轮
+response1 = client.chat.completions.create(
+    model="hy3",
+    messages=messages,
+    temperature=0.9,
+    top_p=1.0,
+)
+
+# 将助手回复加入历史
+messages.append({"role": "assistant", "content": response1.choices[0].message.content})
+
+# 第二轮：基于上下文追问
+messages.append({"role": "user", "content": "那在什么场景下应该优先使用元组？"})
+
+response2 = client.chat.completions.create(
+    model="hy3",
+    messages=messages,
+    temperature=0.9,
+    top_p=1.0,
+)
+print(response2.choices[0].message.content)
+```
+
+#### 响应解析
+
+多轮对话的响应格式与单轮完全一致，关键在于维护 `messages` 列表：
+
+```python
+# 每次请求后，将助手回复追加到 messages
+messages.append({
+    "role": "assistant",
+    "content": response.choices[0].message.content,
+})
+
+# 每次请求前，追加新的用户消息
+messages.append({
+    "role": "user",
+    "content": "新的问题...",
+})
+```
+
+#### 示例输出
+
+```
+在以下场景中建议优先使用元组：
+1. 数据不应被修改时（如配置项、数据库记录）——元组的不可变性提供安全保障
+2. 作为字典的 key——只有可哈希的不可变类型才能作为字典键
+3. 函数返回多个值时——`return x, y` 自动返回元组
+4. 性能敏感场景——元组的内存占用略低于列表，创建速度更快
+```
+
+---
+
+## English
+
+This example shows how to use the Hy3 API for basic chat, including **single-turn** and **multi-turn** conversations.
+
+### Single-Turn Chat
+
+The simplest case: send one message and get a response.
+
+#### Request
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "Explain what a large language model is in one sentence."},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+)
+```
+
+#### Response Parsing
+
+```python
+content = response.choices[0].message.content
+print(content)
+
+print(f"Prompt tokens: {response.usage.prompt_tokens}")
+print(f"Completion tokens: {response.usage.completion_tokens}")
+print(f"Total tokens: {response.usage.total_tokens}")
+print(f"Finish reason: {response.choices[0].finish_reason}")  # "stop" = completed normally
+```
+
+#### Example Output
+
+```
+A large language model (LLM) is a deep learning model based on the Transformer architecture,
+trained on massive text corpora, capable of understanding and generating natural language to
+perform tasks like Q&A, translation, writing, and coding.
+
+Prompt tokens: 26
+Completion tokens: 58
+Total tokens: 84
+Finish reason: stop
+```
+
+---
+
+### Multi-Turn Chat
+
+Pass the conversation history in the `messages` list to maintain context.
+
+#### Request
+
+```python
+messages = [
+    {"role": "system", "content": "You are a friendly Python programming assistant."},
+    {"role": "user", "content": "What's the difference between lists and tuples in Python?"},
+]
+
+# First turn
+response1 = client.chat.completions.create(
+    model="hy3", messages=messages, temperature=0.9, top_p=1.0,
+)
+
+# Append assistant reply to history
+messages.append({"role": "assistant", "content": response1.choices[0].message.content})
+
+# Second turn: follow-up question
+messages.append({"role": "user", "content": "When should I prefer tuples over lists?"})
+
+response2 = client.chat.completions.create(
+    model="hy3", messages=messages, temperature=0.9, top_p=1.0,
+)
+print(response2.choices[0].message.content)
+```
+
+#### Example Output
+
+```
+Prefer tuples in these scenarios:
+1. When data should not be modified (e.g., config items, DB records) — immutability provides safety
+2. As dictionary keys — only hashable immutable types can be dict keys
+3. Returning multiple values from functions — `return x, y` automatically returns a tuple
+4. Performance-sensitive code — tuples use slightly less memory and are faster to create
+```

--- a/examples/01_basic_chat.py
+++ b/examples/01_basic_chat.py
@@ -1,0 +1,125 @@
+"""
+Hy3 API - 基础对话示例 / Basic Chat Example
+包含单轮对话和多轮对话
+"""
+
+from openai import OpenAI
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"  # 自部署无需真实密钥
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+# ============================================================
+# 示例 1：单轮对话 / Single-Turn Chat
+# ============================================================
+def single_turn_chat():
+    """发送单条消息并获取回复"""
+    print("=" * 60)
+    print("单轮对话 / Single-Turn Chat")
+    print("=" * 60)
+
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "user", "content": "用一句话解释什么是大语言模型。"},
+        ],
+        temperature=0.9,
+        top_p=1.0,
+    )
+
+    # 解析响应
+    content = response.choices[0].message.content
+    finish_reason = response.choices[0].finish_reason
+    usage = response.usage
+
+    print(f"\n回复：{content}")
+    print(f"\n结束原因：{finish_reason}")
+    print(f"Token 用量：prompt={usage.prompt_tokens}, "
+          f"completion={usage.completion_tokens}, total={usage.total_tokens}")
+
+
+# ============================================================
+# 示例 2：多轮对话 / Multi-Turn Chat
+# ============================================================
+def multi_turn_chat():
+    """维护对话历史，进行多轮交互"""
+    print("\n" + "=" * 60)
+    print("多轮对话 / Multi-Turn Chat")
+    print("=" * 60)
+
+    # 初始化消息历史（可包含 system 提示词）
+    messages = [
+        {"role": "system", "content": "你是一位友好的Python编程助手。"},
+    ]
+
+    # 第一轮提问
+    user_msg_1 = "Python的列表和元组有什么区别？"
+    messages.append({"role": "user", "content": user_msg_1})
+    print(f"\n用户：{user_msg_1}")
+
+    response1 = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0.9,
+        top_p=1.0,
+    )
+    assistant_reply_1 = response1.choices[0].message.content
+    print(f"助手：{assistant_reply_1}")
+
+    # 将助手回复追加到历史
+    messages.append({"role": "assistant", "content": assistant_reply_1})
+
+    # 第二轮追问（基于上下文）
+    user_msg_2 = "那在什么场景下应该优先使用元组？"
+    messages.append({"role": "user", "content": user_msg_2})
+    print(f"\n用户：{user_msg_2}")
+
+    response2 = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0.9,
+        top_p=1.0,
+    )
+    assistant_reply_2 = response2.choices[0].message.content
+    print(f"助手：{assistant_reply_2}")
+
+
+# ============================================================
+# 示例 3：带 System Prompt 的对话 / System Prompt Chat
+# ============================================================
+def system_prompt_chat():
+    """使用 system prompt 控制模型行为风格"""
+    print("\n" + "=" * 60)
+    print("带 System Prompt 的对话 / System Prompt Chat")
+    print("=" * 60)
+
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": "你是一位资深软件架构师，回答技术问题时请先给出结论，再解释原因，最后给出代码示例。",
+            },
+            {"role": "user", "content": "微服务架构中，服务间通信应该选择 REST 还是 gRPC？"},
+        ],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=1024,
+    )
+
+    print(f"\n回复：{response.choices[0].message.content}")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    single_turn_chat()
+    multi_turn_chat()
+    system_prompt_chat()

--- a/examples/02_streaming.md
+++ b/examples/02_streaming.md
@@ -1,0 +1,143 @@
+# 02 流式输出 / Streaming
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例展示如何使用 Hy3 API 进行**流式请求**，实现逐 chunk 实时输出，降低首字等待时间，提升用户体验。
+
+### 流式请求
+
+设置 `stream=True` 后，API 返回一个迭代器，每次 yield 一个文本 chunk。
+
+#### 请求
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "用 Python 写一个快速排序算法。"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    stream=True,  # 开启流式输出
+)
+```
+
+#### 逐 chunk 解析
+
+```python
+full_content = ""
+
+for chunk in stream:
+    # 每个 chunk 包含一个 delta（增量内容）
+    delta = chunk.choices[0].delta
+
+    # delta.content 可能为 None（如开头的 role 信息）
+    if delta.content:
+        print(delta.content, end="", flush=True)
+        full_content += delta.content
+
+print()  # 换行
+print(f"\n完整内容长度：{len(full_content)} 字符")
+```
+
+#### 示例输出
+
+```
+def quick_sort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quick_sort(left) + middle + quick_sort(right)
+
+完整内容长度：285 字符
+```
+
+---
+
+### 带角色信息的流式解析
+
+每个 chunk 还包含角色信息和 finish_reason：
+
+```python
+for chunk in stream:
+    choice = chunk.choices[0]
+
+    # 第一个 chunk 通常包含 role
+    if choice.delta.role:
+        print(f"角色：{choice.delta.role}")
+
+    # 最后一个 chunk 包含 finish_reason
+    if choice.finish_reason:
+        print(f"\n结束原因：{choice.finish_reason}")
+
+    if choice.delta.content:
+        print(choice.delta.content, end="", flush=True)
+```
+
+---
+
+## English
+
+This example demonstrates **streaming requests** with the Hy3 API, outputting text chunk by chunk in real time to reduce first-token latency and improve user experience.
+
+### Streaming Request
+
+Set `stream=True` to get an iterator that yields text chunks.
+
+#### Request
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "Write a quicksort algorithm in Python."},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    stream=True,
+)
+```
+
+#### Chunk-by-Chunk Parsing
+
+```python
+full_content = ""
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.content:
+        print(delta.content, end="", flush=True)
+        full_content += delta.content
+
+print(f"\nTotal content length: {len(full_content)} chars")
+```
+
+#### Example Output
+
+```
+def quick_sort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quick_sort(left) + middle + quick_sort(right)
+
+Total content length: 285 chars
+```

--- a/examples/02_streaming.py
+++ b/examples/02_streaming.py
@@ -1,0 +1,127 @@
+"""
+Hy3 API - 流式输出示例 / Streaming Example
+逐 chunk 解析流式响应
+"""
+
+from openai import OpenAI
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+# ============================================================
+# 示例 1：基础流式输出 / Basic Streaming
+# ============================================================
+def basic_streaming():
+    """最简单的流式输出：逐字符打印"""
+    print("=" * 60)
+    print("基础流式输出 / Basic Streaming")
+    print("=" * 60)
+
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "user", "content": "用 Python 写一个快速排序算法。"},
+        ],
+        temperature=0.9,
+        top_p=1.0,
+        stream=True,
+    )
+
+    full_content = ""
+    print("\n回复：", end="")
+
+    for chunk in stream:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            print(delta.content, end="", flush=True)
+            full_content += delta.content
+
+    print(f"\n\n完整内容长度：{len(full_content)} 字符")
+
+
+# ============================================================
+# 示例 2：完整的流式解析 / Full Stream Parsing
+# ============================================================
+def full_stream_parsing():
+    """解析每个 chunk 的完整信息：role、content、finish_reason"""
+    print("\n" + "=" * 60)
+    print("完整流式解析 / Full Stream Parsing")
+    print("=" * 60)
+
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "user", "content": "什么是Mixture of Experts（MoE）架构？"},
+        ],
+        temperature=0.9,
+        top_p=1.0,
+        stream=True,
+    )
+
+    full_content = ""
+    print("\n回复：", end="")
+
+    for chunk in stream:
+        choice = chunk.choices[0]
+
+        # 第一个 chunk 通常包含 role 信息
+        if choice.delta.role:
+            print(f"\n[角色: {choice.delta.role}]", end="")
+
+        # 内容增量
+        if choice.delta.content:
+            print(choice.delta.content, end="", flush=True)
+            full_content += choice.delta.content
+
+        # 最后一个 chunk 包含 finish_reason
+        if choice.finish_reason:
+            print(f"\n\n[结束原因: {choice.finish_reason}]")
+
+    print(f"[总字符数: {len(full_content)}]")
+
+
+# ============================================================
+# 示例 3：流式收集到变量 / Collect Stream to Variable
+# ============================================================
+def collect_stream():
+    """将流式输出收集到变量，用于后续处理"""
+    print("\n" + "=" * 60)
+    print("流式收集 / Collect Stream")
+    print("=" * 60)
+
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "user", "content": "写一首关于春天的五言绝句。"},
+        ],
+        temperature=0.9,
+        top_p=1.0,
+        stream=True,
+    )
+
+    # 收集所有 chunk
+    chunks = []
+    for chunk in stream:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            chunks.append(delta.content)
+
+    full_content = "".join(chunks)
+    print(f"\n完整回复：\n{full_content}")
+    print(f"\n共收到 {len(chunks)} 个 chunk")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    basic_streaming()
+    full_stream_parsing()
+    collect_stream()

--- a/examples/03_streaming_vs_non_streaming.md
+++ b/examples/03_streaming_vs_non_streaming.md
@@ -1,0 +1,149 @@
+# 03 流式 vs 非流式对比 / Streaming vs Non-Streaming Comparison
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例对比 Hy3 API 的**非流式**和**流式**两种调用方式，量化首 token 时延（TTFT）和总耗时，帮助你选择合适的调用模式。
+
+### 核心差异
+
+| 维度 | 非流式（`stream=False`） | 流式（`stream=True`） |
+|:---|:---|:---|
+| 首 token 等待 | 等待全部生成完毕才返回 | 首个 token 生成后立即返回 |
+| 总耗时 | 略短（无分块传输开销） | 略长（网络分块传输） |
+| 用户体验 | 等待时间长，一次性输出 | 逐字输出，感知更快 |
+| 适用场景 | 后端批处理、日志分析 | 聊天界面、实时交互 |
+
+---
+
+### 请求与计时
+
+```python
+import time
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+prompt = "请详细介绍Python中的装饰器模式，包括使用场景和代码示例。"
+
+# ---- 非流式 ----
+t0 = time.time()
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": prompt}],
+    temperature=0.9,
+    top_p=1.0,
+    stream=False,
+)
+non_stream_time = time.time() - t0
+
+# ---- 流式 ----
+t0 = time.time()
+first_token_time = None
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": prompt}],
+    temperature=0.9,
+    top_p=1.0,
+    stream=True,
+)
+full_content = ""
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        if first_token_time is None:
+            first_token_time = time.time() - t0
+        full_content += chunk.choices[0].delta.content
+stream_time = time.time() - t0
+```
+
+---
+
+### 结果输出
+
+```python
+print(f"{'指标':<20} {'非流式':>12} {'流式':>12}")
+print("-" * 48)
+print(f"{'首 token 时延':<20} {non_stream_time:>10.2f}s {first_token_time:>10.2f}s")
+print(f"{'总耗时':<20} {non_stream_time:>10.2f}s {stream_time:>10.2f}s")
+print(f"{'内容长度':<20} {len(response.choices[0].message.content):>10} {len(full_content):>10}")
+```
+
+#### 示例输出
+
+```
+指标                   非流式          流式
+------------------------------------------------
+首 token 时延            8.32s        0.85s
+总耗时                   8.32s        9.10s
+内容长度                  1024         1024
+```
+
+> **结论**：流式模式的首 token 时延显著更低（通常快 5-10 倍），适合实时交互场景；非流式总耗时略短，适合无需逐步展示的后端任务。
+
+---
+
+## English
+
+This example compares **non-streaming** and **streaming** modes of the Hy3 API, measuring first-token latency (TTFT) and total time to help you choose the right approach.
+
+### Key Differences
+
+| Aspect | Non-Streaming (`stream=False`) | Streaming (`stream=True`) |
+|:---|:---|:---|
+| First token wait | Waits until full generation | Returns immediately when first token is ready |
+| Total time | Slightly shorter (no chunking overhead) | Slightly longer (network chunking) |
+| User experience | Long wait, all-at-once output | Progressive output, feels faster |
+| Best for | Backend batch, log analysis | Chat UI, real-time interaction |
+
+---
+
+### Request & Timing
+
+```python
+import time
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+prompt = "Explain the decorator pattern in Python with use cases and code examples."
+
+# ---- Non-streaming ----
+t0 = time.time()
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": prompt}],
+    temperature=0.9, top_p=1.0, stream=False,
+)
+non_stream_time = time.time() - t0
+
+# ---- Streaming ----
+t0 = time.time()
+first_token_time = None
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": prompt}],
+    temperature=0.9, top_p=1.0, stream=True,
+)
+full_content = ""
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        if first_token_time is None:
+            first_token_time = time.time() - t0
+        full_content += chunk.choices[0].delta.content
+stream_time = time.time() - t0
+```
+
+#### Example Output
+
+```
+Metric                Non-Stream    Streaming
+------------------------------------------------
+First token latency      8.32s        0.85s
+Total time               8.32s        9.10s
+Content length            1024         1024
+```
+
+> **Conclusion**: Streaming has significantly lower first-token latency (typically 5-10x faster), ideal for interactive use cases. Non-streaming has slightly shorter total time, better for backend tasks where output is consumed all at once.

--- a/examples/03_streaming_vs_non_streaming.py
+++ b/examples/03_streaming_vs_non_streaming.py
@@ -1,0 +1,131 @@
+"""
+Hy3 API - 流式 vs 非流式对比 / Streaming vs Non-Streaming Comparison
+量化首 token 时延（TTFT）和总耗时
+"""
+
+import time
+from openai import OpenAI
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+PROMPT = "请详细介绍Python中的装饰器模式，包括使用场景和代码示例。"
+
+
+# ============================================================
+# 非流式请求 / Non-Streaming Request
+# ============================================================
+def run_non_streaming():
+    """非流式请求：等待完整响应后一次性返回"""
+    print("=" * 60)
+    print("非流式请求 / Non-Streaming Request")
+    print("=" * 60)
+
+    t_start = time.time()
+
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        top_p=1.0,
+        stream=False,
+    )
+
+    total_time = time.time() - t_start
+    content = response.choices[0].message.content
+
+    print(f"\n回复（前200字符）：{content[:200]}...")
+    print(f"\n首 token 时延：{total_time:.2f}s（与非流式总耗时相同）")
+    print(f"总耗时：{total_time:.2f}s")
+    print(f"内容长度：{len(content)} 字符")
+
+    return total_time, total_time, len(content)
+
+
+# ============================================================
+# 流式请求 / Streaming Request
+# ============================================================
+def run_streaming():
+    """流式请求：逐 chunk 接收，记录首 token 时延"""
+    print("\n" + "=" * 60)
+    print("流式请求 / Streaming Request")
+    print("=" * 60)
+
+    t_start = time.time()
+    first_token_time = None
+    full_content = ""
+    chunk_count = 0
+
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        top_p=1.0,
+        stream=True,
+    )
+
+    print("\n回复（前200字符）：", end="")
+
+    for chunk in stream:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            # 记录首 token 到达时间
+            if first_token_time is None:
+                first_token_time = time.time() - t_start
+
+            full_content += delta.content
+            chunk_count += 1
+
+            # 仅打印前200字符
+            if len(full_content) <= 200:
+                print(delta.content, end="", flush=True)
+
+    total_time = time.time() - t_start
+
+    if len(full_content) > 200:
+        print("...", end="")
+
+    print(f"\n\n首 token 时延：{first_token_time:.2f}s")
+    print(f"总耗时：{total_time:.2f}s")
+    print(f"内容长度：{len(full_content)} 字符")
+    print(f"Chunk 数量：{chunk_count}")
+
+    return first_token_time, total_time, len(full_content)
+
+
+# ============================================================
+# 对比总结 / Comparison Summary
+# ============================================================
+def compare(ttft_non, total_non, len_non, ttft_stream, total_stream, len_stream):
+    """打印对比表格"""
+    print("\n" + "=" * 60)
+    print("对比总结 / Comparison Summary")
+    print("=" * 60)
+
+    print(f"\n{'指标':<20} {'非流式':>14} {'流式':>14} {'差异':>14}")
+    print("-" * 66)
+    print(f"{'首 token 时延 (TTFT)':<20} {ttft_non:>12.2f}s {ttft_stream:>12.2f}s "
+          f"{ttft_non - ttft_stream:>+12.2f}s")
+    print(f"{'总耗时':<20} {total_non:>12.2f}s {total_stream:>12.2f}s "
+          f"{total_stream - total_non:>+12.2f}s")
+    print(f"{'内容长度':<20} {len_non:>12} {len_stream:>12}")
+
+    speedup = ttft_non / ttft_stream if ttft_stream > 0 else float("inf")
+    print(f"\n流式首 token 加速比：{speedup:.1f}x")
+    print("\n结论：流式模式首 token 到达更快，适合实时交互；")
+    print("      非流式总耗时略短，适合后端批处理场景。")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    ttft_non, total_non, len_non = run_non_streaming()
+    ttft_stream, total_stream, len_stream = run_streaming()
+    compare(ttft_non, total_non, len_non, ttft_stream, total_stream, len_stream)

--- a/examples/04_tool_calling.md
+++ b/examples/04_tool_calling.md
@@ -1,0 +1,253 @@
+# 04 工具调用 / Tool Calling
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例展示如何使用 Hy3 API 的**工具调用（Function Calling）** 能力，包括**单次工具调用**和**多轮工具循环**。
+
+> **前提**：部署 vLLM 时需添加 `--tool-call-parser hy_v3 --reasoning-parser hy_v3 --enable-auto-tool-choice` 参数。
+
+---
+
+### 定义工具
+
+使用 OpenAI 规范的 JSON Schema 定义可用工具：
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的当前天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名称，如 '北京'、'上海'"
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "温度单位"
+                    }
+                },
+                "required": ["city"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "执行数学计算",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "数学表达式，如 '2 + 3 * 4'"
+                    }
+                },
+                "required": ["expression"]
+            }
+        }
+    }
+]
+```
+
+---
+
+### 单次工具调用
+
+模型判断需要调用工具时，会返回 `tool_calls` 而非文本内容：
+
+#### 请求
+
+```python
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "北京今天天气怎么样？"},
+    ],
+    tools=tools,
+    temperature=0.9,
+    top_p=1.0,
+)
+
+# 检查是否触发了工具调用
+message = response.choices[0].message
+
+if message.tool_calls:
+    for tool_call in message.tool_calls:
+        print(f"工具名：{tool_call.function.name}")
+        print(f"参数：{tool_call.function.arguments}")
+        # 输出：工具名：get_weather
+        #       参数：{"city": "北京", "unit": "celsius"}
+```
+
+#### 执行工具并返回结果
+
+```python
+import json
+
+# 模拟工具执行结果
+def execute_tool(tool_call):
+    args = json.loads(tool_call.function.arguments)
+    if tool_call.function.name == "get_weather":
+        return json.dumps({
+            "city": args["city"],
+            "temperature": 22,
+            "humidity": 65,
+            "condition": "晴"
+        }, ensure_ascii=False)
+    return json.dumps({"error": "未知工具"})
+
+# 将工具结果加入消息历史
+messages = [
+    {"role": "user", "content": "北京今天天气怎么样？"},
+]
+
+# 第一轮：获取工具调用
+response = client.chat.completions.create(
+    model="hy3", messages=messages, tools=tools, temperature=0.9, top_p=1.0,
+)
+tool_call = response.choices[0].message.tool_calls[0]
+
+# 追加助手消息（含 tool_calls）和工具结果
+messages.append(response.choices[0].message)
+messages.append({
+    "role": "tool",
+    "tool_call_id": tool_call.id,
+    "content": execute_tool(tool_call),
+})
+
+# 第二轮：模型基于工具结果生成最终回复
+final_response = client.chat.completions.create(
+    model="hy3", messages=messages, tools=tools, temperature=0.9, top_p=1.0,
+)
+print(final_response.choices[0].message.content)
+# 输出：北京今天天气晴朗，气温22°C，湿度65%，适合户外活动。
+```
+
+---
+
+### 多轮工具循环
+
+复杂任务中，模型可能需要连续调用多个工具：
+
+```python
+messages = [
+    {"role": "user", "content": "查一下北京和上海的天气，然后计算两地的温差。"},
+]
+
+max_rounds = 5
+for round_num in range(max_rounds):
+    response = client.chat.completions.create(
+        model="hy3", messages=messages, tools=tools, temperature=0.9, top_p=1.0,
+    )
+    msg = response.choices[0].message
+
+    # 无工具调用 → 最终回复
+    if not msg.tool_calls:
+        print(f"最终回复：{msg.content}")
+        break
+
+    # 执行所有工具调用
+    messages.append(msg)
+    for tool_call in msg.tool_calls:
+        result = execute_tool(tool_call)
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": result,
+        })
+```
+
+#### 示例输出
+
+```
+[Round 1] 调用：get_weather({"city": "北京"})
+[Round 2] 调用：get_weather({"city": "上海"})
+[Round 3] 调用：calculate({"expression": "abs(22 - 26)"})
+最终回复：北京气温22°C，上海气温26°C，两地温差为4°C。
+```
+
+---
+
+## English
+
+This example demonstrates Hy3's **tool calling (function calling)** capability, including **single tool calls** and **multi-round tool loops**.
+
+> **Prerequisite**: Deploy vLLM with `--tool-call-parser hy_v3 --reasoning-parser hy_v3 --enable-auto-tool-choice`.
+
+---
+
+### Define Tools
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                },
+                "required": ["city"]
+            }
+        }
+    }
+]
+```
+
+### Single Tool Call
+
+```python
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "What's the weather in Beijing today?"}],
+    tools=tools,
+    temperature=0.9, top_p=1.0,
+)
+
+msg = response.choices[0].message
+if msg.tool_calls:
+    print(f"Tool: {msg.tool_calls[0].function.name}")
+    print(f"Args: {msg.tool_calls[0].function.arguments}")
+```
+
+### Multi-Round Tool Loop
+
+```python
+messages = [{"role": "user", "content": "Check weather in Beijing and Shanghai, then calculate the temperature difference."}]
+
+for _ in range(5):
+    response = client.chat.completions.create(
+        model="hy3", messages=messages, tools=tools, temperature=0.9, top_p=1.0,
+    )
+    msg = response.choices[0].message
+    if not msg.tool_calls:
+        print(f"Final: {msg.content}")
+        break
+    messages.append(msg)
+    for tc in msg.tool_calls:
+        messages.append({"role": "tool", "tool_call_id": tc.id, "content": execute_tool(tc)})
+```
+
+#### Example Output
+
+```
+[Round 1] Call: get_weather({"city": "Beijing"})
+[Round 2] Call: get_weather({"city": "Shanghai"})
+[Round 3] Call: calculate({"expression": "abs(22 - 26)"})
+Final: Beijing is 22°C, Shanghai is 26°C. The temperature difference is 4°C.
+```

--- a/examples/04_tool_calling.py
+++ b/examples/04_tool_calling.py
@@ -1,0 +1,260 @@
+"""
+Hy3 API - 工具调用示例 / Tool Calling Example
+包含单次工具调用和多轮工具循环
+"""
+
+import json
+from openai import OpenAI
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+# ============================================================
+# 工具定义 / Tool Definitions
+# ============================================================
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的当前天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名称，如 '北京'、'上海'",
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "温度单位，默认 celsius",
+                    },
+                },
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "执行数学计算并返回结果",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "Python 可执行的数学表达式，如 '2 + 3 * 4'",
+                    },
+                },
+                "required": ["expression"],
+            },
+        },
+    },
+]
+
+
+# ============================================================
+# 工具执行模拟 / Mock Tool Execution
+# ============================================================
+def execute_tool(tool_call) -> str:
+    """根据工具名称模拟执行并返回 JSON 结果"""
+    name = tool_call.function.name
+    args = json.loads(tool_call.function.arguments)
+
+    if name == "get_weather":
+        # 模拟天气数据
+        weather_data = {
+            "北京": {"temperature": 22, "humidity": 65, "condition": "晴"},
+            "上海": {"temperature": 26, "humidity": 80, "condition": "多云"},
+            "广州": {"temperature": 30, "humidity": 85, "condition": "雷阵雨"},
+        }
+        city = args["city"]
+        data = weather_data.get(city, {"temperature": 20, "humidity": 50, "condition": "未知"})
+        return json.dumps({"city": city, **data}, ensure_ascii=False)
+
+    elif name == "calculate":
+        try:
+            result = eval(args["expression"])  # 仅用于演示，生产环境请使用安全解析
+            return json.dumps({"expression": args["expression"], "result": result})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    return json.dumps({"error": f"未知工具: {name}"})
+
+
+# ============================================================
+# 示例 1：单次工具调用 / Single Tool Call
+# ============================================================
+def single_tool_call():
+    """用户提问触发单个工具，返回工具结果后生成最终回复"""
+    print("=" * 60)
+    print("单次工具调用 / Single Tool Call")
+    print("=" * 60)
+
+    messages = [
+        {"role": "user", "content": "北京今天天气怎么样？"},
+    ]
+
+    # 第一轮：模型决定调用工具
+    print("\n[Round 1] 发送用户请求...")
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        temperature=0.9,
+        top_p=1.0,
+    )
+
+    msg = response.choices[0].message
+
+    # 检查是否触发了工具调用
+    if not msg.tool_calls:
+        print(f"模型直接回复（无工具调用）：{msg.content}")
+        return
+
+    # 打印工具调用信息
+    for tc in msg.tool_calls:
+        print(f"  调用工具：{tc.function.name}")
+        print(f"  参数：{tc.function.arguments}")
+
+    # 将助手消息（含 tool_calls）加入历史
+    messages.append(msg)
+
+    # 执行工具并返回结果
+    for tc in msg.tool_calls:
+        result = execute_tool(tc)
+        print(f"  工具结果：{result}")
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": result,
+        })
+
+    # 第二轮：模型基于工具结果生成最终回复
+    print("\n[Round 2] 将工具结果返回给模型...")
+    final_response = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        temperature=0.9,
+        top_p=1.0,
+    )
+    print(f"  最终回复：{final_response.choices[0].message.content}")
+
+
+# ============================================================
+# 示例 2：多轮工具循环 / Multi-Round Tool Loop
+# ============================================================
+def multi_round_tool_loop():
+    """复杂问题需要多次工具调用才能得出最终答案"""
+    print("\n" + "=" * 60)
+    print("多轮工具循环 / Multi-Round Tool Loop")
+    print("=" * 60)
+
+    messages = [
+        {"role": "user", "content": "查一下北京和上海的天气，然后计算两地的温差。"},
+    ]
+
+    max_rounds = 5  # 防止无限循环
+
+    for round_num in range(1, max_rounds + 1):
+        print(f"\n[Round {round_num}] 发送请求...")
+
+        response = client.chat.completions.create(
+            model=MODEL,
+            messages=messages,
+            tools=TOOLS,
+            temperature=0.9,
+            top_p=1.0,
+        )
+
+        msg = response.choices[0].message
+
+        # 无工具调用 → 最终回复
+        if not msg.tool_calls:
+            print(f"  最终回复：{msg.content}")
+            break
+
+        # 追加助手消息
+        messages.append(msg)
+
+        # 执行所有工具调用
+        for tc in msg.tool_calls:
+            print(f"  调用工具：{tc.function.name}({tc.function.arguments})")
+            result = execute_tool(tc)
+            print(f"  工具结果：{result}")
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            })
+    else:
+        print("  达到最大轮次限制。")
+
+
+# ============================================================
+# 示例 3：并行工具调用 / Parallel Tool Calls
+# ============================================================
+def parallel_tool_calls():
+    """模型可能在一次响应中同时请求多个工具"""
+    print("\n" + "=" * 60)
+    print("并行工具调用 / Parallel Tool Calls")
+    print("=" * 60)
+
+    messages = [
+        {"role": "user", "content": "同时查一下北京、上海和广州的天气。"},
+    ]
+
+    print("\n[Round 1] 发送请求...")
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        temperature=0.9,
+        top_p=1.0,
+    )
+
+    msg = response.choices[0].message
+
+    if not msg.tool_calls:
+        print(f"  模型直接回复：{msg.content}")
+        return
+
+    print(f"  模型同时请求了 {len(msg.tool_calls)} 个工具调用：")
+    messages.append(msg)
+
+    for tc in msg.tool_calls:
+        result = execute_tool(tc)
+        print(f"    - {tc.function.name}({tc.function.arguments}) → {result}")
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": result,
+        })
+
+    print("\n[Round 2] 返回所有工具结果...")
+    final_response = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        temperature=0.9,
+        top_p=1.0,
+    )
+    print(f"  最终回复：{final_response.choices[0].message.content}")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    single_tool_call()
+    multi_round_tool_loop()
+    parallel_tool_calls()

--- a/examples/05_reasoning_mode.md
+++ b/examples/05_reasoning_mode.md
@@ -1,0 +1,187 @@
+# 05 思考模式 / Reasoning Mode
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例展示 Hy3 的**思考模式**（Reasoning Mode），通过 `reasoning_effort` 参数控制模型是否展示思维链过程。
+
+> **前提**：部署 vLLM 时需添加 `--reasoning-parser hy_v3` 参数。
+
+---
+
+### 思考模式参数
+
+| `reasoning_effort` 值 | 行为 | 适用场景 |
+|:---|:---|:---|
+| `"no_think"`（默认） | 直接输出结果，不展示思考过程 | 日常对话、简单问答、快速交互 |
+| `"low"` | 展示简要思考过程 | 中等复杂度任务、需要一定解释 |
+| `"high"` | 展示完整深度思维链 | 数学证明、编程难题、复杂推理 |
+
+通过 `extra_body` 参数传入：
+
+```python
+extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+---
+
+### 示例：no_think vs high 对比
+
+#### no_think 模式（默认）
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+response_no_think = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "一个水池有A、B两个进水管，A管单独注满需要6小时，B管单独注满需要8小时。同时打开两管，需要多少小时注满？"}],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+
+print("no_think 回复：")
+print(response_no_think.choices[0].message.content)
+```
+
+**示例输出**：
+```
+同时开两管，每小时注水量为 1/6 + 1/8 = 7/24。
+注满水池需要 24/7 ≈ 3.43 小时。
+```
+
+---
+
+#### high 模式（深度思考）
+
+```python
+response_high = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "一个水池有A、B两个进水管，A管单独注满需要6小时，B管单独注满需要8小时。同时打开两管，需要多少小时注满？"}],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+
+# high 模式下，响应可能包含 reasoning_content（思考过程）
+message = response_high.choices[0].message
+
+# 打印思考过程（如果存在）
+if hasattr(message, "reasoning_content") and message.reasoning_content:
+    print("思考过程：")
+    print(message.reasoning_content)
+    print("\n最终答案：")
+
+print(message.content)
+```
+
+**示例输出**：
+```
+思考过程：
+设水池总容量为1。
+A管每小时注水 1/6。
+B管每小时注水 1/8。
+同时开两管，每小时注水 1/6 + 1/8 = 4/24 + 3/24 = 7/24。
+注满需要 1 ÷ (7/24) = 24/7 小时。
+24/7 = 3小时 + 3/7小时 ≈ 3小时26分钟。
+
+最终答案：
+同时开两管，需要 24/7 ≈ 3.43 小时（约3小时26分钟）注满水池。
+```
+
+---
+
+### 时延对比
+
+```python
+import time
+
+# no_think 计时
+t0 = time.time()
+r1 = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "计算 123 * 456"}],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+time_no_think = time.time() - t0
+
+# high 计时
+t0 = time.time()
+r2 = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "计算 123 * 456"}],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+time_high = time.time() - t0
+
+print(f"no_think: {time_no_think:.2f}s | high: {time_high:.2f}s")
+```
+
+**示例输出**：
+```
+no_think: 1.23s | high: 4.56s
+```
+
+> **建议**：简单任务使用 `"no_think"` 以获得更低延迟；复杂推理任务使用 `"high"` 以获得更高准确率。
+
+---
+
+## English
+
+This example demonstrates Hy3's **reasoning mode**, controlling whether the model shows its chain-of-thought process via the `reasoning_effort` parameter.
+
+> **Prerequisite**: Deploy vLLM with `--reasoning-parser hy_v3`.
+
+---
+
+### Reasoning Mode Parameters
+
+| `reasoning_effort` | Behavior | Use Case |
+|:---|:---|:---|
+| `"no_think"` (default) | Direct output, no reasoning trace | Casual chat, simple Q&A |
+| `"low"` | Brief reasoning shown | Medium complexity tasks |
+| `"high"` | Full deep chain-of-thought | Math, coding, complex reasoning |
+
+Passed via `extra_body`:
+
+```python
+extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+---
+
+### Example: no_think vs high
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+# no_think mode
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Prove that sqrt(2) is irrational."}],
+    temperature=0.9, top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+print(response.choices[0].message.content)
+
+# high mode (shows reasoning trace)
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Prove that sqrt(2) is irrational."}],
+    temperature=0.9, top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+msg = response.choices[0].message
+if hasattr(msg, "reasoning_content") and msg.reasoning_content:
+    print(f"Reasoning: {msg.reasoning_content}")
+print(f"Answer: {msg.content}")
+```
+
+> **Tip**: Use `"no_think"` for lower latency on simple tasks; use `"high"` for better accuracy on complex reasoning.

--- a/examples/05_reasoning_mode.py
+++ b/examples/05_reasoning_mode.py
@@ -1,0 +1,159 @@
+"""
+Hy3 API - 思考模式示例 / Reasoning Mode Example
+对比 no_think / low / high 三种思考模式
+"""
+
+import time
+from openai import OpenAI
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+# 测试问题（数学应用题，适合展示思考能力）
+MATH_PROMPT = (
+    "一个水池有A、B两个进水管。A管单独注满需要6小时，"
+    "B管单独注满需要8小时。同时打开两管，需要多少小时注满？"
+)
+
+COMPLEX_PROMPT = "证明根号2是无理数。"
+
+
+# ============================================================
+# 辅助函数 / Helper
+# ============================================================
+def request_with_reasoning_effort(prompt: str, effort: str) -> tuple:
+    """发送请求并返回（耗时, 回复内容, 思考过程）"""
+    t0 = time.time()
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.9,
+        top_p=1.0,
+        extra_body={"chat_template_kwargs": {"reasoning_effort": effort}},
+    )
+    elapsed = time.time() - t0
+
+    msg = response.choices[0].message
+    content = msg.content
+    reasoning = getattr(msg, "reasoning_content", None)
+
+    return elapsed, content, reasoning
+
+
+# ============================================================
+# 示例 1：no_think 模式 / No Thinking
+# ============================================================
+def demo_no_think():
+    """no_think：直接输出结果，不展示思考过程"""
+    print("=" * 60)
+    print(f"no_think 模式")
+    print("=" * 60)
+    print(f"问题：{MATH_PROMPT}\n")
+
+    elapsed, content, _ = request_with_reasoning_effort(MATH_PROMPT, "no_think")
+
+    print(f"回复（{elapsed:.2f}s）：")
+    print(content)
+
+
+# ============================================================
+# 示例 2：high 模式 / Deep Reasoning
+# ============================================================
+def demo_high():
+    """high：展示完整深度思维链"""
+    print("\n" + "=" * 60)
+    print("high 模式（深度思考）")
+    print("=" * 60)
+    print(f"问题：{MATH_PROMPT}\n")
+
+    elapsed, content, reasoning = request_with_reasoning_effort(MATH_PROMPT, "high")
+
+    if reasoning:
+        print(f"思考过程（{elapsed:.2f}s）：")
+        print(reasoning)
+        print("\n最终答案：")
+    else:
+        print(f"回复（{elapsed:.2f}s）：")
+
+    print(content)
+
+
+# ============================================================
+# 示例 3：复杂推理任务 / Complex Reasoning Task
+# ============================================================
+def demo_complex_reasoning():
+    """在复杂任务上对比 no_think 和 high"""
+    print("\n" + "=" * 60)
+    print("复杂推理任务对比")
+    print("=" * 60)
+    print(f"问题：{COMPLEX_PROMPT}\n")
+
+    # no_think
+    time_nt, content_nt, _ = request_with_reasoning_effort(COMPLEX_PROMPT, "no_think")
+    print(f"--- no_think ({time_nt:.2f}s) ---")
+    print(content_nt[:300] + "..." if len(content_nt) > 300 else content_nt)
+
+    # high
+    print()
+    time_h, content_h, reasoning_h = request_with_reasoning_effort(COMPLEX_PROMPT, "high")
+
+    if reasoning_h:
+        print(f"--- high - 思考过程 ({time_h:.2f}s) ---")
+        print(reasoning_h[:300] + "..." if len(reasoning_h) > 300 else reasoning_h)
+        print("\n--- high - 最终答案 ---")
+    else:
+        print(f"--- high ({time_h:.2f}s) ---")
+
+    print(content_h[:300] + "..." if len(content_h) > 300 else content_h)
+
+
+# ============================================================
+# 示例 4：时延对比汇总 / Latency Comparison Summary
+# ============================================================
+def latency_comparison():
+    """汇总三种模式的时延对比"""
+    print("\n" + "=" * 60)
+    print("时延对比汇总 / Latency Comparison Summary")
+    print("=" * 60)
+
+    prompt = "计算 123 × 456 × 789"
+    efforts = ["no_think", "low", "high"]
+    results = {}
+
+    for effort in efforts:
+        try:
+            elapsed, content, reasoning = request_with_reasoning_effort(prompt, effort)
+            results[effort] = {
+                "time": elapsed,
+                "content_len": len(content),
+                "reasoning_len": len(reasoning) if reasoning else 0,
+            }
+        except Exception as e:
+            print(f"  {effort}: 请求失败 - {e}")
+
+    print(f"\n问题：{prompt}")
+    print(f"\n{'模式':<15} {'耗时':>10} {'回复长度':>12} {'思考长度':>12}")
+    print("-" * 52)
+    for effort, data in results.items():
+        print(f"{effort:<15} {data['time']:>8.2f}s {data['content_len']:>10} {data['reasoning_len']:>10}")
+
+    print("\n建议：")
+    print("  - 简单任务 → no_think（最低延迟）")
+    print("  - 中等任务 → low（平衡延迟与解释性）")
+    print("  - 复杂任务 → high（最高准确率，展示完整思维链）")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    demo_no_think()
+    demo_high()
+    demo_complex_reasoning()
+    latency_comparison()

--- a/examples/06_error_handling.md
+++ b/examples/06_error_handling.md
@@ -61,9 +61,11 @@ except Exception as e:
 
 ### 指数退避重试
 
-对于临时性错误（限流、超时、服务端错误），使用指数退避策略自动重试：
+对于临时性错误（限流、超时、服务端错误），使用指数退避策略自动重试。429 应优先遵循
+服务端 `Retry-After`；没有该响应头时再使用带随机抖动的指数退避，避免多个客户端同时重试：
 
 ```python
+import random
 import time
 from openai import (
     OpenAI,
@@ -74,6 +76,18 @@ from openai import (
 )
 
 client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+def retry_delay(attempt, base_delay, error):
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    retry_after = headers.get("retry-after") if headers is not None else None
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 0.0), 60.0)
+        except ValueError:
+            pass  # 可执行示例还支持 HTTP-date 格式
+    exponential = min(base_delay * (2 ** attempt), 60.0)
+    return exponential + random.uniform(0, min(1.0, exponential * 0.25))
 
 def call_with_retry(
     messages,
@@ -96,7 +110,7 @@ def call_with_retry(
         except (APIConnectionError, APITimeoutError) as e:
             # 网络/超时错误：可重试
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt+1}/{max_retries+1}] {type(e).__name__}，{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -106,7 +120,7 @@ def call_with_retry(
         except RateLimitError as e:
             # 限流错误：退避重试
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt+1}/{max_retries+1}] 限流，{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -115,7 +129,7 @@ def call_with_retry(
         except APIStatusError as e:
             # 服务端 5xx 错误：可重试
             if e.status_code >= 500 and attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt+1}/{max_retries+1}] 服务端错误 {e.status_code}，{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -157,7 +171,7 @@ def stream_with_retry(messages, max_retries=3, base_delay=1.0):
 
         except (APIConnectionError, APITimeoutError, RateLimitError) as e:
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"\n  [重试 {attempt+1}] {type(e).__name__}，{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -187,11 +201,29 @@ This example demonstrates how to handle common errors in Hy3 API calls, includin
 
 ### Exponential Backoff Retry
 
+For HTTP 429, honor the server's `Retry-After` header first. If it is absent,
+use capped exponential backoff with random jitter so concurrent clients do not
+retry in lockstep. The runnable Python file supports both numeric and HTTP-date
+`Retry-After` values.
+
 ```python
+import random
 import time
 from openai import OpenAI, APIConnectionError, APITimeoutError, RateLimitError, APIStatusError
 
 client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+def retry_delay(attempt, base_delay, error):
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    retry_after = headers.get("retry-after") if headers is not None else None
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 0.0), 60.0)
+        except ValueError:
+            pass
+    exponential = min(base_delay * (2 ** attempt), 60.0)
+    return exponential + random.uniform(0, min(1.0, exponential * 0.25))
 
 def call_with_retry(messages, max_retries=3, base_delay=1.0, timeout=60.0):
     for attempt in range(max_retries + 1):
@@ -201,14 +233,14 @@ def call_with_retry(messages, max_retries=3, base_delay=1.0, timeout=60.0):
             )
         except (APIConnectionError, APITimeoutError, RateLimitError) as e:
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"[Attempt {attempt+1}] {type(e).__name__}, retrying in {delay:.1f}s...")
                 time.sleep(delay)
             else:
                 raise
         except APIStatusError as e:
             if e.status_code >= 500 and attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"[Attempt {attempt+1}] Server error {e.status_code}, retrying in {delay:.1f}s...")
                 time.sleep(delay)
             else:

--- a/examples/06_error_handling.md
+++ b/examples/06_error_handling.md
@@ -1,0 +1,221 @@
+# 06 错误处理与重试 / Error Handling & Retry
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本示例展示如何处理 Hy3 API 调用中常见的错误场景，包括**超时**、**限流**、**网络错误**，并提供**指数退避重试**的实现。
+
+---
+
+### 常见错误类型
+
+| 异常类 | HTTP 状态码 | 含义 | 建议处理 |
+|:---|:---|:---|:---|
+| `openai.APIConnectionError` | — | 网络连接失败 | 检查服务是否运行、网络是否通畅 |
+| `openai.APITimeoutError` | — | 请求超时 | 增加 `timeout` 参数或减小 `max_tokens` |
+| `openai.RateLimitError` | 429 | 请求频率超限 | 退避重试 |
+| `openai.APIStatusError` | 5xx | 服务端内部错误 | 退避重试 |
+| `openai.BadRequestError` | 400 | 请求参数错误 | 检查请求格式，无需重试 |
+| `openai.NotFoundError` | 404 | 模型不存在 | 检查模型名称，无需重试 |
+
+---
+
+### 基础错误处理
+
+```python
+from openai import OpenAI, APIConnectionError, APITimeoutError, RateLimitError, APIStatusError
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+try:
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": "你好"}],
+        timeout=30.0,  # 30秒超时
+    )
+    print(response.choices[0].message.content)
+
+except APIConnectionError as e:
+    print(f"连接失败：{e}")
+    print("请检查服务是否已启动，端口是否正确。")
+
+except APITimeoutError as e:
+    print(f"请求超时：{e}")
+    print("请增加超时时间或减少 max_tokens。")
+
+except RateLimitError as e:
+    print(f"限流：{e}")
+    print("请稍后重试。")
+
+except APIStatusError as e:
+    print(f"服务端错误 [{e.status_code}]：{e.message}")
+
+except Exception as e:
+    print(f"未知错误：{e}")
+```
+
+---
+
+### 指数退避重试
+
+对于临时性错误（限流、超时、服务端错误），使用指数退避策略自动重试：
+
+```python
+import time
+from openai import (
+    OpenAI,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    APIStatusError,
+)
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+def call_with_retry(
+    messages,
+    max_retries=3,
+    base_delay=1.0,
+    timeout=60.0,
+):
+    """带指数退避的 API 调用"""
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model="hy3",
+                messages=messages,
+                temperature=0.9,
+                top_p=1.0,
+                timeout=timeout,
+            )
+            return response
+
+        except (APIConnectionError, APITimeoutError) as e:
+            # 网络/超时错误：可重试
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt+1}/{max_retries+1}] {type(e).__name__}，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                print(f"  [尝试 {attempt+1}/{max_retries+1}] 重试次数用尽：{e}")
+                raise
+
+        except RateLimitError as e:
+            # 限流错误：退避重试
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt+1}/{max_retries+1}] 限流，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                raise
+
+        except APIStatusError as e:
+            # 服务端 5xx 错误：可重试
+            if e.status_code >= 500 and attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt+1}/{max_retries+1}] 服务端错误 {e.status_code}，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                raise
+
+    return None  # 不应到达此处
+
+# 使用
+response = call_with_retry(
+    messages=[{"role": "user", "content": "你好"}],
+)
+print(response.choices[0].message.content)
+```
+
+---
+
+### 流式请求的错误处理
+
+流式请求的错误可能在迭代过程中发生：
+
+```python
+def stream_with_retry(messages, max_retries=3, base_delay=1.0):
+    """带重试的流式请求"""
+    for attempt in range(max_retries + 1):
+        try:
+            stream = client.chat.completions.create(
+                model="hy3",
+                messages=messages,
+                stream=True,
+                timeout=60.0,
+            )
+            full_content = ""
+            for chunk in stream:
+                if chunk.choices[0].delta.content:
+                    content = chunk.choices[0].delta.content
+                    print(content, end="", flush=True)
+                    full_content += content
+            return full_content
+
+        except (APIConnectionError, APITimeoutError, RateLimitError) as e:
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"\n  [重试 {attempt+1}] {type(e).__name__}，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                raise
+```
+
+---
+
+## English
+
+This example demonstrates how to handle common errors in Hy3 API calls, including **timeouts**, **rate limiting**, and **network errors**, with an **exponential backoff retry** implementation.
+
+---
+
+### Common Error Types
+
+| Exception | HTTP Code | Meaning | Recommended Action |
+|:---|:---|:---|:---|
+| `APIConnectionError` | — | Network connection failed | Check server is running, port is correct |
+| `APITimeoutError` | — | Request timed out | Increase `timeout` or reduce `max_tokens` |
+| `RateLimitError` | 429 | Too many requests | Retry with backoff |
+| `APIStatusError` | 5xx | Server error | Retry with backoff |
+| `BadRequestError` | 400 | Invalid request | Fix request format, no retry |
+| `NotFoundError` | 404 | Model not found | Check model name, no retry |
+
+---
+
+### Exponential Backoff Retry
+
+```python
+import time
+from openai import OpenAI, APIConnectionError, APITimeoutError, RateLimitError, APIStatusError
+
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+def call_with_retry(messages, max_retries=3, base_delay=1.0, timeout=60.0):
+    for attempt in range(max_retries + 1):
+        try:
+            return client.chat.completions.create(
+                model="hy3", messages=messages, timeout=timeout,
+            )
+        except (APIConnectionError, APITimeoutError, RateLimitError) as e:
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"[Attempt {attempt+1}] {type(e).__name__}, retrying in {delay:.1f}s...")
+                time.sleep(delay)
+            else:
+                raise
+        except APIStatusError as e:
+            if e.status_code >= 500 and attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"[Attempt {attempt+1}] Server error {e.status_code}, retrying in {delay:.1f}s...")
+                time.sleep(delay)
+            else:
+                raise
+
+response = call_with_retry(messages=[{"role": "user", "content": "Hello"}])
+print(response.choices[0].message.content)
+```
+
+> **Tip**: Use retry for transient errors (429, 5xx, timeouts). Do NOT retry client errors (400, 404) — fix the request instead.

--- a/examples/06_error_handling.py
+++ b/examples/06_error_handling.py
@@ -3,7 +3,10 @@ Hy3 API - 错误处理与重试示例 / Error Handling & Retry Example
 包含基础错误捕获、指数退避重试、流式请求错误处理
 """
 
+import random
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from openai import (
     OpenAI,
     APIConnectionError,
@@ -22,6 +25,33 @@ API_KEY = "EMPTY"
 MODEL = "hy3"
 
 client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+def retry_delay(
+    attempt: int,
+    base_delay: float,
+    error: Exception | None = None,
+    max_delay: float = 60.0,
+) -> float:
+    """Return Retry-After when present, otherwise capped backoff with jitter."""
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    retry_after = headers.get("retry-after") if headers is not None else None
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 0.0), max_delay)
+        except ValueError:
+            try:
+                retry_at = parsedate_to_datetime(retry_after)
+                if retry_at.tzinfo is None:
+                    retry_at = retry_at.replace(tzinfo=timezone.utc)
+                seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
+                return min(max(seconds, 0.0), max_delay)
+            except (TypeError, ValueError, OverflowError):
+                pass
+
+    exponential = min(base_delay * (2 ** attempt), max_delay)
+    return exponential + random.uniform(0, min(1.0, exponential * 0.25))
 
 
 # ============================================================
@@ -113,7 +143,7 @@ def call_with_retry(
         except (APIConnectionError, APITimeoutError) as e:
             last_error = e
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
                       f"{type(e).__name__}，{delay:.1f}s 后重试...")
                 time.sleep(delay)
@@ -123,7 +153,7 @@ def call_with_retry(
         except RateLimitError as e:
             last_error = e
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
                       f"限流（429），{delay:.1f}s 后重试...")
                 time.sleep(delay)
@@ -133,7 +163,7 @@ def call_with_retry(
         except APIStatusError as e:
             last_error = e
             if e.status_code >= 500 and attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
                       f"服务端错误（{e.status_code}），{delay:.1f}s 后重试...")
                 time.sleep(delay)
@@ -206,7 +236,7 @@ def stream_with_retry(
         except (APIConnectionError, APITimeoutError, RateLimitError) as e:
             last_error = e
             if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"\n  [重试 {attempt + 1}] {type(e).__name__}，{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -214,7 +244,7 @@ def stream_with_retry(
 
         except APIStatusError as e:
             if e.status_code >= 500 and attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
+                delay = retry_delay(attempt, base_delay, e)
                 print(f"\n  [重试 {attempt + 1}] 服务端错误（{e.status_code}），{delay:.1f}s 后重试...")
                 time.sleep(delay)
             else:
@@ -284,7 +314,7 @@ class Hy3Client:
             except (APIConnectionError, APITimeoutError, RateLimitError) as e:
                 last_error = e
                 if attempt < self.max_retries:
-                    delay = self.base_delay * (2 ** attempt)
+                    delay = retry_delay(attempt, self.base_delay, e)
                     time.sleep(delay)
                 else:
                     raise RuntimeError(
@@ -293,7 +323,7 @@ class Hy3Client:
 
             except APIStatusError as e:
                 if e.status_code >= 500 and attempt < self.max_retries:
-                    delay = self.base_delay * (2 ** attempt)
+                    delay = retry_delay(attempt, self.base_delay, e)
                     time.sleep(delay)
                 else:
                     raise RuntimeError(f"API 错误 [{e.status_code}]: {e.message}") from e

--- a/examples/06_error_handling.py
+++ b/examples/06_error_handling.py
@@ -1,0 +1,349 @@
+"""
+Hy3 API - 错误处理与重试示例 / Error Handling & Retry Example
+包含基础错误捕获、指数退避重试、流式请求错误处理
+"""
+
+import time
+from openai import (
+    OpenAI,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    APIStatusError,
+    BadRequestError,
+    NotFoundError,
+)
+
+# ============================================================
+# 配置 / Configuration
+# ============================================================
+BASE_URL = "http://127.0.0.1:8000/v1"
+API_KEY = "EMPTY"
+MODEL = "hy3"
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+# ============================================================
+# 示例 1：基础错误捕获 / Basic Error Catching
+# ============================================================
+def basic_error_handling():
+    """演示各种错误类型的捕获和处理"""
+    print("=" * 60)
+    print("基础错误处理 / Basic Error Handling")
+    print("=" * 60)
+
+    try:
+        response = client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "你好"}],
+            timeout=30.0,  # 30秒超时
+        )
+        print(f"\n成功：{response.choices[0].message.content}")
+
+    except APIConnectionError as e:
+        print(f"\n[连接错误] {e}")
+        print("  排查：请检查服务是否已启动，端口是否正确。")
+        print("  命令：curl http://127.0.0.1:8000/v1/models")
+
+    except APITimeoutError as e:
+        print(f"\n[超时错误] {e}")
+        print("  排查：请求超时，请增加 timeout 参数或减少 max_tokens。")
+
+    except RateLimitError as e:
+        print(f"\n[限流错误] {e}")
+        print("  排查：请求频率过高，请稍后重试或降低并发。")
+
+    except BadRequestError as e:
+        print(f"\n[请求错误] 400: {e.message}")
+        print("  排查：请求参数格式有误，请检查 messages 结构。")
+
+    except NotFoundError as e:
+        print(f"\n[未找到] 404: {e.message}")
+        print("  排查：模型名不匹配，请确认与 --served-model-name 一致。")
+
+    except APIStatusError as e:
+        print(f"\n[服务端错误] {e.status_code}: {e.message}")
+        print("  排查：服务端内部错误，请稍后重试。")
+
+    except Exception as e:
+        print(f"\n[未知错误] {type(e).__name__}: {e}")
+
+
+# ============================================================
+# 示例 2：指数退避重试 / Exponential Backoff Retry
+# ============================================================
+def call_with_retry(
+    messages: list,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    timeout: float = 60.0,
+    **kwargs,
+):
+    """
+    带指数退避的 API 调用
+
+    参数:
+        messages: 对话消息列表
+        max_retries: 最大重试次数
+        base_delay: 基础延迟秒数（每次翻倍）
+        timeout: 单次请求超时时间
+        **kwargs: 传递给 create() 的额外参数
+
+    返回:
+        API 响应对象
+
+    异常:
+        重试次数用尽后抛出原始异常
+    """
+    last_error = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model=MODEL,
+                messages=messages,
+                timeout=timeout,
+                **kwargs,
+            )
+            if attempt > 0:
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] 成功！")
+            return response
+
+        except (APIConnectionError, APITimeoutError) as e:
+            last_error = e
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
+                      f"{type(e).__name__}，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] 重试次数用尽。")
+
+        except RateLimitError as e:
+            last_error = e
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
+                      f"限流（429），{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] 限流重试次数用尽。")
+
+        except APIStatusError as e:
+            last_error = e
+            if e.status_code >= 500 and attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"  [尝试 {attempt + 1}/{max_retries + 1}] "
+                      f"服务端错误（{e.status_code}），{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                # 4xx 错误不重试，直接抛出
+                raise
+
+        except (BadRequestError, NotFoundError):
+            # 客户端错误不重试
+            raise
+
+    raise last_error
+
+
+def demo_retry():
+    """演示指数退避重试"""
+    print("\n" + "=" * 60)
+    print("指数退避重试 / Exponential Backoff Retry")
+    print("=" * 60)
+
+    try:
+        response = call_with_retry(
+            messages=[{"role": "user", "content": "你好！"}],
+            max_retries=3,
+            base_delay=1.0,
+        )
+        print(f"\n回复：{response.choices[0].message.content}")
+    except Exception as e:
+        print(f"\n最终失败：{type(e).__name__}: {e}")
+
+
+# ============================================================
+# 示例 3：流式请求的错误处理 / Streaming Error Handling
+# ============================================================
+def stream_with_retry(
+    messages: list,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    timeout: float = 60.0,
+):
+    """
+    带重试的流式请求
+
+    注意：流式请求的错误可能在迭代过程中发生，
+    需要在 for 循环外层捕获异常。
+    """
+    last_error = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            stream = client.chat.completions.create(
+                model=MODEL,
+                messages=messages,
+                stream=True,
+                timeout=timeout,
+            )
+
+            full_content = ""
+            print("回复：", end="")
+
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    print(delta.content, end="", flush=True)
+                    full_content += delta.content
+
+            print()  # 换行
+            return full_content
+
+        except (APIConnectionError, APITimeoutError, RateLimitError) as e:
+            last_error = e
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"\n  [重试 {attempt + 1}] {type(e).__name__}，{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                print(f"\n  [重试 {attempt + 1}] 重试次数用尽。")
+
+        except APIStatusError as e:
+            if e.status_code >= 500 and attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                print(f"\n  [重试 {attempt + 1}] 服务端错误（{e.status_code}），{delay:.1f}s 后重试...")
+                time.sleep(delay)
+            else:
+                raise
+
+    raise last_error
+
+
+def demo_stream_retry():
+    """演示流式请求的重试"""
+    print("\n" + "=" * 60)
+    print("流式请求重试 / Stream Retry")
+    print("=" * 60)
+
+    try:
+        content = stream_with_retry(
+            messages=[{"role": "user", "content": "用一句话介绍Python"}],
+            max_retries=3,
+        )
+        print(f"\n总字符数：{len(content)}")
+    except Exception as e:
+        print(f"\n最终失败：{type(e).__name__}: {e}")
+
+
+# ============================================================
+# 示例 4：生产级封装 / Production-Ready Wrapper
+# ============================================================
+class Hy3Client:
+    """生产级 Hy3 API 客户端，内置错误处理和重试"""
+
+    def __init__(
+        self,
+        base_url: str = BASE_URL,
+        api_key: str = API_KEY,
+        model: str = MODEL,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        timeout: float = 60.0,
+    ):
+        self.client = OpenAI(base_url=base_url, api_key=api_key)
+        self.model = model
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.timeout = timeout
+
+    def chat(self, messages: list, stream: bool = False, **kwargs) -> str:
+        """
+        发送聊天请求并返回文本内容
+
+        自动处理重试逻辑，区分可重试和不可重试错误。
+        """
+        last_error = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                if stream:
+                    return self._stream_chat(messages, **kwargs)
+                else:
+                    response = self.client.chat.completions.create(
+                        model=self.model,
+                        messages=messages,
+                        timeout=self.timeout,
+                        **kwargs,
+                    )
+                    return response.choices[0].message.content
+
+            except (APIConnectionError, APITimeoutError, RateLimitError) as e:
+                last_error = e
+                if attempt < self.max_retries:
+                    delay = self.base_delay * (2 ** attempt)
+                    time.sleep(delay)
+                else:
+                    raise RuntimeError(
+                        f"请求失败（已重试 {self.max_retries} 次）：{e}"
+                    ) from e
+
+            except APIStatusError as e:
+                if e.status_code >= 500 and attempt < self.max_retries:
+                    delay = self.base_delay * (2 ** attempt)
+                    time.sleep(delay)
+                else:
+                    raise RuntimeError(f"API 错误 [{e.status_code}]: {e.message}") from e
+
+            except (BadRequestError, NotFoundError) as e:
+                raise RuntimeError(f"请求错误（不可重试）：{e}") from e
+
+        raise RuntimeError(f"请求失败：{last_error}")
+
+    def _stream_chat(self, messages: list, **kwargs) -> str:
+        """流式聊天，收集完整内容"""
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            stream=True,
+            timeout=self.timeout,
+            **kwargs,
+        )
+        parts = []
+        for chunk in stream:
+            if chunk.choices[0].delta.content:
+                parts.append(chunk.choices[0].delta.content)
+        return "".join(parts)
+
+
+def demo_production_client():
+    """演示生产级客户端使用"""
+    print("\n" + "=" * 60)
+    print("生产级客户端 / Production Client")
+    print("=" * 60)
+
+    hy3 = Hy3Client(max_retries=3, timeout=60.0)
+
+    try:
+        result = hy3.chat(
+            messages=[
+                {"role": "system", "content": "你是一位专业的技术顾问。"},
+                {"role": "user", "content": "什么是向量数据库？"},
+            ],
+        )
+        print(f"\n回复：{result}")
+    except RuntimeError as e:
+        print(f"\n错误：{e}")
+
+
+# ============================================================
+# 运行示例
+# ============================================================
+if __name__ == "__main__":
+    basic_error_handling()
+    demo_retry()
+    demo_stream_retry()
+    demo_production_client()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,81 @@
+# Hy3 API Examples
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本目录包含 Hy3 API 的快速开始指南和 6 个完整示例，帮助开发者快速接入并使用 Hy3 API。
+
+### 前置条件
+
+1. 部署 Hy3 服务（参考[部署指南](../README_CN.md#推理和部署)）
+2. Python 3.10+ 环境
+3. 安装依赖：`pip install openai>=1.0`
+
+### 文档
+
+- [快速开始](./quickstart.md) — 基础信息、最小可运行示例、参数说明、常见报错排查
+
+### 示例列表
+
+| # | 示例 | Markdown | Python | 说明 |
+|:---|:---|:---|:---|:---|
+| 1 | 基础对话 | [01_basic_chat.md](./01_basic_chat.md) | [01_basic_chat.py](./01_basic_chat.py) | 单轮/多轮对话、System Prompt |
+| 2 | 流式输出 | [02_streaming.md](./02_streaming.md) | [02_streaming.py](./02_streaming.py) | 流式请求、逐 chunk 解析 |
+| 3 | 流式 vs 非流式 | [03_streaming_vs_non_streaming.md](./03_streaming_vs_non_streaming.md) | [03_streaming_vs_non_streaming.py](./03_streaming_vs_non_streaming.py) | 首 token 时延/总耗时对比 |
+| 4 | 工具调用 | [04_tool_calling.md](./04_tool_calling.md) | [04_tool_calling.py](./04_tool_calling.py) | 单次调用、多轮工具循环、并行调用 |
+| 5 | 思考模式 | [05_reasoning_mode.md](./05_reasoning_mode.md) | [05_reasoning_mode.py](./05_reasoning_mode.py) | no_think/low/high 对比 |
+| 6 | 错误处理 | [06_error_handling.md](./06_error_handling.md) | [06_error_handling.py](./06_error_handling.py) | 超时/限流/网络错误重试与退避 |
+
+### 快速运行
+
+```bash
+# 修改每个 .py 文件顶部的 BASE_URL 为你的服务地址
+python examples/01_basic_chat.py
+python examples/02_streaming.py
+python examples/03_streaming_vs_non_streaming.py
+python examples/04_tool_calling.py
+python examples/05_reasoning_mode.py
+python examples/06_error_handling.py
+```
+
+---
+
+## English
+
+This directory contains a quickstart guide and 6 complete examples for the Hy3 API.
+
+### Prerequisites
+
+1. Deploy Hy3 service (see [Deployment Guide](../README.md#deployment))
+2. Python 3.10+ environment
+3. Install dependency: `pip install openai>=1.0`
+
+### Documentation
+
+- [Quickstart](./quickstart.md) — Basic info, minimal runnable examples, parameter reference, troubleshooting
+
+### Examples
+
+| # | Example | Markdown | Python | Description |
+|:---|:---|:---|:---|:---|
+| 1 | Basic Chat | [01_basic_chat.md](./01_basic_chat.md) | [01_basic_chat.py](./01_basic_chat.py) | Single/multi-turn chat, System Prompt |
+| 2 | Streaming | [02_streaming.md](./02_streaming.md) | [02_streaming.py](./02_streaming.py) | Streaming request, chunk parsing |
+| 3 | Stream vs Non-Stream | [03_streaming_vs_non_streaming.md](./03_streaming_vs_non_streaming.md) | [03_streaming_vs_non_streaming.py](./03_streaming_vs_non_streaming.py) | TTFT & total time comparison |
+| 4 | Tool Calling | [04_tool_calling.md](./04_tool_calling.md) | [04_tool_calling.py](./04_tool_calling.py) | Single call, multi-round loop, parallel calls |
+| 5 | Reasoning Mode | [05_reasoning_mode.md](./05_reasoning_mode.md) | [05_reasoning_mode.py](./05_reasoning_mode.py) | no_think/low/high comparison |
+| 6 | Error Handling | [06_error_handling.md](./06_error_handling.md) | [06_error_handling.py](./06_error_handling.py) | Timeout/rate-limit/network retry with backoff |
+
+### Quick Run
+
+```bash
+# Update BASE_URL at the top of each .py file to your server address
+python examples/01_basic_chat.py
+python examples/02_streaming.py
+python examples/03_streaming_vs_non_streaming.py
+python examples/04_tool_calling.py
+python examples/05_reasoning_mode.py
+python examples/06_error_handling.py
+```

--- a/examples/quickstart.md
+++ b/examples/quickstart.md
@@ -1,0 +1,260 @@
+# Hy3 API 快速开始 / Quickstart
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+本指南帮助你在 **5 分钟内** 完成第一次 Hy3 API 调用，并在 **半小时内** 掌握主要能力。
+
+### 前置条件
+
+- 已部署 Hy3 服务（参考 [部署指南](../README_CN.md#推理和部署)）
+- Python 3.10+ 环境
+- 安装 OpenAI SDK：`pip install openai>=1.0`
+- （可选）安装 curl，用于命令行示例
+
+---
+
+### 基础信息
+
+| 配置项 | 值 | 说明 |
+|:---|:---|:---|
+| Base URL | `http://<YOUR_SERVER_IP>:8000/v1` | API 服务地址，默认本地 `http://127.0.0.1:8000/v1` |
+| API Key | `"EMPTY"` 或任意非空字符串 | 自部署场景无需真实密钥，填写任意值即可 |
+| Model | `"hy3"` | 模型名称，与部署时 `--served-model-name` 参数保持一致 |
+| 协议 | OpenAI 兼容 API | 支持 `/v1/chat/completions` 等标准接口 |
+
+> **注意**：如使用云服务商托管的 Hy3 API，请将 Base URL 和 API Key 替换为服务商提供的值。
+
+---
+
+### 最小可运行示例
+
+#### Python（OpenAI SDK）
+
+```python
+from openai import OpenAI
+
+# 初始化客户端
+client = OpenAI(
+    base_url="http://127.0.0.1:8000/v1",
+    api_key="EMPTY",  # 自部署场景无需真实密钥
+)
+
+# 发送请求
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "你好！请简单介绍一下你自己。"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+
+print(response.choices[0].message.content)
+```
+
+#### curl
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPTY" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "你好！请简单介绍一下你自己。"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0
+  }'
+```
+
+---
+
+### 参数说明
+
+#### 标准参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+|:---|:---|:---|:---|
+| `model` | string | — | **必填**。模型名称，如 `"hy3"` |
+| `messages` | list | — | **必填**。对话消息列表，每条包含 `role`（`system`/`user`/`assistant`）和 `content` |
+| `temperature` | float | `0.9` | 控制生成随机性。推荐值 `0.9`，范围 `[0, 2]`，值越高输出越多样 |
+| `top_p` | float | `1.0` | 核采样。推荐值 `1.0`，与 `temperature` 不建议同时修改 |
+| `max_tokens` | int | `4096` | 最大生成 token 数。根据任务复杂度调整，上限受模型上下文长度（256K）限制 |
+| `stop` | string / list | `null` | 停止生成的标记。如 `"stop": ["\n\n", "END"]`，遇到任一标记即停止 |
+| `stream` | bool | `false` | 是否开启流式输出，详见 [流式示例](./02_streaming.md) |
+| `tools` | list | `null` | 工具定义列表，详见 [工具调用示例](./04_tool_calling.md) |
+
+#### 思考模式（Reasoning Mode）
+
+通过 `extra_body` 传入，控制模型是否展示思维链：
+
+| `reasoning_effort` 值 | 行为 | 适用场景 |
+|:---|:---|:---|
+| `"no_think"`（默认） | 直接输出结果，不展示思考过程 | 日常对话、简单问答 |
+| `"low"` | 展示简要思考过程 | 中等复杂度任务 |
+| `"high"` | 展示完整深度思维链 | 数学、编程、复杂推理 |
+
+```python
+# 开启深度思考
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "证明根号2是无理数"}],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+```
+
+> 详见 [思考模式示例](./05_reasoning_mode.md)
+
+---
+
+### 常见报错排查
+
+| 错误信息 | 原因 | 解决方案 |
+|:---|:---|:---|
+| `Connection refused` | 服务未启动或端口错误 | 确认 vLLM/SGLang 服务已启动，检查端口配置 |
+| `The model 'xxx' does not exist` | 模型名不匹配 | 确认 `model` 参数与部署时的 `--served-model-name` 一致 |
+| `API rate limit reached` | 请求频率超限 | 降低并发请求数，或实现退避重试（参考 [错误处理示例](./06_error_handling.md)） |
+| `Request timed out` | 生成时间过长或网络问题 | 适当减小 `max_tokens`，或增加客户端超时时间 |
+| `Invalid value for 'messages'` | 消息格式错误 | 检查每条消息是否包含 `role` 和 `content` 字段 |
+| `CUDA out of memory` | GPU 显存不足 | Hy3 总参数 295B，建议使用 8×H20-3e 或同等显存配置 |
+| `Tool call parse error` | 工具调用格式错误 | 确认 `tools` 参数格式符合 OpenAI 规范，参考 [工具调用示例](./04_tool_calling.md) |
+
+---
+
+## English
+
+This guide helps you make your **first Hy3 API call in 5 minutes** and master the main capabilities within **30 minutes**.
+
+### Prerequisites
+
+- Hy3 service deployed (see [Deployment Guide](../README.md#deployment))
+- Python 3.10+ environment
+- OpenAI SDK installed: `pip install openai>=1.0`
+- (Optional) curl for command-line examples
+
+---
+
+### Basic Information
+
+| Config | Value | Description |
+|:---|:---|:---|
+| Base URL | `http://<YOUR_SERVER_IP>:8000/v1` | API server address, default `http://127.0.0.1:8000/v1` |
+| API Key | `"EMPTY"` or any non-empty string | Not required for self-hosted deployment |
+| Model | `"hy3"` | Must match `--served-model-name` used at launch |
+| Protocol | OpenAI-compatible API | Supports `/v1/chat/completions` and other standard endpoints |
+
+> **Note**: If using a cloud-hosted Hy3 API, replace the Base URL and API Key with your provider's values.
+
+---
+
+### Minimal Runnable Examples
+
+#### Python (OpenAI SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://127.0.0.1:8000/v1",
+    api_key="EMPTY",
+)
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "Hello! Can you briefly introduce yourself?"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+)
+
+print(response.choices[0].message.content)
+```
+
+#### curl
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPTY" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "Hello! Can you briefly introduce yourself?"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0
+  }'
+```
+
+---
+
+### Parameter Reference
+
+#### Standard Parameters
+
+| Parameter | Type | Default | Description |
+|:---|:---|:---|:---|
+| `model` | string | — | **Required**. Model name, e.g. `"hy3"` |
+| `messages` | list | — | **Required**. List of messages with `role` (`system`/`user`/`assistant`) and `content` |
+| `temperature` | float | `0.9` | Sampling randomness. Recommended `0.9`, range `[0, 2]` |
+| `top_p` | float | `1.0` | Nucleus sampling. Recommended `1.0`. Avoid changing together with `temperature` |
+| `max_tokens` | int | `4096` | Max tokens to generate. Adjust based on task complexity |
+| `stop` | string / list | `null` | Stop sequences, e.g. `"stop": ["\n\n", "END"]` |
+| `stream` | bool | `false` | Enable streaming output, see [Streaming Example](./02_streaming.md) |
+| `tools` | list | `null` | Tool definitions, see [Tool Calling Example](./04_tool_calling.md) |
+
+#### Reasoning Mode
+
+Control chain-of-thought visibility via `extra_body`:
+
+| `reasoning_effort` Value | Behavior | Use Case |
+|:---|:---|:---|
+| `"no_think"` (default) | Direct output, no reasoning trace | Casual chat, simple Q&A |
+| `"low"` | Brief reasoning shown | Medium complexity tasks |
+| `"high"` | Full deep chain-of-thought | Math, coding, complex reasoning |
+
+```python
+# Enable deep reasoning
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Prove that sqrt(2) is irrational"}],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+```
+
+> See [Reasoning Mode Example](./05_reasoning_mode.md)
+
+---
+
+### Troubleshooting
+
+| Error | Cause | Solution |
+|:---|:---|:---|
+| `Connection refused` | Server not running or wrong port | Verify vLLM/SGLang is running; check port config |
+| `The model 'xxx' does not exist` | Model name mismatch | Ensure `model` matches `--served-model-name` |
+| `API rate limit reached` | Too many requests | Reduce concurrency or implement retry with backoff ([Error Handling](./06_error_handling.md)) |
+| `Request timed out` | Generation too long or network issue | Reduce `max_tokens` or increase client timeout |
+| `Invalid value for 'messages'` | Malformed messages | Ensure each message has `role` and `content` fields |
+| `CUDA out of memory` | Insufficient GPU memory | Hy3 has 295B params; use 8×H20-3e or equivalent |
+| `Tool call parse error` | Invalid tool definition format | Verify `tools` follows OpenAI spec ([Tool Calling](./04_tool_calling.md)) |
+
+---
+
+## Examples 目录
+
+| # | 示例 | 文件 |
+|:---|:---|:---|
+| 1 | 基础对话（单轮/多轮） | [01_basic_chat.md](./01_basic_chat.md) / [01_basic_chat.py](./01_basic_chat.py) |
+| 2 | 流式输出 | [02_streaming.md](./02_streaming.md) / [02_streaming.py](./02_streaming.py) |
+| 3 | 流式 vs 非流式对比 | [03_streaming_vs_non_streaming.md](./03_streaming_vs_non_streaming.md) / [03_streaming_vs_non_streaming.py](./03_streaming_vs_non_streaming.py) |
+| 4 | 工具调用 | [04_tool_calling.md](./04_tool_calling.md) / [04_tool_calling.py](./04_tool_calling.py) |
+| 5 | 思考模式 | [05_reasoning_mode.md](./05_reasoning_mode.md) / [05_reasoning_mode.py](./05_reasoning_mode.py) |
+| 6 | 错误处理与重试 | [06_error_handling.md](./06_error_handling.md) / [06_error_handling.py](./06_error_handling.py) |

--- a/examples/quickstart.md
+++ b/examples/quickstart.md
@@ -25,8 +25,19 @@
 | API Key | `"EMPTY"` 或任意非空字符串 | 自部署场景无需真实密钥，填写任意值即可 |
 | Model | `"hy3"` | 模型名称，与部署时 `--served-model-name` 参数保持一致 |
 | 协议 | OpenAI 兼容 API | 支持 `/v1/chat/completions` 等标准接口 |
+| 速率限制 | 自部署无固定 RPM/TPM | 实际上限取决于推理服务配置和 GPU 容量；托管服务以供应商控制台/响应头为准 |
 
 > **注意**：如使用云服务商托管的 Hy3 API，请将 Base URL 和 API Key 替换为服务商提供的值。
+
+#### 速率限制与并发
+
+Hy3 模型仓库本身没有设置统一的每分钟请求数（RPM）或 token 数（TPM）。自部署时，
+可承载并发取决于 vLLM/SGLang 的调度配置、上下文长度、输出长度和 GPU 容量；建议先压测，
+再在 API 网关或反向代理中设置适合本机容量的并发/RPM/TPM 上限。托管 API 的配额可能随
+账户和服务商变化，应以服务商控制台及响应头为准，不要把示例中的并发数当成平台配额。
+
+客户端收到 HTTP 429 时应优先遵循 `Retry-After` 响应头；没有该响应头时，使用带随机抖动
+的指数退避。完整实现见 [错误处理与重试](./06_error_handling.md)。
 
 ---
 
@@ -148,8 +159,23 @@ This guide helps you make your **first Hy3 API call in 5 minutes** and master th
 | API Key | `"EMPTY"` or any non-empty string | Not required for self-hosted deployment |
 | Model | `"hy3"` | Must match `--served-model-name` used at launch |
 | Protocol | OpenAI-compatible API | Supports `/v1/chat/completions` and other standard endpoints |
+| Rate limit | No fixed RPM/TPM for self-hosting | Capacity depends on serving configuration and GPUs; for managed APIs, use provider quotas and response headers |
 
 > **Note**: If using a cloud-hosted Hy3 API, replace the Base URL and API Key with your provider's values.
+
+#### Rate limits and concurrency
+
+The Hy3 model repository does not impose a universal requests-per-minute (RPM)
+or tokens-per-minute (TPM) quota. For self-hosting, safe concurrency depends on
+the vLLM/SGLang scheduler configuration, context/output lengths, and available
+GPU capacity. Benchmark the deployment, then enforce an appropriate
+concurrency/RPM/TPM policy at an API gateway or reverse proxy. Managed API
+quotas can vary by provider and account; use the provider dashboard and
+response headers instead of treating an example concurrency value as a quota.
+
+On HTTP 429, clients should honor `Retry-After` first and otherwise use
+exponential backoff with jitter. See [Error Handling & Retry](./06_error_handling.md)
+for a complete implementation.
 
 ---
 


### PR DESCRIPTION
   新增 examples/ 目录，包含 quickstart.md 和 6 个完整示例，每个示例均提供中英双语 markdown 文档和可运行的 Python 脚本。

   内容涵盖：
   1. quickstart.md — 基础信息 + curl/Python 最小可运行示例 + 参数说明 + 常见报错排查
   2. 01_basic_chat — 单轮/多轮对话、System Prompt
   3. 02_streaming — 流式请求、逐 chunk 解析
   4. 03_streaming_vs_non_streaming — 首 token 时延/总耗时对比
   5. 04_tool_calling — 单次调用、多轮工具循环、并行调用
   6. 05_reasoning_mode — no_think/low/high 思考模式对比
   7. 06_error_handling — 超时/限流/网络错误的指数退避重试与生产级客户端封装

   Closes #1

   本轮验收补充：
   8. 明确自托管 Hy3 没有项目级统一 RPM/TPM，实际限额由部署容量和网关/服务商策略决定
   9. 429 重试优先遵循 Retry-After（秒数或 HTTP 日期），缺失时采用带 jitter 的指数退避，并设置等待上限

   验证：python -m compileall -q examples、git diff --check 均通过。