### PR TITLE
docs: add Hy3 API quickstart & 6 examples

### DIFF
--- a/examples/01_basic_chat.md
+++ b/examples/01_basic_chat.md
@@ -1,0 +1,37 @@
+# 01 · Basic Chat
+
+## 说明
+
+演示 Chat Completions 的单轮问答与多轮对话。
+
+## 运行
+
+```bash
+python 01_basic_chat.py
+```
+
+## 请求
+
+- 接口：`POST {BASE_URL}/chat/completions`
+- `messages` 支持 `system` / `user` / `assistant`
+- 多轮时将上一轮 `assistant` 内容写回 `messages`
+
+## 响应字段
+
+```text
+resp.choices[0].message.content
+resp.usage
+resp.model
+```
+
+## 示例输出
+
+```text
+=== single-turn ===
+assistant: 我是混元，是由腾讯开发的大模型，能回答问题、解决问题、学习新知识、创造内容以及进行闲聊。
+usage: CompletionUsage(completion_tokens=26, prompt_tokens=19, total_tokens=45, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=0, rejected_prediction_tokens=None), prompt_tokens_details=PromptTokensDetails(audio_tokens=None, cached_tokens=0))
+
+=== multi-turn ===
+assistant-1: 好的，小明，我已经记住你的名字了。有什么可以帮你的吗？
+assistant-2: 你叫小明。
+```

--- a/examples/01_basic_chat.py
+++ b/examples/01_basic_chat.py
@@ -1,0 +1,49 @@
+"""01 basic chat: single-turn and multi-turn conversation."""
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+
+
+def single_turn():
+    print("=== single-turn ===")
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": "用一句话介绍你自己"}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=128,
+    )
+    msg = resp.choices[0].message
+    print("assistant:", msg.content)
+    print("usage:", getattr(resp, "usage", None))
+    return resp
+
+
+def multi_turn():
+    print("\n=== multi-turn ===")
+    messages = [
+        {"role": "system", "content": "你是简洁的中文助手。"},
+        {"role": "user", "content": "我叫小明，请记住。"},
+    ]
+    r1 = client.chat.completions.create(
+        model=MODEL, messages=messages, max_tokens=64, temperature=0.9
+    )
+    a1 = r1.choices[0].message.content
+    print("assistant-1:", a1)
+    messages.append({"role": "assistant", "content": a1 or ""})
+    messages.append({"role": "user", "content": "我叫什么名字？"})
+    r2 = client.chat.completions.create(
+        model=MODEL, messages=messages, max_tokens=64, temperature=0.9
+    )
+    print("assistant-2:", r2.choices[0].message.content)
+    return r2
+
+
+if __name__ == "__main__":
+    single_turn()
+    multi_turn()

--- a/examples/02_streaming.md
+++ b/examples/02_streaming.md
@@ -1,0 +1,33 @@
+# 02 · Streaming
+
+## 说明
+
+使用 `stream=True` 接收增量 token，并拼接完整回复。
+
+## 运行
+
+```bash
+python 02_streaming.py
+```
+
+## 请求
+
+```python
+stream = client.chat.completions.create(..., stream=True)
+for chunk in stream:
+    piece = chunk.choices[0].delta.content  # 可能为 None
+```
+
+## 响应
+
+- 增量内容在 `delta.content`
+- 客户端自行拼接完整文本
+
+## 示例输出
+
+```text
+=== streaming ===
+人工智能是模拟人类智能的计算机技术。它能学习、推理并自主完成任务。已广泛应用于医疗、交通等领域。
+--- assembled ---
+人工智能是模拟人类智能的计算机技术。它能学习、推理并自主完成任务。已广泛应用于医疗、交通等领域。
+```

