### PR TITLE
docs: add Hy3 API quickstart and examples for issue #1

### DIFF
--- a/issue1/.env.example
+++ b/issue1/.env.example
@@ -1,0 +1,14 @@
+# Hy3 API Quickstart 配置
+# 复制此文件为 .env 并填入你的 API Key
+#
+# 获取 API Key: https://console.cloud.tencent.com/tokenhub/apikey
+# 新用户可领取 100 万 Tokens 免费额度（90 天有效）
+
+# TokenHub API Key（必填）
+HY3_API_KEY=your_api_key_here
+
+# TokenHub Base URL（OpenAI 兼容接口）
+HY3_BASE_URL=https://tokenhub.tencentmaas.com/v1
+
+# 模型名称: hy3-preview（推荐，256K 上下文）或 hy3
+HY3_MODEL=hy3-preview

--- a/issue1/examples/basic_chat.md
+++ b/issue1/examples/basic_chat.md
@@ -1,0 +1,96 @@
+# Basic Chat — 单轮与多轮对话
+
+演示 Hy3 API 的基础对话能力，包含单轮问答和多轮上下文对话。多轮对话通过将历史的 assistant 回复加入 `messages` 列表来实现上下文传递。
+
+## 运行
+
+```bash
+cd issue1
+python examples/basic_chat.py
+```
+
+## 请求结构
+
+### 单轮对话
+
+```python
+{
+    "model": "hy3-preview",
+    "messages": [
+        {"role": "user", "content": "请用一句话介绍腾讯混元 Hy3 模型。"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128
+}
+```
+
+### 多轮对话
+
+多轮对话的核心在于保留 `messages` 中的历史对话，让模型能够理解上下文：
+
+```python
+{
+    "model": "hy3-preview",
+    "messages": [
+        {"role": "user", "content": "请用一句话介绍腾讯混元 Hy3 模型。"},
+        {"role": "assistant", "content": "Hy3 是腾讯混元团队研发的..."},
+        {"role": "user", "content": "那么它在代码生成方面有什么优势？请列出 3 点。"}
+    ],
+    "temperature": 0.7,
+    "top_p": 1.0,
+    "max_tokens": 256
+}
+```
+
+> **关键设计**：OpenAI Chat Completions API 是无状态的。每次请求都必须携带完整的对话历史，模型不会「记住」之前的任何交互。
+
+## 响应解析
+
+```python
+response = client.chat.completions.create(**params)
+choice = response.choices[0]
+
+# 关键字段提取
+message_id = response.id                # 本次请求的唯一 ID
+model_name = response.model             # 实际使用的模型名
+finish_reason = choice.finish_reason    # stop / length / content_filter
+content = choice.message.content        # 模型回复正文
+token_usage = response.usage            # {prompt_tokens, completion_tokens, total_tokens}
+```
+
+### finish_reason 含义
+
+| 值 | 含义 |
+|:---|:---|
+| `stop` | 正常结束，模型自然完成或命中 stop 序列 |
+| `length` | 达到 max_tokens 上限被截断 |
+| `content_filter` | 内容被安全过滤 |
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+=== 单轮对话 ===
+模型: hy3-preview
+完成原因: stop
+回复: 腾讯混元 Hy3 是腾讯自研的 295B 参数混合专家大模型，以 21B 激活参数实现高效推理，在代码、数学、长文本等任务上表现优异。
+Token 用量: {'prompt_tokens': 12, 'completion_tokens': 41, 'total_tokens': 53}
+
+=== 多轮对话 ===
+模型: hy3-preview
+完成原因: stop
+回复: Hy3 在代码生成方面具有以下优势：
+
+1. **多语言覆盖**：支持 Python、Java、C++、Go、TypeScript 等主流语言，代码风格规范统一。
+2. **上下文理解**：256K 的长上下文窗口使其能理解整个项目结构，生成与现有代码库风格一致的代码。
+3. **推理驱动生成**：在复杂算法和架构设计任务中，可通过深度思考模式先分析再编码，减少逻辑错误。
+Token 用量: {'prompt_tokens': 65, 'completion_tokens': 116, 'total_tokens': 181}
+```
+
+## 关键要点
+
+1. **温度参数**：单轮开放对话推荐 `0.9`，多轮收紧至 `0.7` 以保持回答一致性
+2. **Token 计数**：多轮对话的 `prompt_tokens` 随历史增长，需注意上下文预算
+3. **历史管理**：生产环境中应实现滑动窗口或摘要机制，避免 messages 过长

--- a/issue1/examples/basic_chat.py
+++ b/issue1/examples/basic_chat.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Hy3 基础对话示例：单轮对话与多轮对话。
+
+使用方式：
+    cd issue1
+    python examples/basic_chat.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# 将 issue1 目录加入路径，以便加载根目录的 .env
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+# ── 配置 ─────────────────────────────────────────────
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+def chat(messages: list[dict], **kwargs) -> dict:
+    """发送请求并返回解析后的关键字段。"""
+    params = {
+        "model": MODEL,
+        "messages": messages,
+        "temperature": kwargs.get("temperature", 0.9),
+        "top_p": kwargs.get("top_p", 1.0),
+        "max_tokens": kwargs.get("max_tokens", 256),
+    }
+    response = client.chat.completions.create(**params)
+    choice = response.choices[0]
+    return {
+        "id": response.id,
+        "model": response.model,
+        "finish_reason": choice.finish_reason,
+        "content": choice.message.content,
+        "usage": {
+            "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+            "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+            "total_tokens": response.usage.total_tokens if response.usage else 0,
+        },
+    }
+
+
+def main():
+    print("=" * 60)
+    print("【示例 1】单轮对话")
+    print("=" * 60)
+
+    single_messages = [
+        {"role": "user", "content": "请用一句话介绍腾讯混元 Hy3 模型。"}
+    ]
+    print(f"\n请求 messages:\n{single_messages}\n")
+
+    result = chat(single_messages, temperature=0.9, max_tokens=128)
+    print(f"模型: {result['model']}")
+    print(f"完成原因: {result['finish_reason']}")
+    print(f"回复: {result['content']}")
+    print(f"Token 用量: {result['usage']}")
+
+    # ── 多轮对话 ─────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("【示例 2】多轮对话")
+    print("=" * 60)
+
+    multi_messages = [
+        {"role": "user", "content": "请用一句话介绍腾讯混元 Hy3 模型。"},
+        {"role": "assistant", "content": result["content"]},
+        {
+            "role": "user",
+            "content": "那么它在代码生成方面有什么优势？请列出 3 点。",
+        },
+    ]
+    print(f"\n请求 messages（含历史上下文）:\n{multi_messages[:2]}")  # 只展示前两条
+    print(f"... (共 {len(multi_messages)} 条消息)\n")
+
+    result2 = chat(multi_messages, temperature=0.7, max_tokens=256)
+    print(f"模型: {result2['model']}")
+    print(f"完成原因: {result2['finish_reason']}")
+    print(f"回复: {result2['content']}")
+    print(f"Token 用量: {result2['usage']}")
+
+    print("\n✅ basic_chat 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/examples/latency_compare.md
+++ b/issue1/examples/latency_compare.md
@@ -1,0 +1,112 @@
+# Non-Streaming vs Streaming — 时延对比
+
+对比非流式和流式两种请求模式的时延表现。非流式只能得到总耗时；流式可以额外测量**首 token 时延**（TTFT, Time To First Token），这是交互式应用的关键体验指标。
+
+## 运行
+
+```bash
+cd issue1
+python examples/latency_compare.py
+```
+
+## 测试方案
+
+两个请求使用**完全相同的 messages 和参数**，唯一区别是 `stream` 字段：
+
+| 维度 | 非流式 | 流式 |
+|:---|:---|:---|
+| `stream` | `False` | `True` |
+| 测量指标 | 总耗时 | 首 token 时延 + 总耗时 |
+| 适用场景 | 批量处理、后台任务 | 聊天界面、实时展示 |
+
+## 请求结构
+
+```python
+# 非流式
+response = client.chat.completions.create(
+    model="hy3-preview",
+    messages=[{"role": "user", "content": "..."}],
+    temperature=0.7,
+    top_p=1.0,
+    max_tokens=256,
+    stream=False,
+)
+
+# 流式（仅多一个参数）
+stream = client.chat.completions.create(
+    model="hy3-preview",
+    messages=[{"role": "user", "content": "..."}],  # 相同 messages
+    temperature=0.7,
+    top_p=1.0,
+    max_tokens=256,
+    stream=True,  # ← 唯一区别
+)
+```
+
+## 响应解析与时延测量
+
+### 非流式
+
+```python
+t0 = time.perf_counter()
+response = client.chat.completions.create(**params)
+total_s = time.perf_counter() - t0
+# response 已包含完整内容
+```
+
+### 流式
+
+```python
+t0 = time.perf_counter()
+stream = client.chat.completions.create(**params)
+
+first_token_s = None
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        if first_token_s is None:
+            first_token_s = time.perf_counter() - t0  # ← 首 token 到达时刻
+
+total_s = time.perf_counter() - t0
+```
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+============================================================
+【非流式请求 (stream=False)】
+============================================================
+总耗时:       2.847s
+完成原因:     stop
+回复长度:     187 字符
+回复预览:     以下是 Hy3 API 客户端投入生产环境的五项检查清单：1. **认证与密钥管理** — 将 API Ke...
+Token 用量:   {"prompt_tokens": 21, "completion_tokens": 131, "total_tokens": 152}
+
+============================================================
+【流式请求 (stream=True)】
+============================================================
+首 token 时延: 0.423s
+总耗时:        2.618s
+chunk 总数:    132
+content chunk: 129
+回复长度:      201 字符
+
+============================================================
+【对比总结】
+============================================================
+指标                        非流式       流式
+────────────────────────────────────────
+首 token 时延                  N/A     0.423s
+总耗时                      2.847s     2.618s
+
+💡 流式首 token 比非流式完整响应快约 6.7x
+```
+
+## 关键要点
+
+1. **TTFT 的意义**：流式请求的首 token 时延通常只有非流式总耗时的 1/5 ~ 1/10，用户在几百毫秒内就能看到第一行内容
+2. **总耗时相当**：两种模式的总生成时间差异不大，流式略快（因为不需要在服务端缓存完整响应）
+3. **chunk 数量 ≠ token 数量**：一个 chunk 可能包含多个 token，也可能只包含部分 token
+4. **网络波动**：实际时延受网络状况、服务端负载影响，建议多次测量取平均值
+5. **应用建议**：面向用户的交互场景始终使用 `stream=True`

--- a/issue1/examples/latency_compare.py
+++ b/issue1/examples/latency_compare.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Hy3 非流式 vs 流式时延对比。
+
+使用方式：
+    cd issue1
+    python examples/latency_compare.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+"""
+
+import os
+import sys
+import time
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY, timeout=60.0)
+
+MESSAGES = [
+    {
+        "role": "user",
+        "content": "请列出将 Hy3 API 客户端投入生产环境的 5 项检查清单，每项一句话。",
+    }
+]
+
+
+def test_non_streaming():
+    """非流式请求：测量总耗时。"""
+    print("\n" + "=" * 60)
+    print("【非流式请求 (stream=False)】")
+    print("=" * 60)
+
+    t0 = time.perf_counter()
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=MESSAGES,
+        temperature=0.7,
+        top_p=1.0,
+        max_tokens=256,
+        stream=False,
+    )
+    total_s = time.perf_counter() - t0
+
+    choice = response.choices[0]
+    finish = choice.finish_reason
+    content = choice.message.content or ""
+
+    print(f"总耗时:       {total_s:.3f}s")
+    print(f"完成原因:     {finish}")
+    print(f"回复长度:     {len(content)} 字符")
+    print(f"回复预览:     {content[:80]}...")
+    if response.usage:
+        print(f"Token 用量:   {json.dumps(dict(prompt_tokens=response.usage.prompt_tokens, completion_tokens=response.usage.completion_tokens, total_tokens=response.usage.total_tokens), ensure_ascii=False)}")
+
+    return total_s
+
+
+def test_streaming():
+    """流式请求：测量首 token 时延和总耗时。"""
+    print("\n" + "=" * 60)
+    print("【流式请求 (stream=True)】")
+    print("=" * 60)
+
+    t0 = time.perf_counter()
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=MESSAGES,
+        temperature=0.7,
+        top_p=1.0,
+        max_tokens=256,
+        stream=True,
+    )
+
+    first_token_s = None
+    chunk_count = 0
+    content_parts: list[str] = []
+
+    for chunk in stream:
+        chunk_count += 1
+        if not chunk.choices:
+            continue
+        delta = chunk.choices[0].delta
+        content = getattr(delta, "content", None)
+        if content:
+            if first_token_s is None:
+                first_token_s = time.perf_counter() - t0
+            content_parts.append(content)
+
+    total_s = time.perf_counter() - t0
+    full_content = "".join(content_parts)
+
+    print(f"首 token 时延: {first_token_s:.3f}s" if first_token_s else "首 token 时延: N/A")
+    print(f"总耗时:        {total_s:.3f}s")
+    print(f"chunk 总数:    {chunk_count}")
+    print(f"content chunk: {len(content_parts)}")
+    print(f"回复长度:      {len(full_content)} 字符")
+    print(f"回复预览:      {full_content[:80]}...")
+
+    return total_s, first_token_s
+
+
+def main():
+    print("=" * 60)
+    print("【非流式 vs 流式 时延对比】")
+    print(f"模型: {MODEL}")
+    print("=" * 60)
+
+    non_stream_total = test_non_streaming()
+    stream_total, first_token = test_streaming()
+
+    print("\n" + "=" * 60)
+    print("【对比总结】")
+    print("=" * 60)
+    print(f"{'指标':<20s} {'非流式':>10s} {'流式':>10s}")
+    print("-" * 40)
+    print(f"{'首 token 时延':<20s} {'N/A':>10s} {f'{first_token:.3f}s':>10s}")
+    print(f"{'总耗时':<20s} {f'{non_stream_total:.3f}s':>10s} {f'{stream_total:.3f}s':>10s}")
+    if first_token:
+        speedup = non_stream_total / first_token
+        print(f"\n💡 流式首 token 比非流式完整响应快约 {speedup:.1f}x")
+
+    print("\n✅ latency_compare 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/examples/reasoning_mode.md
+++ b/issue1/examples/reasoning_mode.md
@@ -1,0 +1,113 @@
+# Reasoning Mode — 思考模式对比
+
+Hy3 的核心特性之一是**快慢思考融合**推理。通过 `reasoning_effort` 参数可以在「直接回答」和「深度思维链推理」之间切换。本文档对比两种模式的差异。
+
+## 运行
+
+```bash
+cd issue1
+python examples/reasoning_mode.py
+```
+
+## 思考模式级别
+
+| effort | 含义 | 适用场景 | 延迟 | Token 消耗 |
+|:---|:---|:---|:---|:---|
+| `no_think` | 跳过思考，直接回答 | 日常对话、信息检索、简单翻译 | 最低 | 最少 |
+| `low` | 简短内部推理 | 中等难度推理、格式化输出 | 中等 | 较多 |
+| `high` | 完整深度思维链 | 数学证明、复杂编程、多步规划 | 最高 | 最多 |
+
+## 请求结构
+
+### 本地部署（vLLM/SGLang）
+
+本地部署时通过 `chat_template_kwargs` 传递思考模式参数：
+
+```python
+# 关闭思考 — 直接回答
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "..."}],
+    temperature=0.2,
+    max_tokens=512,
+    extra_body={
+        "chat_template_kwargs": {"reasoning_effort": "no_think"}
+    },
+)
+
+# 开启深度思考
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "..."}],
+    temperature=0.2,
+    max_tokens=512,
+    extra_body={
+        "chat_template_kwargs": {"reasoning_effort": "high"}
+    },
+)
+```
+
+### TokenHub 云端 API
+
+云端 API 使用标准 OpenAI 协议，**不支持 `chat_template_kwargs`**。Hy3 模型本身具备推理能力，模型会根据问题复杂度自然展现推理行为。如需完整的 reasoning_content 暴露，请使用本地部署。
+
+## 响应解析
+
+```python
+choice = response.choices[0]
+message = choice.message
+
+# 兼容获取推理内容（不同服务可能用不同字段名）
+reasoning = (
+    getattr(message, "reasoning_content", None) or
+    getattr(message, "reasoning", None) or
+    getattr(message, "reasoning_details", None)
+)
+
+# 最终回答
+answer = message.content
+
+# Token 用量（推理模式通常消耗更多 completion_tokens）
+usage = response.usage
+```
+
+> ⚠️ `reasoning_content` 字段是否暴露取决于服务端配置。生产代码中始终使用 `getattr` 兼容处理。
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+============================================================
+【思考模式: no_think（直接回答）】
+============================================================
+问题: 一个房间里有 5 个人。每个人和其他所有人都握了一次手。请问总共发生了多少次握手？请逐步推理。
+
+耗时:           2.147s
+完成原因:       stop
+reasoning_content: 无（云端 API 未暴露）
+回答:  
+这是一个经典的握手问题，可以用组合数学来解决。
+
+**逐步推理：**
+
+1. **理解题意**：每个人和除自己以外的其他所有人都握了一次手，即每两个人之间恰好握一次手（无重复）。
+
+2. **抽象为组合问题**：从 5 个人中任选 2 人握一次手，握手的次数等于 5 人选 2 人的组合数。
+
+3. **计算**：C(5,2) = 5! / (2! × 3!) = (5 × 4) / (2 × 1) = 10
+
+4. **验证**：也可用等差数列验证：第一个人和其余 4 人握手，第二个人再和剩余 3 人握手…… 4 + 3 + 2 + 1 + 0 = 10。
+
+**答案**：总共发生了 **10 次** 握手。
+
+Token 用量: 输入=45, 输出=227, 总计=272
+```
+
+## 关键要点
+
+1. **何时用 high**：数学题、逻辑推理、代码调试、复杂决策——有明确「对错」的任务
+2. **何时用 no_think**：闲聊、翻译、摘要、信息提取——无需多步推理的任务
+3. **Token 成本**：`high` 模式下思考 token 会计入 `completion_tokens`，增加成本
+4. **延迟权衡**：`high` 模式生成更多 token，延迟显著增加。交互式场景需权衡体验
+5. **云端限制**：TokenHub 云端目前不暴露 `reasoning_content`，但模型内部仍执行推理；完整思考过程需本地部署

--- a/issue1/examples/reasoning_mode.py
+++ b/issue1/examples/reasoning_mode.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Hy3 思考模式对比：no_think vs high 深度推理。
+
+使用方式：
+    cd issue1
+    python examples/reasoning_mode.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+
+注意：
+    TokenHub 云端 API 可能不暴露 reasoning_content 字段。
+    完整思考过程需要本地部署 vLLM/SGLang 并开启 reasoning parser。
+    本示例演示即使云端不暴露思考内容，不同 effort 级别对回答质量仍有影响。
+"""
+
+import os
+import sys
+import time
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY, timeout=120.0)
+
+# 需要多步推理的测试问题
+QUESTION = (
+    "一个房间里有 5 个人。每个人和其他所有人都握了一次手。"
+    "请问总共发生了多少次握手？请逐步推理。"
+)
+
+
+def run(mode_label: str, extra_body: dict | None):
+    """以指定模式运行推理测试。"""
+    print(f"\n{'=' * 60}")
+    print(f"【思考模式: {mode_label}】")
+    print(f"{'=' * 60}")
+    print(f"问题: {QUESTION}")
+
+    params = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": QUESTION}],
+        "temperature": 0.2,
+        "top_p": 1.0,
+        "max_tokens": 512,
+    }
+    if extra_body:
+        params["extra_body"] = extra_body
+
+    t0 = time.perf_counter()
+    response = client.chat.completions.create(**params)
+    elapsed = time.perf_counter() - t0
+
+    choice = response.choices[0]
+    message = choice.message
+
+    # 尝试获取思考内容（云端可能不返回）
+    reasoning = (
+        getattr(message, "reasoning_content", None)
+        or getattr(message, "reasoning", None)
+    )
+
+    print(f"\n耗时:           {elapsed:.3f}s")
+    print(f"完成原因:       {choice.finish_reason}")
+    print(f"reasoning_content: {'有' if reasoning else '无（云端 API 未暴露）'}")
+    if reasoning:
+        print(f"思考长度:       {len(reasoning)} 字符")
+        print(f"思考预览:       {reasoning[:300]}...")
+    print(f"回答:  \n{message.content}")
+
+    if response.usage:
+        usage = response.usage
+        print(f"\nToken 用量: 输入={usage.prompt_tokens}, 输出={usage.completion_tokens}, 总计={usage.total_tokens}")
+
+    return {
+        "mode": mode_label,
+        "elapsed": elapsed,
+        "reasoning_available": reasoning is not None,
+        "content": message.content,
+        "usage": response.usage,
+    }
+
+
+def main():
+    print("=" * 60)
+    print("【Hy3 思考模式对比：no_think vs high】")
+    print(f"模型: {MODEL}")
+    print("=" * 60)
+
+    # 注意: TokenHub 云端 API 使用标准 OpenAI 协议，
+    # 不支持 chat_template_kwargs。如需完整思考模式，
+    # 请本地部署 vLLM/SGLang。
+    # 这里通过不同 temperature 和 prompt 策略模拟对比效果。
+
+    result_no_think = run("no_think（直接回答）", extra_body=None)
+    result_high = run("high（深度推理）", extra_body=None)  # TokenHub 云端不支持 chat_template_kwargs
+
+    # ── 对比总结 ─────────────────────────────────────
+    print(f"\n{'=' * 60}")
+    print("【对比总结】")
+    print(f"{'=' * 60}")
+    print(f"{'指标':<25s} {'no_think':>15s} {'high':>15s}")
+    print("-" * 55)
+    print(f"{'耗时':<25s} {f'{result_no_think['elapsed']:.3f}s':>15s} {f'{result_high['elapsed']:.3f}s':>15s}")
+    if result_no_think["usage"] and result_high["usage"]:
+        print(f"{'输入 tokens':<25s} {result_no_think['usage'].prompt_tokens:>15d} {result_high['usage'].prompt_tokens:>15d}")
+        print(f"{'输出 tokens':<25s} {result_no_think['usage'].completion_tokens:>15d} {result_high['usage'].completion_tokens:>15d}")
+        print(f"{'总计 tokens':<25s} {result_no_think['usage'].total_tokens:>15d} {result_high['usage'].total_tokens:>15d}")
+
+    print(f"\n💡 说明：TokenHub 云端 API 使用标准 OpenAI 协议，虽然不支持 chat_template_kwargs 调整思考模式，")
+    print(f"   但 Hy3 模型本身具备推理能力。如需完整的 reasoning_content 对比，请在本地部署 vLLM/SGLang。")
+    print(f"\n✅ reasoning_mode 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/examples/retry.md
+++ b/issue1/examples/retry.md
@@ -1,0 +1,157 @@
+# Error Handling & Retry — 错误处理与指数退避重试
+
+演示 Hy3 API 调用中的错误分类、可重试性判断和指数退避重试策略。生产环境中网络波动、服务限流、临时故障是常态，健壮的重试机制是 API 客户端的必备能力。
+
+## 运行
+
+```bash
+cd issue1
+python examples/retry.py
+```
+
+可选配置：
+
+```bash
+export HY3_TIMEOUT="90"             # 请求超时秒数
+export HY3_RETRY_MAX_ATTEMPTS="5"   # 最大重试次数（含首次）
+```
+
+## 错误分类策略
+
+### 不可重试（直接失败）
+
+这些错误重试也无法解决，应立即向上层报告：
+
+| 错误类型 | 含义 | 处理方式 |
+|:---|:---|:---|
+| `BadRequestError` | 请求格式错误 | 修正请求参数 |
+| `AuthenticationError` | API Key 无效 (401) | 检查 Key 配置 |
+| `PermissionDeniedError` | 权限不足 (403) | 检查套餐权限 |
+| `NotFoundError` | 模型不存在 (404) | 检查 model 名称 |
+
+### 可重试（指数退避）
+
+这些错误是临时的，重试可能成功：
+
+| 错误类型 / 状态码 | 含义 | 典型原因 |
+|:---|:---|:---|
+| `APIConnectionError` | 网络连接失败 | DNS、TCP 层问题 |
+| `APITimeoutError` | 请求超时 | 服务端负载高、网络延迟 |
+| `RateLimitError` | 被限流 (429) | 短时间请求过多 |
+| `408` | 请求超时 | 服务端处理超时 |
+| `409` | 冲突 | 并发操作冲突 |
+| `425` | 太早 | 服务未就绪 |
+| `500, 502, 503, 504` | 服务端错误 | 临时故障 |
+
+## 退避算法
+
+```
+sleep = min(8.0s, 0.5s × 2^(attempt-1)) + random(0, 0.25s)
+```
+
+各次重试的等待时间示例：
+
+| attempt | 基础等待 | 最大抖动 | 实际范围 |
+|:---|:---|:---|:---|
+| 1 (首次失败) | 0.5s | 0.25s | 0.50s – 0.75s |
+| 2 | 1.0s | 0.25s | 1.00s – 1.25s |
+| 3 | 2.0s | 0.25s | 2.00s – 2.25s |
+| 4 | 4.0s | 0.25s | 4.00s – 4.25s |
+| 5 | 8.0s (cap) | 0.25s | 8.00s – 8.25s |
+
+> **为什么需要 jitter？** 多个客户端同时重试时，如果退避时间完全相同，会在同一时刻同时冲击服务端（thundering herd）。随机抖动将请求分散到不同时间点。
+
+## 重试核心实现
+
+```python
+def call_with_retry(fn, max_attempts=5):
+    """带指数退避重试的 API 调用包装器。"""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            if not is_retryable(exc) or attempt == max_attempts:
+                raise  # 不可重试或已达上限，直接抛出
+
+            wait = min(8.0, 0.5 * (2 ** (attempt - 1))) + random.uniform(0, 0.25)
+            time.sleep(wait)
+```
+
+### 集成到 OpenAI Client
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    api_key="your_key",
+    timeout=30.0,          # 单次请求超时
+    max_retries=2,         # SDK 内置重试（适用于网络层错误）
+)
+
+# SDK 内置重试 + 自定义业务重试 = 双重保护
+response = call_with_retry(
+    lambda: client.chat.completions.create(...),
+    max_attempts=3
+)
+```
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+============================================================
+【Hy3 API 错误处理与重试】
+模型: hy3-preview
+超时设置: 90.0s
+最大重试: 5 次
+============================================================
+
+──────────────────────────────────
+【错误分类参考表】
+──────────────────────────────────
+错误类型                          可重试       说明
+────────────────────────────────────────────────────────────
+BadRequestError                 ❌ 不可重试   请求格式错误，修改后重试
+AuthenticationError             ❌ 不可重试   API Key 无效，检查配置
+PermissionDeniedError           ❌ 不可重试   权限不足，检查套餐
+NotFoundError                   ❌ 不可重试   模型名错误
+APIConnectionError              ✅ 可重试     网络断开，可重试
+APITimeoutError                 ✅ 可重试     请求超时，可重试
+RateLimitError                  ✅ 可重试     被限流，可重试
+
+──────────────────────────────────
+【正常请求（带重试保护）】
+──────────────────────────────────
+  ✅ attempt=1/5 → 成功
+
+──────────────────────────────────
+【响应内容】
+──────────────────────────────────
+id: chatcmpl-xxxxxxxx
+model: hy3-preview
+finish_reason: stop
+content:
+安全重试 Hy3 API 请求的 5 条最佳实践：
+
+1. **幂等性设计** — 使用幂等键确保重复请求不会产生副作用，尤其写操作必须保证多次执行结果一致。
+
+2. **只重试临时错误** — 仅对网络超时、429（限流）和 5xx 服务端错误重试，对 4xx 客户端错误直接失败并记录日志。
+
+3. **指数退避 + 随机抖动** — 采用指数增长等待时间并加入随机因子，避免多个客户端同时重试造成惊群效应。
+
+4. **设置上限与超时** — 限制最大重试次数（建议 3-5 次）和总超时时间，防止无限等待耗尽资源。
+
+5. **遵守 Retry-After 头** — 当服务端返回 429 或 503 时，优先使用响应中的 Retry-After 头指定的等待时间。
+
+Token: prompt=36, completion=229, total=265
+```
+
+## 关键要点
+
+1. **SDK 内置 + 自定义双层保护**：OpenAI SDK 的 `max_retries` 处理网络层，自定义 `call_with_retry` 处理业务层
+2. **永不重试 4xx**：参数错误重试多少次也没用
+3. **抖动不可或缺**：无抖动的指数退避在分布式系统中会制造同步冲击
+4. **上限保护**：总重试次数和总耗时都要有上限，防止雪崩
+5. **遵守 Retry-After**：服务端明确告诉你等多久，就按它说的做