--- a/examples/02_streaming.py
+++ b/examples/02_streaming.py
@@ -1,0 +1,35 @@
+"""02 streaming: stream=True and parse chunks."""
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+
+
+def main():
+    print("=== streaming ===")
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": "用三句话介绍人工智能，简短一些。"}],
+        max_tokens=256,
+        temperature=0.9,
+        stream=True,
+    )
+    full = []
+    for chunk in stream:
+        if not chunk.choices:
+            continue
+        delta = chunk.choices[0].delta
+        piece = delta.content or ""
+        if piece:
+            print(piece, end="", flush=True)
+            full.append(piece)
+    print("\n--- assembled ---")
+    print("".join(full))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_nonstream_vs_stream.md
+++ b/examples/03_nonstream_vs_stream.md
@@ -1,0 +1,34 @@
+# 03 · Non-stream vs Stream
+
+## 说明
+
+同一 prompt 下对比非流式与流式时延。
+
+- **非流式**：一次返回完整结果
+- **流式**：记录首 token 时延（TTFT）与总耗时
+
+## 运行
+
+```bash
+python 03_nonstream_vs_stream.py
+```
+
+## 指标
+
+| 指标 | 非流式 | 流式 |
+|------|--------|------|
+| TTFT | 记为总耗时（首包即全文） | 第一个非空 `delta.content` 到达时间 |
+| total | 完整响应返回时间 | 流结束时间 |
+
+实际数值受网络与负载影响。
+
+## 示例输出
+
+```text
+=== non-stream ===
+{'mode': 'non-stream', 'ttft_s': 3.193050599991693, 'total_s': 3.193050599991693, 'chars': 35, 'preview': '源码公开聚群贤，\n众手添薪火始燃。\n无界共享通大道，\n春风吹绿万重山。'}
+=== stream ===
+{'mode': 'stream', 'ttft_s': 0.9790744999918388, 'total_s': 1.7011559999955352, 'chars': 35, 'preview': '代码如光破闭锁，\n众手同耕无界河。\n源码摊开星海阔，\n千秋智慧共磋磨。'}
+
+说明: non-stream 的 ttft_s 记为总耗时（首包即完整响应）；stream 的 ttft_s 为第一个 content chunk 到达时间。
+```

--- a/examples/03_nonstream_vs_stream.py
+++ b/examples/03_nonstream_vs_stream.py
@@ -1,0 +1,66 @@
+"""03 compare non-stream vs stream: TTFT and total latency."""
+import os
+import time
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+PROMPT = "写一首四句的短诗，主题是开源。"
+
+
+def non_stream():
+    t0 = time.perf_counter()
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": PROMPT}],
+        max_tokens=200,
+        temperature=0.9,
+        stream=False,
+    )
+    total = time.perf_counter() - t0
+    text = resp.choices[0].message.content or ""
+    # 非流式无标准 TTFT；用总耗时近似「首包即全文」
+    return {"mode": "non-stream", "ttft_s": total, "total_s": total, "chars": len(text), "preview": text[:80]}
+
+
+def streaming():
+    t0 = time.perf_counter()
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": PROMPT}],
+        max_tokens=200,
+        temperature=0.9,
+        stream=True,
+    )
+    ttft = None
+    full = []
+    for chunk in stream:
+        if not chunk.choices:
+            continue
+        piece = chunk.choices[0].delta.content or ""
+        if piece and ttft is None:
+            ttft = time.perf_counter() - t0
+        if piece:
+            full.append(piece)
+    total = time.perf_counter() - t0
+    text = "".join(full)
+    return {
+        "mode": "stream",
+        "ttft_s": ttft,
+        "total_s": total,
+        "chars": len(text),
+        "preview": text[:80],
+    }
+
+
+if __name__ == "__main__":
+    a = non_stream()
+    b = streaming()
+    print("=== non-stream ===")
+    print(a)
+    print("=== stream ===")
+    print(b)
+    print("\n说明: non-stream 的 ttft_s 记为总耗时（首包即完整响应）；stream 的 ttft_s 为第一个 content chunk 到达时间。")

--- a/examples/04_tool_calling.md
+++ b/examples/04_tool_calling.md
@@ -1,0 +1,45 @@
+# 04 · Tool Calling
+
+## 说明
+
+1. 单次请求中解析 `tool_calls`
+2. 本地执行工具后，以 `role=tool` 回传结果，完成多轮工具循环
+
+## 运行
+
+```bash
+python 04_tool_calling.py
+```
+
+## 请求
+
+- `tools`：OpenAI function 格式
+- `tool_choice`: `"auto"`
+- 本地部署需启用 tool parser（见仓库 README）
+- 云端网关若未透传 tools，可能仅返回文本
+
+## 响应字段
+
+```text
+message.tool_calls[i].id
+message.tool_calls[i].function.name
+message.tool_calls[i].function.arguments
+```
+
+工具结果使用 `role: tool` 与 `tool_call_id` 写回 `messages`。
+
+## 示例输出
+
+环境：腾讯云 TokenHub。
+
+```text
+=== one-shot tool call ===
+content: 
+tool_calls: [ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-da6bbd5b878f4efa9026c66f04aec5db', function=Function(arguments='{"city": "北京"}', name='get_weather'), type='function')]
+
+=== multi-turn tool loop ===
+round1 content: 
+round1 tool_calls: [ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-a4430a70de96d635', function=Function(arguments='{"city": "上海"}', name='get_weather'), type='function')]
+tool result: {"city": "上海", "weather": "晴", "temp_c": 26}
+round2 final: 上海今天天气晴朗，气温为26摄氏度，气候舒适宜人。
+```

--- a/examples/04_tool_calling.py
+++ b/examples/04_tool_calling.py
@@ -1,0 +1,122 @@
+"""04 tool calling: one-shot tools + multi-turn tool loop."""
+import json
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "查询城市天气（演示用假数据）",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "城市名，如 北京"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def fake_get_weather(city: str) -> str:
+    return json.dumps({"city": city, "weather": "晴", "temp_c": 26}, ensure_ascii=False)
+
+
+def once_tool_call():
+    print("=== one-shot tool call ===")
+    messages = [{"role": "user", "content": "北京今天天气怎么样？请调用工具查询。"}]
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        tool_choice="auto",
+        max_tokens=256,
+        temperature=0.2,
+    )
+    msg = resp.choices[0].message
+    print("content:", msg.content)
+    print("tool_calls:", msg.tool_calls)
+    return resp
+
+
+def multi_turn_tool_loop():
+    print("\n=== multi-turn tool loop ===")
+    messages = [{"role": "user", "content": "查询上海的天气，并用一句话总结。"}]
+    # round 1: model may request tool
+    r1 = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        tool_choice="auto",
+        max_tokens=256,
+        temperature=0.2,
+    )
+    m1 = r1.choices[0].message
+    print("round1 content:", m1.content)
+    print("round1 tool_calls:", m1.tool_calls)
+
+    # append assistant message (with tool_calls if any)
+    assistant_msg = {
+        "role": "assistant",
+        "content": m1.content or "",
+    }
+    if m1.tool_calls:
+        assistant_msg["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in m1.tool_calls
+        ]
+    messages.append(assistant_msg)
+
+    if not m1.tool_calls:
+        print("模型未返回 tool_calls（云端/本地若未开 tool parser 时可能发生）。结束演示。")
+        return r1
+
+    for tc in m1.tool_calls:
+        name = tc.function.name
+        try:
+            args = json.loads(tc.function.arguments or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        if name == "get_weather":
+            result = fake_get_weather(args.get("city", "未知"))
+        else:
+            result = json.dumps({"error": f"unknown tool {name}"})
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            }
+        )
+        print("tool result:", result)
+
+    r2 = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOLS,
+        max_tokens=256,
+        temperature=0.2,
+    )
+    print("round2 final:", r2.choices[0].message.content)
+    return r2
+
+
+if __name__ == "__main__":
+    once_tool_call()
+    multi_turn_tool_loop()