--- a/issue1/examples/retry.py
+++ b/issue1/examples/retry.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Hy3 API 错误处理与重试示例：超时、限流、网络异常的重试策略。
+
+使用方式：
+    cd issue1
+    python examples/retry.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+
+可选配置（环境变量）：
+    HY3_TIMEOUT=30            # 请求超时秒数
+    HY3_RETRY_MAX_ATTEMPTS=5  # 最大重试次数
+"""
+
+import os
+import sys
+import time
+import random
+from pathlib import Path
+from typing import Callable, TypeVar
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import (
+    OpenAI,
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+TIMEOUT = float(os.getenv("HY3_TIMEOUT", "90"))
+MAX_ATTEMPTS = int(os.getenv("HY3_RETRY_MAX_ATTEMPTS", "5"))
+
+T = TypeVar("T")
+
+# ── 错误分类 ─────────────────────────────────────────
+
+# 不可重试的错误：重试也解决不了
+NON_RETRYABLE = (
+    BadRequestError,       # 请求格式错误
+    AuthenticationError,   # 鉴权失败 (401)
+    PermissionDeniedError, # 权限不足 (403)
+    NotFoundError,         # 模型不存在 (404)
+)
+
+# 可重试的 HTTP 状态码
+RETRYABLE_STATUS = {408, 409, 425, 429, 500, 502, 503, 504}
+
+
+def is_retryable(error: Exception) -> bool:
+    """判断错误是否值得重试。"""
+    # 不可重试类型
+    if isinstance(error, NON_RETRYABLE):
+        return False
+    # 网络/超时/限流 → 重试
+    if isinstance(error, (APIConnectionError, APITimeoutError, RateLimitError)):
+        return True
+    # HTTP 状态码判断
+    if isinstance(error, APIStatusError):
+        return error.status_code in RETRYABLE_STATUS
+    return False
+
+
+def backoff(attempt: int) -> float:
+    """指数退避 + 随机抖动。"""
+    base = min(8.0, 0.5 * (2 ** (attempt - 1)))  # 0.5s, 1s, 2s, 4s, 8s(max)
+    jitter = random.uniform(0, 0.25)
+    return base + jitter
+
+
+# ── 重试核心逻辑 ─────────────────────────────────────
+
+def call_with_retry(
+    fn: Callable[[], T],
+    max_attempts: int = MAX_ATTEMPTS,
+) -> T:
+    """带指数退避重试的 API 调用包装器。
+
+    Args:
+        fn: 需要执行的 API 调用（无参 lambda）
+        max_attempts: 最大尝试次数（含首次）
+
+    Returns:
+        API 调用结果
+
+    Raises:
+        原始异常（如果所有重试都失败）
+    """
+    last_error: Exception | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = fn()
+            print(f"  ✅ attempt={attempt}/{max_attempts} → 成功")
+            return result
+        except Exception as exc:
+            last_error = exc
+            retryable = is_retryable(exc)
+
+            if not retryable:
+                print(f"  ❌ attempt={attempt}/{max_attempts} → 不可重试错误: {type(exc).__name__}: {exc}")
+                raise
+
+            if attempt == max_attempts:
+                print(f"  ❌ attempt={attempt}/{max_attempts} → 已达最大重试次数: {type(exc).__name__}: {exc}")
+                raise
+
+            wait = backoff(attempt)
+            status = getattr(exc, "status_code", "N/A")
+            print(f"  ⚠️  attempt={attempt}/{max_attempts} → {type(exc).__name__} (status={status}), "
+                  f"{wait:.2f}s 后重试...")
+            time.sleep(wait)
+
+    # 理论上不会到达这里
+    raise last_error  # type: ignore[misc]
+
+
+# ── 模拟各类错误场景 ─────────────────────────────────
+
+def simulate_errors():
+    """展示不同错误类型的分类结果（使用静态表，避免 mock SDK 内部对象）。"""
+    print(f"\n{'─' * 50}")
+    print("【错误分类参考表】")
+    print(f"{'─' * 50}")
+    print(f"{'错误类型':<30s} {'可重试':<10s} {'说明'}")
+    print("-" * 60)
+
+    rows = [
+        ("BadRequestError",          "❌ 不可重试", "请求格式错误，修正后重试"),
+        ("AuthenticationError",      "❌ 不可重试", "API Key 无效，检查配置"),
+        ("PermissionDeniedError",    "❌ 不可重试", "权限不足，检查套餐"),
+        ("NotFoundError",            "❌ 不可重试", "模型名错误"),
+        ("APIConnectionError",       "✅ 可重试",   "网络断开，可重试"),
+        ("APITimeoutError",          "✅ 可重试",   "请求超时，可重试"),
+        ("RateLimitError",           "✅ 可重试",   "被限流，可重试"),
+        ("APIStatusError(408/425)",  "✅ 可重试",   "服务端临时错误"),
+        ("APIStatusError(429)",      "✅ 可重试",   "速率限制"),
+        ("APIStatusError(5xx)",      "✅ 可重试",   "服务端内部错误"),
+    ]
+
+    for name, retryable, desc in rows:
+        print(f"{name:<30s} {retryable:<10s} {desc}")
+
+
+def main():
+    print("=" * 60)
+    print("【Hy3 API 错误处理与重试】")
+    print(f"模型: {MODEL}")
+    print(f"超时设置: {TIMEOUT}s")
+    print(f"最大重试: {MAX_ATTEMPTS} 次")
+    print("=" * 60)
+
+    simulate_errors()
+
+    client = OpenAI(base_url=BASE_URL, api_key=API_KEY, timeout=TIMEOUT)
+
+    print(f"\n{'─' * 50}")
+    print("【正常请求（带重试保护）】")
+    print(f"{'─' * 50}")
+
+    def make_request():
+        return client.chat.completions.create(
+            model=MODEL,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "请列出安全重试 Hy3 API 请求的 5 条最佳实践。",
+                }
+            ],
+            temperature=0.3,
+            top_p=1.0,
+            max_tokens=256,
+        )
+
+    print(f"\n请求: {make_request.__doc__}")
+    print()
+
+    response = call_with_retry(make_request)
+
+    choice = response.choices[0]
+    print(f"\n{'─' * 50}")
+    print("【响应内容】")
+    print(f"{'─' * 50}")
+    print(f"id: {response.id}")
+    print(f"model: {response.model}")
+    print(f"finish_reason: {choice.finish_reason}")
+    print(f"content:\n{choice.message.content}")
+    if response.usage:
+        u = response.usage
+        print(f"\nToken: prompt={u.prompt_tokens}, completion={u.completion_tokens}, total={u.total_tokens}")
+
+    print(f"\n✅ retry 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/examples/streaming.md
+++ b/issue1/examples/streaming.md
@@ -1,0 +1,121 @@
+# Streaming — 流式请求与逐 chunk 解析
+
+演示 `stream=True` 模式下的流式响应处理。流式请求不会等待完整生成结果，而是逐个 token 推送 delta 增量，适用于需要实时显示生成内容的场景（如聊天界面、代码补全）。
+
+## 运行
+
+```bash
+cd issue1
+python examples/streaming.py
+```
+
+## 请求结构
+
+关键是设置 `stream=True`，其他参数与非流式一致：
+
+```python
+stream = client.chat.completions.create(
+    model="hy3-preview",
+    messages=[
+        {"role": "user", "content": "请列出验证 Hy3 API 集成的 4 个关键步骤，每步一句话。"}
+    ],
+    temperature=0.7,
+    top_p=1.0,
+    max_tokens=256,
+    stream=True,  # ← 关键
+)
+```
+
+## 响应解析
+
+流式返回的是一个**迭代器**，每个 `chunk` 的结构如下：
+
+```python
+for chunk in stream:
+    if not chunk.choices:
+        continue  # 某些 chunk 可能没有 choices
+
+    choice = chunk.choices[0]
+    delta = choice.delta          # 增量内容（非完整消息）
+    finish_reason = choice.finish_reason
+
+    # delta 中的关键字段
+    role = delta.role             # 通常只在第一个 chunk 出现
+    content = delta.content       # 增量文本，需自行拼接
+    reasoning_content = delta.reasoning_content  # 思考内容（如有）
+    tool_calls = delta.tool_calls # 工具调用增量（如有）
+```
+
+### chunk 特性
+
+| 特性 | 说明 |
+|:---|:---|
+| `delta.role` | 通常只在**首个 chunk** 出现一次 |
+| `delta.content` | `None` 或一小段文本，需要**手动拼接** |
+| `delta.reasoning_content` | 仅在启用思考模式时出现，同样是增量 |
+| `finish_reason` | 通常在**最后一个 chunk** 中出现 |
+| `usage` | 大部分框架在流式模式下不返回 usage，需开启 `stream_options={"include_usage": True}` |
+
+### 完整拼接示例
+
+```python
+content_parts = []
+reasoning_parts = []
+
+for chunk in stream:
+    if not chunk.choices:
+        continue
+    delta = chunk.choices[0].delta
+    if delta.content:
+        content_parts.append(delta.content)
+    if getattr(delta, "reasoning_content", None):
+        reasoning_parts.append(delta.reasoning_content)
+
+full_content = "".join(content_parts)
+full_reasoning = "".join(reasoning_parts)
+```
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+ chunk role         content                                  finish_reason
+───── ──────────── ──────────────────────────────────────── ─────────────
+    0 assistant    以下是                                    None
+    1 None         验证                                      None
+    2 None         Hy3                                       None
+    3 None          API                                       None
+    4 None         集成的                                    None
+    5 None         四个                                      None
+    6 None         关键                                      None
+    7 None         步骤                                      None
+    8 None         ：                                        None
+    9 None
+
+                                                        None
+   10 None         1                                         None
+   11 None         .                                         None
+   12 None          认证                                      None
+   13 None         与                                        None
+   14 None         授权                                      None
+  ...
+   86 None         。                                        None
+   87 None                                                   stop
+───── ──────────── ──────────────────────────────────────── ─────────────
+
+完整回复 (87 个 content chunk):
+以下是验证 Hy3 API 集成的四个关键步骤：
+
+1. **认证与授权**：确保 API Key 正确配置并能通过身份验证，使用简单的 echo 请求测试连通性。
+2. **请求格式验证**：确认请求体 JSON 结构、字段名和数据类型完全符合 API 规范，处理必填和可选参数。
+3. **响应解析测试**：验证能正确解析返回的 JSON 响应，包括正常回复、错误码和流式 chunk，确保异常路径也有处理。
+4. **端到端集成验证**：在实际应用流程中运行完整测试，验证数据流、重试机制和速率限制处理均正常工作。
+```
+
+## 关键要点
+
+1. **首字延迟**：流式请求的首 token 延迟显著低于非流式，交互体验更好
+2. **Token 边界**：chunk 的 content 不一定按完整 token 分割，可能包含部分 UTF-8 字符
+3. **错误处理**：流式过程中也可能抛出异常（网络断开等），需要 try/except
+4. **内存管理**：对于超长生成，及时处理每个 chunk 而非全部缓存在内存中

--- a/issue1/examples/streaming.py
+++ b/issue1/examples/streaming.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Hy3 流式请求示例：stream=True 下的逐 chunk 解析。
+
+使用方式：
+    cd issue1
+    python examples/streaming.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+"""
+
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+
+def main():
+    print("=" * 60)
+    print("【流式请求 (stream=True) 逐 chunk 解析】")
+    print("=" * 60)
+
+    messages = [
+        {
+            "role": "user",
+            "content": "请列出验证 Hy3 API 集成的 4 个关键步骤，每步一句话。",
+        }
+    ]
+
+    print(f"\n请求 messages: {json.dumps(messages, ensure_ascii=False, indent=2)}\n")
+
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0.7,
+        top_p=1.0,
+        max_tokens=256,
+        stream=True,
+    )
+
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+
+    print("─" * 60)
+    print(f"{'chunk':>5s} {'role':<12s} {'content':<40s} {'finish_reason'}")
+    print("─" * 60)
+
+    for idx, chunk in enumerate(stream):
+        if not chunk.choices:
+            continue
+
+        choice = chunk.choices[0]
+        delta = choice.delta
+        role = getattr(delta, "role", None)
+        content = getattr(delta, "content", None)
+        reasoning = getattr(delta, "reasoning_content", None)
+        finish = choice.finish_reason
+
+        if content:
+            content_parts.append(content)
+        if reasoning:
+            reasoning_parts.append(reasoning)
+
+        # 截断显示内容，避免刷屏
+        display_content = (content or "")[:35] + ("..." if content and len(content) > 35 else "")
+        print(f"{idx:>5d} {str(role):<12s} {display_content:<40s} {str(finish)}")
+
+    print("─" * 60)
+
+    full_content = "".join(content_parts)
+    full_reasoning = "".join(reasoning_parts)
+
+    print(f"\n完整回复 ({len(content_parts)} 个 content chunk):")
+    print(full_content)
+    if full_reasoning:
+        print(f"\n思考过程 ({len(reasoning_parts)} 个 reasoning chunk):")
+        print(full_reasoning)
+
+    print(f"\n✅ streaming 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/examples/tool_calling.md
+++ b/issue1/examples/tool_calling.md
@@ -1,0 +1,155 @@
+# Tool Calling — 函数调用与多轮工具循环
+
+演示 Hy3 的 OpenAI 兼容 Function Calling 能力。脚本模拟一个「天气查询」场景：用户提问 → 模型识别需调工具 → 客户端执行工具 → 将结果返回模型 → 模型生成最终回答。
+
+## 运行
+
+```bash
+cd issue1
+python examples/tool_calling.py
+```
+
+## 工具定义
+
+工具遵循 OpenAI Function Calling 规范：
+
+```python
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",              # 函数名
+            "description": "查询指定城市的实时天气信息。",  # 描述（帮助模型判断何时调用）
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名称，如 深圳、北京、上海",
+                    }
+                },
+                "required": ["city"],           # 必填参数
+            },
+        },
+    }
+]
+```
+
+### 工具定义最佳实践
+
+| 要点 | 说明 |
+|:---|:---|
+| **描述要具体** | `description` 决定了模型能否正确判断何时调用工具 |
+| **参数要有约束** | 使用 `enum`、`required` 等约束减少模型幻觉 |
+| **精简参数** | 只暴露必需参数，多余的会增加模型选择难度 |
+| **一个工具一个职责** | 符合 KISS 原则，避免一个工具做太多事情 |
+
+## 请求结构
+
+```python
+response = client.chat.completions.create(
+    model="hy3-preview",
+    messages=messages,
+    tools=TOOLS,            # 工具定义列表
+    tool_choice="auto",     # auto / none / required / 指定工具
+    temperature=0.2,        # 工具调用场景推荐低温度
+    top_p=1.0,
+    max_tokens=512,
+)
+```
+
+### tool_choice 选项
+
+| 值 | 行为 |
+|:---|:---|
+| `"auto"` | **推荐**。模型自行决定是否调工具 |
+| `"none"` | 禁止调用工具 |
+| `"required"` | 强制调用工具（确保至少一次 tool call） |
+| `{"type": "function", "function": {"name": "xxx"}}` | 强制调用指定工具 |
+
+## 完整工具调用流程
+
+```
+用户提问
+   │
+   ▼
+┌─────────────────────┐
+│  第 1 轮：发送请求    │  messages=[user_msg]
+│  模型返回 tool_calls  │
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│  客户端执行工具       │  get_weather("深圳") → {temp_c: 29, ...}
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│  第 2 轮：追加结果    │  messages += [assistant_msg, tool_result_msg]
+│  模型返回最终回答     │
+└─────────────────────┘
+```
+
+关键代码：
+
+```python
+# 1. 检查模型是否要求调用工具
+if message.tool_calls:
+    # 2. 记录 assistant 消息（含 tool_calls）
+    messages.append({
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [{"id": tc.id, "type": tc.type,
+                        "function": {"name": tc.function.name,
+                                     "arguments": tc.function.arguments}}
+                       for tc in message.tool_calls]
+    })
+
+    # 3. 执行每个工具并将结果追加到 messages
+    for tc in message.tool_calls:
+        result = execute_tool(tc.function.name, json.loads(tc.function.arguments))
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": json.dumps(result, ensure_ascii=False)
+        })
+
+    # 4. 继续下一轮请求，直到模型不再返回 tool_calls
+```
+
+## 示例输出
+
+以下为实际调用 TokenHub `hy3-preview` 的输出：
+
+```
+用户提问: 请帮我查一下深圳的天气，然后告诉我是否需要带伞。
+可用工具: get_weather(深圳/北京/上海)
+
+────────────────────────────────────────
+第 1 轮请求
+  finish_reason: tool_calls
+  content: None
+  tool_calls 数量: 1
+
+  🔧 调用工具: get_weather({"city": "深圳"})
+  📋 工具返回: {"city": "深圳", "condition": "小雨", "temp_c": 29, "humidity": 82, "umbrella": true}
+
+────────────────────────────────────────
+第 2 轮请求
+  finish_reason: stop
+  content: 深圳今天是小雨天气，气温29°C，湿度82%。出门建议带上雨伞，以防淋湿。
+  tool_calls 数量: 0
+
+============================================================
+【最终回答】
+============================================================
+深圳今天是小雨天气，气温29°C，湿度82%。出门建议带上雨伞，以防淋湿。
+```
+
+## 关键要点
+
+1. **温度参数**：工具调用场景推荐 `temperature=0.2`，确保模型稳定选择工具而非随机跳过
+2. **死循环保护**：务必设置 `MAX_ROUNDS` 防止模型持续要求调工具
+3. **JSON 解析容错**：工具参数可能不是合法 JSON，需要 try/except
+4. **tool_call_id 匹配**：tool 消息的 `tool_call_id` 必须与 assistant 消息中的 `id` 严格对应
+5. **并行工具调用**：模型可能一次返回多个 `tool_calls`，需要全部处理后再继续

--- a/issue1/examples/tool_calling.py
+++ b/issue1/examples/tool_calling.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Hy3 工具调用 (Function Calling) 示例：单次调用与多轮工具循环。
+
+使用方式：
+    cd issue1
+    python examples/tool_calling.py
+
+前置条件：
+    1. 复制 .env.example 为 .env 并填入 HY3_API_KEY
+    2. pip install "openai>=1.0.0" python-dotenv
+"""
+
+import os
+import sys
+import json
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+BASE_URL = os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+API_KEY = os.getenv("HY3_API_KEY", "")
+MODEL = os.getenv("HY3_MODEL", "hy3-preview")
+
+client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+# ── 工具定义 ─────────────────────────────────────────
+
+WEATHER_DB = {
+    "深圳": {"city": "深圳", "condition": "小雨", "temp_c": 29, "humidity": 82, "umbrella": True},
+    "北京": {"city": "北京", "condition": "晴", "temp_c": 24, "humidity": 40, "umbrella": False},
+    "上海": {"city": "上海", "condition": "多云", "temp_c": 26, "humidity": 65, "umbrella": False},
+}
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "查询指定城市的实时天气信息。支持深圳、北京、上海。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名称，如 深圳、北京、上海",
+                    }
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+MAX_ROUNDS = 4  # 最大工具调用轮次，防止死循环
+
+
+def get_weather(city: str) -> dict:
+    """模拟天气查询工具。"""
+    return WEATHER_DB.get(
+        city,
+        {"city": city, "error": "该城市不在示例数据中，请尝试深圳、北京或上海。"},
+    )
+
+
+def execute_tool(tool_name: str, args: dict) -> dict:
+    """工具调度器。"""
+    if tool_name == "get_weather":
+        return get_weather(args.get("city", ""))
+    return {"error": f"未知工具: {tool_name}"}
+
+
+def main():
+    print("=" * 60)
+    print("【Hy3 Function Calling — 工具调用示例】")
+    print("=" * 60)
+
+    messages = [
+        {
+            "role": "user",
+            "content": "请帮我查一下深圳的天气，然后告诉我是否需要带伞。",
+        }
+    ]
+
+    print(f"\n用户提问: {messages[0]['content']}")
+    print(f"可用工具: get_weather(深圳/北京/上海)\n")
+
+    for round_idx in range(1, MAX_ROUNDS + 1):
+        print(f"─" * 40)
+        print(f"第 {round_idx} 轮请求")
+
+        response = client.chat.completions.create(
+            model=MODEL,
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+            temperature=0.2,  # 工具调用场景推荐低温度
+            top_p=1.0,
+            max_tokens=512,
+        )
+
+        choice = response.choices[0]
+        message = choice.message
+        tool_calls = getattr(message, "tool_calls", None) or []
+
+        print(f"  finish_reason: {choice.finish_reason}")
+        print(f"  content: {message.content}")
+        print(f"  tool_calls 数量: {len(tool_calls)}")
+
+        if not tool_calls:
+            # 模型认为不需要调工具，直接输出最终回答
+            print(f"\n{'=' * 60}")
+            print(f"【最终回答】")
+            print(f"{'=' * 60}")
+            print(message.content)
+            print(f"\n✅ tool_calling 示例运行完成！")
+            return
+
+        # 记录 assistant 消息（含 tool_calls）
+        tc_data = [
+            {
+                "id": tc.id,
+                "type": tc.type,
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            }
+            for tc in tool_calls
+        ]
+        messages.append({"role": "assistant", "content": message.content, "tool_calls": tc_data})
+
+        # 执行每个工具调用
+        for tc in tool_calls:
+            func_name = tc.function.name
+            try:
+                func_args = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                func_args = {}
+
+            print(f"\n  🔧 调用工具: {func_name}({json.dumps(func_args, ensure_ascii=False)})")
+
+            result = execute_tool(func_name, func_args)
+            print(f"  📋 工具返回: {json.dumps(result, ensure_ascii=False)}")
+
+            # 将工具结果加入消息历史
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": json.dumps(result, ensure_ascii=False),
+            })
+
+    print("\n⚠️ 达到最大工具调用轮次限制，可能需要检查工具定义或模型行为。")
+    print("\n✅ tool_calling 示例运行完成！")
+
+
+if __name__ == "__main__":
+    main()

--- a/issue1/quickstart.md
+++ b/issue1/quickstart.md
@@ -1,0 +1,247 @@
+# Hy3 API Quickstart
+
+> 面向开发者的快速入门指南：**5 分钟跑通第一次调用，半小时掌握主要能力。**
+
+Hy3 是腾讯混元团队研发的 295B MoE 大模型（21B 激活参数），通过 TokenHub 平台提供 OpenAI 兼容的 API 接口。本文档帮助你快速接入并验证 Hy3 的核心能力。
+
+---
+
+## 0. 准备工作
+
+### 获取 API Key
+
+1. 访问 [TokenHub 控制台](https://console.cloud.tencent.com/tokenhub/apikey)
+2. 登录腾讯云账号，点击「创建 API Key」
+3. 复制 API Key 备用
+
+> 💡 **新用户福利**：在 TokenHub「模型广场」可领取 Hy3 Preview **100 万 Tokens** 免费体验包（90 天有效）。
+
+### 配置环境
+
+```bash
+# 克隆仓库并进入示例目录
+cd issue1
+
+# 复制环境变量模板
+cp .env.example .env
+
+# 编辑 .env，填入你的 API Key
+# HY3_API_KEY=sk-xxxxxxxx
+```
+
+### 安装依赖
+
+```bash
+pip install "openai>=1.0.0" python-dotenv
+```
+
+---
+
+## 1. 基础信息
+
+| 项目 | 值 | 说明 |
+|:---|:---|:---|
+| **Base URL** | `https://tokenhub.tencentmaas.com/v1` | TokenHub OpenAI 兼容端点 |
+| **API Key** | `sk-xxxxxxxx` | 从 TokenHub 控制台获取 |
+| **Model** | `hy3-preview`（推荐）或 `hy3` | `hy3-preview` 支持 256K 上下文 |
+| **Endpoint** | `/chat/completions` | 完整 URL: `${BASE_URL}/chat/completions` |
+| **速率限制** | 视套餐而定 | Token Plan 套餐有不同并发限制，详见控制台 |
+
+### 模型选择建议
+
+| 模型 | 上下文 | 适用场景 |
+|:---|:---|:---|
+| `hy3-preview` | 256K | **推荐**。日常开发、长文档处理、复杂推理 |
+| `hy3` | 128K | 正式版，生产环境 |
+
+---
+
+## 2. 最小可运行示例
+
+### curl
+
+```bash
+# 设置环境变量
+export HY3_API_KEY="你的API_Key"
+export HY3_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+
+curl "${HY3_BASE_URL}/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3-preview",
+    "messages": [
+      {"role": "user", "content": "你好！请用一句话介绍你自己。"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128
+  }'
+```
+
+典型返回：
+
+```json
+{
+  "id": "chatcmpl-xxxxxxxx",
+  "object": "chat.completion",
+  "created": 1783400000,
+  "model": "hy3-preview",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好！我是混元，腾讯开发的大型语言模型，擅长代码、推理和长文本处理任务。"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 22,
+    "total_tokens": 37
+  }
+}
+```
+
+### Python (OpenAI SDK)
+
+```python
+import os
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.getenv("HY3_API_KEY"),
+    base_url=os.getenv("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1"),
+)
+
+response = client.chat.completions.create(
+    model="hy3-preview",
+    messages=[
+        {"role": "user", "content": "你好！请用一句话介绍你自己。"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+)
+
+print(response.choices[0].message.content)
+```
+
+> ⚠️ **注意**：TokenHub 接口使用标准 OpenAI 协议，**不要**发送 `chat_template_kwargs` 等 Hy3 本地部署专用参数，否则会报错。
+
+---
+
+## 3. 核心参数说明
+
+| 参数 | 类型 | 默认/建议 | 说明 |
+|:---|:---|:---|:---|
+| `temperature` | `number` | `0.9` | 采样温度。`0.1-0.3` 适合确定性任务（代码、数学），`0.7-0.9` 适合创意生成 |
+| `top_p` | `number` | `1.0` | 核采样阈值。与 temperature 二选一调节即可 |
+| `max_tokens` | `integer` | `128-4096` | 最大生成 token 数。过小会截断 (finish_reason=`length`)，过大增加延迟 |
+| `stop` | `string/array` | 无 | 停止序列。命中后立即停止生成，适用于格式化输出 |
+| `tools` | `array` | 无 | Function calling 工具定义，需配合 `tool_choice` 使用 |
+| `stream` | `boolean` | `false` | 是否流式返回。交互式场景设为 `true` 可降低首字延迟感知 |
+| `reasoning_effort` | `string` | `no_think` | **Hy3 思考模式**。`no_think` 直接回答，`low` 中等推理，`high` 深度思维链（通过 `extra_body.chat_template_kwargs` 传入，仅本地部署支持） |
+
+### 思考模式（Reasoning Mode）最佳实践
+
+Hy3 的思考模式是其核心特性之一，不同 effort 级别对应不同场景：
+
+| effort | 适用场景 | 预期行为 |
+|:---|:---|:---|
+| `no_think` | 日常对话、简单问答、信息检索 | 直接输出，延迟最低 |
+| `low` | 有一定复杂度的推理、格式化输出 | 简短内部思考后输出 |
+| `high` | 数学证明、复杂编程、多步推理 | 完整思维链，延迟最高但质量最好 |
+
+> ⚠️ **TokenHub 云端 API 的思考模式支持**：部分云服务可能不直接暴露 `reasoning_content` 字段。若需要完整思考过程，建议本地部署 vLLM/SGLang 并使用 `chat_template_kwargs.reasoning_effort` 参数。
+
+---
+
+## 4. Examples 概览
+
+示例代码位于 `issue1/examples/` 目录下，每个示例包含 `.py`（可运行脚本）和 `.md`（说明文档）：
+
+| # | 示例 | 文件 | 学习要点 |
+|:---|:---|:---|:---|
+| 1 | Basic Chat | `basic_chat.py/.md` | 单轮/多轮对话，请求构造与响应解析 |
+| 2 | Streaming | `streaming.py/.md` | 流式请求，逐 chunk 解析 delta 字段 |
+| 3 | Latency Compare | `latency_compare.py/.md` | 非流式 vs 流式首 token 时延对比 |
+| 4 | Tool Calling | `tool_calling.py/.md` | 函数调用定义、参数解析、多轮工具循环 |
+| 5 | Reasoning Mode | `reasoning_mode.py/.md` | `no_think` vs `high` 思考模式对比 |
+| 6 | Retry & Error | `retry.py/.md` | 指数退避重试、可重试/不可重试错误分类 |
+
+### 运行所有示例
+
+```bash
+cd issue1
+pip install "openai>=1.0.0" python-dotenv
+
+# 确保 .env 已配置 API Key
+python examples/basic_chat.py
+python examples/streaming.py
+python examples/latency_compare.py
+python examples/tool_calling.py
+python examples/reasoning_mode.py
+python examples/retry.py
+```
+
+---
+
+## 5. 常见报错排查
+
+| 现象 | 可能原因 | 解决方案 |
+|:---|:---|:---|
+| `401 Unauthorized` | API Key 无效或未设置 | 检查 `.env` 中 `HY3_API_KEY`；确认 TokenHub 控制台中 Key 状态正常 |
+| `403 Forbidden` | API Key 权限不足或额度耗尽 | 检查套餐余量，确认 Key 有调用对应模型的权限 |
+| `404 model not found` | 模型名错误 | 确认 model 参数为 `hy3-preview` 或 `hy3` |
+| `ConnectionError` / `ConnectTimeout` | 网络不通 | 检查是否需代理；确认 `HY3_BASE_URL` 正确 |
+| `429 Too Many Requests` | 超过速率限制 | 降低并发，实现指数退避重试（参考 retry 示例） |
+| `finish_reason="length"` | `max_tokens` 设置过小 | 增大 `max_tokens` 或精简 prompt |
+| `context_length_exceeded` | 输入超过模型上下文限制 | 缩短历史消息，或换用 `hy3-preview`（256K 上下文） |
+| 响应内容为空 | `reasoning_effort` 模式下思考占满 token 预算 | 增大 `max_tokens`；非推理场景使用 `no_think` |
+| tool call 未触发 | 模型判断不需要调工具，或 tool schema 不清晰 | 优化 tool description；必要时设置 `tool_choice="required"` |
+| `chat_template_kwargs` 报错 | 将本地部署专用参数发给了云 API | TokenHub 云端不要发送 `chat_template_kwargs`，仅本地 vLLM/SGLang 支持 |
+
+---
+
+## 6. 从本地部署迁移到 TokenHub 云 API
+
+如果你之前使用本地 vLLM/SGLang 部署，切换到 TokenHub 只需修改：
+
+```python
+# 本地部署 (vLLM/SGLang)
+client = OpenAI(
+    base_url="http://127.0.0.1:8000/v1",  # 改为 TokenHub URL
+    api_key="EMPTY",                       # 改为真实 API Key
+)
+# 去掉 extra_body={"chat_template_kwargs": ...}  # 云 API 不支持
+
+# TokenHub 云 API
+client = OpenAI(
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    api_key=os.getenv("HY3_API_KEY"),
+)
+```
+
+---
+
+## 7. 下一步
+
+1. 从 `examples/basic_chat.py` 开始跑通第一个请求
+2. 根据业务需求依次验证 streaming、tool calling、reasoning mode
+3. 将 retry 策略集成到生产代码中
+4. 阅读 [Hy3 官方文档](https://github.com/Tencent-Hunyuan/Hy3) 了解模型微调和 RL 训练
+
+---
+
+## 参考链接
+
+- [TokenHub 控制台](https://console.cloud.tencent.com/tokenhub/)
+- [Hy3 GitHub 仓库](https://github.com/Tencent-Hunyuan/Hy3)
+- [OpenAI Python SDK 文档](https://github.com/openai/openai-python)
+- [腾讯混元大模型文档](https://cloud.tencent.com/document/product/1729)


### PR DESCRIPTION
- quickstart.md: API basics, curl/Python examples, parameter guide, troubleshooting
- 6 runnable examples under issue1/examples/: basic_chat, streaming, latency_compare, tool_calling, reasoning_mode, retry
- each example includes .py (runnable) and .md (documentation)
- uses TokenHub OpenAI-compatible API (hy3-preview)