--- a/examples/05_reasoning_mode.md
+++ b/examples/05_reasoning_mode.md
@@ -1,0 +1,62 @@
+# 05 · Reasoning Mode
+
+## 说明
+
+对比 `reasoning_effort=no_think` 与 `high` 的输出差异。
+
+## 运行
+
+```bash
+python 05_reasoning_mode.py
+```
+
+## 请求
+
+本地（对齐仓库 README）：
+
+```python
+extra_body = {
+    "chat_template_kwargs": {
+        "reasoning_effort": "no_think"  # 或 "low" / "high"
+    }
+}
+```
+
+`05_reasoning_mode.py` 同时附带兼容字段，便于不同网关使用。
+
+## 响应字段
+
+- `message.content`：最终回答
+- `message.reasoning_content`：思考过程（若平台返回）
+
+## 示例输出
+
+环境：腾讯云 TokenHub。
+
+```text
+=== reasoning_effort=no_think ===
+content: **答案：至少 8 人两门都喜欢。**
+
+**简要推理：**
+班级总人数为 30 人。
+喜欢数学的有 18 人，喜欢英语的有 20 人。
+如果不考虑重叠，喜欢至少一门的人数最多为 18 + 20 = 38 人。
+但班级只有 30 人，所以多出来的部分就是两门都喜欢的最少人数：
+18 + 20 - 30 = 8
+因此，至少有 8 人两门都喜欢。
+reasoning_content: None
+
+=== reasoning_effort=high ===
+content: **答案：至少有 8 人两门都喜欢。**
+
+**简要推理：**
+根据集合的容斥原理，喜欢数学或英语的人数 = 喜欢数学的人数 + 喜欢英语的人数 - 两门都喜欢的人数。
+因为喜欢数学或英语的人数最多只能是全班人数 30 人，所以 18 + 20 - 两门都喜欢的人数 ≤ 30，得出两门都喜欢的人数 ≥ 8。
+reasoning_content: 这是一个典型的集合容斥原理问题。
+设班级总人数 N = 30，喜欢数学 |M| = 18，喜欢英语 |E| = 20，两门都喜欢 |M ∩ E| = x。
+至少喜欢一门 |M ∪ E| = 18 + 20 - x = 38 - x。
+因 |M ∪ E| ≤ 30，故 38 - x ≤ 30，即 x ≥ 8。
+当 x = 8 时，只喜欢数学 10 人、只喜欢英语 12 人、两门都喜欢 8 人，合计 30，情形可行。
+若 x = 7，则并集为 31，超过总人数，不可能。
+因此至少有 8 人两门都喜欢。
+```

--- a/examples/05_reasoning_mode.py
+++ b/examples/05_reasoning_mode.py
@@ -1,0 +1,43 @@
+"""05 reasoning mode: no_think vs high effort."""
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+PROMPT = "一个班级有 30 人，其中 18 人喜欢数学，20 人喜欢英语，至少有多少人两门都喜欢？请给出答案与简要推理。"
+
+
+def call_with_effort(effort: str):
+    # 兼容本地 chat_template_kwargs 与部分云端 thinking 字段
+    extra = {
+        "chat_template_kwargs": {"reasoning_effort": effort},
+        "thinking": {"type": "enabled" if effort != "no_think" else "disabled"},
+    }
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": PROMPT}],
+        max_tokens=512,
+        temperature=0.3,
+        extra_body=extra,
+    )
+    msg = resp.choices[0].message
+    reasoning = getattr(msg, "reasoning_content", None)
+    if reasoning is None and isinstance(msg.model_extra, dict):
+        reasoning = msg.model_extra.get("reasoning_content")
+    return {
+        "effort": effort,
+        "content": msg.content,
+        "reasoning_content": reasoning,
+    }
+
+
+if __name__ == "__main__":
+    for effort in ("no_think", "high"):
+        print(f"=== reasoning_effort={effort} ===")
+        out = call_with_effort(effort)
+        print("content:", out["content"])
+        print("reasoning_content:", out["reasoning_content"])
+        print()

--- a/examples/06_error_handling_retry.md
+++ b/examples/06_error_handling_retry.md
@@ -1,0 +1,57 @@
+# 06 · Error Handling & Retry
+
+## 说明
+
+对可重试错误使用指数退避：
+
+- 超时：`APITimeoutError`
+- 限流：`RateLimitError` / HTTP 429
+- 网络：`APIConnectionError`
+
+退避：`delay ≈ base * 2^attempt`，超过最大次数后失败。
+
+## 运行
+
+```bash
+python 06_error_handling_retry.py
+```
+
+## 实现要点
+
+```python
+client = OpenAI(..., timeout=30.0)
+
+def with_retry(fn, max_retries=4, base_delay=0.8):
+    for attempt in range(max_retries + 1):
+        try:
+            return fn()
+        except (RateLimitError, APITimeoutError, APIConnectionError):
+            time.sleep(base_delay * (2 ** attempt))
+    raise RuntimeError(...)
+```
+
+脚本包含：
+
+1. 真实请求外包一层重试
+2. 退避策略说明
+3. 本地模拟超时以验证重试逻辑
+
+## 示例输出
+
+```text
+=== normal call with retry wrapper ===
+ok: OK
+
+=== backoff policy (demo, no real failure required) ===
+On RateLimitError / APITimeoutError / APIConnectionError:
+  attempt 1 -> sleep ~0.8s then retry
+  attempt 2 -> sleep ~1.6s then retry
+  attempt 3 -> sleep ~3.2s then retry
+  attempt 4 -> sleep ~6.4s then retry
+After max_retries exhausted -> raise RuntimeError
+
+=== flaky function + retry (local simulation) ===
+[retry] simulated timeout #1; sleep 0.15s
+[retry] simulated timeout #2; sleep 0.30s
+result: success-after-retries
+```

--- a/examples/06_error_handling_retry.py
+++ b/examples/06_error_handling_retry.py
@@ -1,0 +1,98 @@
+﻿"""06 error handling: timeout / rate limit / network retry with backoff."""
+import os
+import random
+import time
+from typing import Any, Callable
+
+from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+    timeout=30.0,
+)
+MODEL = os.environ.get("HY3_MODEL", "hy3")
+
+
+def with_retry(
+    fn: Callable[[], Any],
+    *,
+    max_retries: int = 4,
+    base_delay: float = 0.8,
+) -> Any:
+    """Retry on timeout / rate limit / connection errors with exponential backoff."""
+    last_err: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            return fn()
+        except (RateLimitError, APITimeoutError, APIConnectionError) as e:
+            last_err = e
+            kind = type(e).__name__
+        except Exception as e:
+            msg = str(e).lower()
+            if "429" in msg or "rate limit" in msg or "timeout" in msg:
+                last_err = e
+                kind = "retryable"
+            else:
+                raise
+        if attempt >= max_retries:
+            break
+        delay = base_delay * (2**attempt) + random.uniform(0, 0.25)
+        print(f"[retry] attempt={attempt + 1} kind={kind} sleep={delay:.2f}s err={last_err!r}")
+        time.sleep(delay)
+    raise RuntimeError(f"failed after retries: {last_err}")
+
+
+def normal_call():
+    print("=== normal call with retry wrapper ===")
+    resp = with_retry(
+        lambda: client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "只回答：OK"}],
+            max_tokens=16,
+            temperature=0,
+        )
+    )
+    print("ok:", resp.choices[0].message.content)
+
+
+def demo_backoff_policy():
+    print("\n=== backoff policy (demo, no real failure required) ===")
+    print("On RateLimitError / APITimeoutError / APIConnectionError:")
+    for attempt in range(4):
+        delay = 0.8 * (2**attempt)
+        print(f"  attempt {attempt + 1} -> sleep ~{delay:.1f}s then retry")
+    print("After max_retries exhausted -> raise RuntimeError")
+
+
+def demo_flaky_logic():
+    print("\n=== flaky function + retry (local simulation) ===")
+    state = {"n": 0}
+
+    def flaky():
+        state["n"] += 1
+        if state["n"] < 3:
+            raise TimeoutError(f"simulated timeout #{state['n']}")
+        return "success-after-retries"
+
+    def with_retry_generic(fn, max_retries=5, base_delay=0.15):
+        last = None
+        for attempt in range(max_retries + 1):
+            try:
+                return fn()
+            except TimeoutError as e:
+                last = e
+                if attempt >= max_retries:
+                    break
+                delay = base_delay * (2**attempt)
+                print(f"[retry] {e}; sleep {delay:.2f}s")
+                time.sleep(delay)
+        raise RuntimeError(last)
+
+    print("result:", with_retry_generic(flaky))
+
+
+if __name__ == "__main__":
+    normal_call()
+    demo_backoff_policy()
+    demo_flaky_logic()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,54 @@
+# Hy3 API Examples
+
+本目录提供 6 个可运行示例，说明见仓库根目录 [`quickstart.md`](../quickstart.md)。
+
+## 环境
+
+```bash
+pip install openai
+```
+
+```powershell
+# TokenHub
+$env:HY3_API_KEY = "your-key"
+$env:HY3_BASE_URL = "https://tokenhub.tencentmaas.com/v1"
+$env:HY3_MODEL = "hy3"
+
+# 本地 vLLM / SGLang
+# $env:HY3_BASE_URL = "http://127.0.0.1:8000/v1"
+# $env:HY3_API_KEY = "EMPTY"
+# $env:HY3_MODEL = "hy3"
+```
+
+## 列表
+
+| 文件 | 说明 |
+|------|------|
+| `01_basic_chat` | 单轮 / 多轮对话 |
+| `02_streaming` | 流式输出 |
+| `03_nonstream_vs_stream` | 非流式与流式时延对比 |
+| `04_tool_calling` | 工具调用与多轮回传 |
+| `05_reasoning_mode` | 思考模式对比 |
+| `06_error_handling_retry` | 错误重试与退避 |
+
+每个示例包含 `.py` 脚本与 `.md` 说明。
+
+## 运行
+
+```bash
+cd examples
+python 01_basic_chat.py
+python 02_streaming.py
+python 03_nonstream_vs_stream.py
+python 04_tool_calling.py
+python 05_reasoning_mode.py
+python 06_error_handling_retry.py
+```
+
+## 环境变量
+
+| 变量 | 默认值 |
+|------|--------|
+| `HY3_BASE_URL` | `http://127.0.0.1:8000/v1` |
+| `HY3_API_KEY` | `EMPTY` |
+| `HY3_MODEL` | `hy3` |

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,198 @@
+# Hy3 API Quickstart
+
+本文说明如何通过 OpenAI 兼容接口调用 Hy3：完成首次请求，并快速上手常用能力。
+
+Hy3 可在以下环境使用：
+
+- **本地部署**：使用 vLLM / SGLang 提供服务（详见仓库 [README](./README.md) Deployment）
+- **云端**：腾讯云 [TokenHub](https://cloud.tencent.com/product/tokenhub) 等 OpenAI 兼容网关
+
+配套示例见 `examples/`。连接信息通过环境变量配置，**不要将 API Key 写入代码或提交到 Git 仓库**。
+
+---
+
+## 1. 基础信息
+
+| 项 | 本地部署（与官方 README 默认一致） | 腾讯云 TokenHub（以控制台为准） |
+|----|-----------------------------------|-------------------------------|
+| **Base URL** | `http://127.0.0.1:8000/v1` | `https://tokenhub.tencentmaas.com/v1` |
+| **API Key** | `EMPTY`（本地占位） | 控制台创建的 API Key |
+| **Model** | `hy3` | `hy3`（或控制台显示的 Model ID） |
+| **协议** | OpenAI Chat Completions | 同左 |
+| **鉴权** | `Authorization: Bearer <API_KEY>` | 同左 |
+
+### 环境变量
+
+| 变量 | 含义 | 示例 |
+|------|------|------|
+| `HY3_BASE_URL` | API 根路径（含 `/v1`） | `https://tokenhub.tencentmaas.com/v1` |
+| `HY3_API_KEY` | 密钥 | （本地配置，勿入库） |
+| `HY3_MODEL` | 模型 ID | `hy3` |
+
+```bash
+# Linux / macOS
+export HY3_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+export HY3_API_KEY="your-key"
+export HY3_MODEL="hy3"
+```
+
+```powershell
+# Windows PowerShell
+$env:HY3_BASE_URL = "https://tokenhub.tencentmaas.com/v1"
+$env:HY3_API_KEY = "your-key"
+$env:HY3_MODEL = "hy3"
+```
+
+### 速率与额度
+
+- **本地**：受 GPU、并发与推理框架配置影响。
+- **TokenHub**：以控制台额度、RPM/TPM 及套餐为准。
+- 调试阶段建议使用较小的 `max_tokens`。
+
+查询可用模型：`GET {BASE_URL}/models`。
+
+---
+
+## 2. 最小可运行示例
+
+### 2.1 curl
+
+```bash
+curl -sS "$HY3_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"${HY3_MODEL:-hy3}\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"用一句话介绍你自己\"}],
+    \"max_tokens\": 128,
+    \"temperature\": 0.9,
+    \"top_p\": 1.0
+  }"
+```
+
+PowerShell：
+
+```powershell
+$headers = @{
+  Authorization = "Bearer $env:HY3_API_KEY"
+  "Content-Type" = "application/json"
+}
+$body = @{
+  model = $env:HY3_MODEL
+  messages = @(@{ role = "user"; content = "用一句话介绍你自己" })
+  max_tokens = 128
+  temperature = 0.9
+} | ConvertTo-Json -Depth 5
+Invoke-RestMethod -Method Post -Uri "$env:HY3_BASE_URL/chat/completions" -Headers $headers -Body $body
+```
+
+### 2.2 Python（OpenAI SDK）
+
+```bash
+pip install openai
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "EMPTY"),
+    base_url=os.environ.get("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+)
+model = os.environ.get("HY3_MODEL", "hy3")
+
+resp = client.chat.completions.create(
+    model=model,
+    messages=[{"role": "user", "content": "用一句话介绍你自己"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+)
+print(resp.choices[0].message.content)
+```
+
+推荐参数（与仓库 README 一致）：`temperature=0.9`，`top_p=1.0`。
+
+---
+
+## 3. 主要参数
+
+| 参数 | 作用 | 说明 |
+|------|------|------|
+| `temperature` | 采样温度 | 通用对话可用 `0.9` |
+| `top_p` | 核采样 | 可用 `1.0` |
+| `max_tokens` | 最大生成长度 | 按任务设置 |
+| `stop` | 停止序列 | 可选 |
+| `stream` | 流式输出 | 见 `examples/02_streaming` |
+| `tools` / `tool_choice` | 工具调用 | 见 `examples/04_tool_calling` |
+| 思考模式 | 快答 / 深度推理 | 见下文 |
+
+### 思考模式
+
+本地 vLLM / SGLang（与官方 README 一致）：
+
+```python
+extra_body = {
+    "chat_template_kwargs": {
+        "reasoning_effort": "no_think"  # 或 "low" / "high"
+    }
+}
+resp = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    extra_body=extra_body,
+)
+```
+
+| `reasoning_effort` | 含义 |
+|--------------------|------|
+| `no_think` | 直接回答 |
+| `low` | 轻度思考 |
+| `high` | 深度推理 |
+
+不同网关字段可能不同；`examples/05_reasoning_mode.py` 提供兼容写法。以实际返回的 `content` / `reasoning_content` 为准。
+
+### 工具调用
+
+本地部署需启用 tool parser，例如：
+
+- vLLM：`--tool-call-parser hy_v3 --enable-auto-tool-choice`
+- SGLang：`--tool-call-parser hunyuan`
+
+云端能力以平台文档为准。
+
+---
+
+## 4. 常见问题
+
+| 现象 | 可能原因 | 处理 |
+|------|----------|------|
+| 连接失败 | 服务未启动或 Base URL 错误 | 检查端口；确认 URL 包含 `/v1` |
+| `401` | Key 无效或未设置 | 检查 `HY3_API_KEY` |
+| `404` / model not found | 模型名不一致 | 调用 `GET /v1/models` 核对 |
+| 超时 | 冷启动或网络慢 | 增大 timeout；减小 `max_tokens` |
+| `429` | 触发限流 | 指数退避重试（见 example 06） |
+| `content` 为空 | 字段解析差异 | 打印完整 `message` |
+| 无 `tool_calls` | 未启用 parser 或模型未调用工具 | 检查启动参数与 tools 定义 |
+
+---
+
+## 5. 示例索引
+
+见 [`examples/README.md`](./examples/README.md)：
+
+1. basic chat  
+2. streaming  
+3. non-stream vs stream latency  
+4. tool calling  
+5. reasoning mode  
+6. error handling & retry  
+
+---
+
+## 6. 参考
+
+- 本仓库 README（Quickstart / Deployment）
+- [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)
+- [混元调用指南](https://cloud.tencent.com/document/product/1823/132252)


### PR DESCRIPTION
## Summary
Add Hy3 API quickstart and 6 runnable examples for Rhinobird issue #1.

Closes #1

## Contents
- quickstart.md: base URL / API key / model / parameters / troubleshooting (local + TokenHub)
- examples/: basic chat, streaming, latency compare, tool calling, reasoning mode, retry

## How to run
See examples/README.md. Set HY3_BASE_URL, HY3_API_KEY, HY3_MODEL.

## Verified on
Tencent Cloud TokenHub (OpenAI-compatible API).