### PR TITLE
docs: add Hy3 API quickstart and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 Thumbs.db
 __pycache__/
 *.pyc
+.env
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - [News](#news)
 - [Model Links](#model-links)
 - [Quickstart](#quickstart)
+- [Hosted API Quickstart](#hosted-api-quickstart)
 - [Deployment](#deployment)
   - [vLLM](#vllm)
   - [SGLang](#sglang)
@@ -136,6 +137,13 @@ print(response.choices[0].message.content)
 > **Reasoning mode**: Set `reasoning_effort` to `"high"` for complex tasks (math, coding, reasoning) or `"no_think"` for direct responses.
 
 See the [Deployment](#deployment) section below for how to start the API server.
+
+## Hosted API Quickstart
+
+Using Tencent Cloud TokenHub (no local GPU required)? See:
+
+- [quickstart.md](./quickstart.md) — first call in ~5 minutes
+- [examples/api/](./examples/api/) — chat / streaming / latency / tools / reasoning / retries
 
 ## Deployment
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -37,6 +37,7 @@
 - [新闻](#新闻)
 - [模型链接](#模型链接)
 - [快速开始](#快速开始)
+- [托管 API Quickstart](#托管-api-quickstart)
 - [推理和部署](#推理和部署)
   - [vLLM](#使用-vllm-推理)
   - [SGLang](#使用-sglang-推理)
@@ -133,6 +134,13 @@ print(response.choices[0].message.content)
 > **推理模式**：复杂任务（数学、编程、推理）建议设置 `reasoning_effort="high"`，日常对话可使用默认的 `"no_think"` 直接回复。
 
 具体部署方式请参考下方[推理和部署](#推理和部署)章节。
+
+## 托管 API Quickstart
+
+若使用腾讯云 TokenHub 托管 API（无需本地 GPU），请参阅：
+
+- [quickstart.md](./quickstart.md) — 5 分钟跑通第一次调用
+- [examples/api/](./examples/api/) — 对话 / 流式 / 时延 / 工具调用 / 思考模式 / 错误重试
 
 ## 推理和部署
 

--- a/examples/api/.env.example
+++ b/examples/api/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and fill in values. Never commit real keys.
+HY3_API_KEY=sk-xxxxxxxx
+HY3_BASE_URL=https://tokenhub.tencentmaas.com/v1
+HY3_MODEL=hy3
+
+# Optional: set to 1 to run examples offline with mock responses
+# HY3_MOCK=1

--- a/examples/api/01_basic_chat/README.md
+++ b/examples/api/01_basic_chat/README.md
@@ -61,18 +61,18 @@ print(resp.choices[0].message.content)
 | `choices[0].finish_reason` | `stop` 正常结束；`length` 触及 `max_tokens` |
 | `usage.prompt_tokens` / `completion_tokens` / `total_tokens` | 用量统计 |
 
-## 示例输出（脱敏）
+## 示例输出（2026-07-18 TokenHub 实测，脱敏）
 
 ```text
 === Single-turn ===
 finish_reason: stop
-content: 你好！我是混元 Hy3，由腾讯混元团队研发的大模型助手。
-usage: prompt=18 completion=28 total=46
+content: 我是混元，是由腾讯开发的大模型，能回答问题、处理信息、辅助创作，为你提供实用帮助。
+usage: prompt=20 completion=25 total=45
 
 === Multi-turn ===
 {
   "role": "assistant",
-  "content": "大文件可用流式解析（如 ijson），或按行读取 NDJSON，避免一次性载入内存。"
+  "content": "用 `ijson` 库流式解析：import ijson; for item in ijson.items(open('a.json','rb'), 'path.to.item'): ...。"
 }
 ```
 

--- a/examples/api/01_basic_chat/README.md
+++ b/examples/api/01_basic_chat/README.md
@@ -1,0 +1,79 @@
+# 01 Basic Chat — 单轮 / 多轮对话
+
+演示最基础的 Chat Completions 调用：单轮提问，以及带 `system` + 历史的多轮续写。
+
+## 运行
+
+```bash
+cd examples/api
+python 01_basic_chat/main.py
+```
+
+## 完整请求（单轮）
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "user", "content": "用一句话介绍你自己。"}
+  ],
+  "temperature": 0.9,
+  "top_p": 1.0,
+  "max_tokens": 256
+}
+```
+
+等价 Python：
+
+```python
+resp = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "用一句话介绍你自己。"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+)
+print(resp.choices[0].message.content)
+```
+
+## 完整请求（多轮）
+
+`messages` 顺序：`system`（可选）→ `user` → `assistant` → `user` → …，且必须以 `user` 结尾。
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "system", "content": "你是简洁的编程助手，回答控制在两句话内。"},
+    {"role": "user", "content": "Python 怎么读取 JSON 文件？"},
+    {"role": "assistant", "content": "用内置 json 模块：import json; data = json.load(open('a.json'))。"},
+    {"role": "user", "content": "如果文件很大怎么办？"}
+  ]
+}
+```
+
+## 响应解析
+
+| 字段 | 含义 |
+|---|---|
+| `choices[0].message.role` | 通常为 `assistant` |
+| `choices[0].message.content` | 最终回答文本 |
+| `choices[0].finish_reason` | `stop` 正常结束；`length` 触及 `max_tokens` |
+| `usage.prompt_tokens` / `completion_tokens` / `total_tokens` | 用量统计 |
+
+## 示例输出（脱敏）
+
+```text
+=== Single-turn ===
+finish_reason: stop
+content: 你好！我是混元 Hy3，由腾讯混元团队研发的大模型助手。
+usage: prompt=18 completion=28 total=46
+
+=== Multi-turn ===
+{
+  "role": "assistant",
+  "content": "大文件可用流式解析（如 ijson），或按行读取 NDJSON，避免一次性载入内存。"
+}
+```
+
+> 实际文案会因采样而变化；结构字段保持一致。

--- a/examples/api/01_basic_chat/main.py
+++ b/examples/api/01_basic_chat/main.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""01 — Basic chat: single-turn and multi-turn."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common import MockMessage, MockResponse, dump_json, get_client, get_config, message_to_dict, with_retry
+
+
+def run_single_turn(client, model: str, mock: bool):
+    messages = [{"role": "user", "content": "用一句话介绍你自己。"}]
+    print("=== Single-turn request ===")
+    print(dump_json({"model": model, "messages": messages, "temperature": 0.9, "top_p": 1.0}))
+
+    if mock:
+        resp = MockResponse(MockMessage("你好！我是混元 Hy3，由腾讯混元团队研发的大模型助手。"))
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.9,
+                top_p=1.0,
+                max_tokens=256,
+            ),
+            label="single-turn",
+        )
+
+    msg = resp.choices[0].message
+    print("\n=== Response parse ===")
+    print(f"finish_reason: {resp.choices[0].finish_reason}")
+    print(f"content: {msg.content}")
+    if getattr(resp, "usage", None):
+        u = resp.usage
+        print(f"usage: prompt={u.prompt_tokens} completion={u.completion_tokens} total={u.total_tokens}")
+    return msg.content
+
+
+def run_multi_turn(client, model: str, mock: bool):
+    messages = [
+        {"role": "system", "content": "你是简洁的编程助手，回答控制在两句话内。"},
+        {"role": "user", "content": "Python 怎么读取 JSON 文件？"},
+        {
+            "role": "assistant",
+            "content": "用内置 json 模块：import json; data = json.load(open('a.json'))。",
+        },
+        {"role": "user", "content": "如果文件很大怎么办？"},
+    ]
+    print("\n=== Multi-turn request ===")
+    print(dump_json({"model": model, "messages": messages}))
+
+    if mock:
+        resp = MockResponse(
+            MockMessage("大文件可用 ijson 流式解析，或按行读取 NDJSON，避免一次性 load 进内存。")
+        )
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.9,
+                top_p=1.0,
+                max_tokens=256,
+            ),
+            label="multi-turn",
+        )
+
+    msg = resp.choices[0].message
+    print("\n=== Response parse ===")
+    print(dump_json(message_to_dict(msg)))
+    return msg.content
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+    run_single_turn(client, cfg.model, cfg.mock)
+    run_multi_turn(client, cfg.model, cfg.mock)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/02_streaming/README.md
+++ b/examples/api/02_streaming/README.md
@@ -1,0 +1,83 @@
+# 02 Streaming — 流式请求与逐 chunk 解析
+
+演示 `stream=true` 的 SSE 流式输出，以及如何拼接 `delta.content`。
+
+## 运行
+
+```bash
+cd examples/api
+python 02_streaming/main.py
+```
+
+## 完整请求
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "user", "content": "用三句话介绍 Hy3 适合做什么。"}
+  ],
+  "temperature": 0.9,
+  "top_p": 1.0,
+  "max_tokens": 512,
+  "stream": true,
+  "stream_options": {"include_usage": true}
+}
+```
+
+```python
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "用三句话介绍 Hy3 适合做什么。"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
+for chunk in stream:
+    if chunk.choices and chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+    if chunk.usage:
+        print("\nusage:", chunk.usage)
+```
+
+## 响应解析
+
+流式响应是多行 `data: {...}`，直到 `data: [DONE]`。
+
+| 阶段 | 字段 | 含义 |
+|---|---|---|
+| 首包 | `choices[0].delta.role` | 常为 `assistant` |
+| 中间包 | `choices[0].delta.content` | 增量文本，可能为空 |
+| 结束包 | `choices[0].finish_reason` | 如 `stop` |
+| 可选尾包 | `usage` | 开启 `include_usage` 后出现；此时 `choices` 可能为空 |
+
+拼装最终答案：
+
+```python
+text = "".join(
+    (c.choices[0].delta.content or "")
+    for c in stream_chunks
+    if c.choices
+)
+```
+
+## 示例输出（脱敏）
+
+```text
+=== Chunk parse (delta.content) ===
+Hy3 适合编程助手与 Agent 工作流。它在长上下文理解上表现稳定。复杂推理任务可开启思考模式。
+
+chunks_seen≈42 finish_reason=stop
+usage: prompt=22 completion=48 total=70
+assembled_content: Hy3 适合编程助手与 Agent 工作流。它在长上下文理解上表现稳定。复杂推理任务可开启思考模式。
+```
+
+原始 SSE 形态示意：
+
+```text
+data: {"id":"REPLACED_ID","object":"chat.completion.chunk","choices":[{"delta":{"role":"assistant"}}]}
+data: {"id":"REPLACED_ID","choices":[{"delta":{"content":"Hy3"}}]}
+data: {"id":"REPLACED_ID","choices":[{"delta":{"content":" 适合"},"finish_reason":null}]}
+...
+data: {"id":"REPLACED_ID","choices":[],"usage":{"prompt_tokens":22,"completion_tokens":48,"total_tokens":70}}
+data: [DONE]
+```

--- a/examples/api/02_streaming/README.md
+++ b/examples/api/02_streaming/README.md
@@ -60,15 +60,16 @@ text = "".join(
 )
 ```
 
-## 示例输出（脱敏）
+## 示例输出（2026-07-18 TokenHub 实测，脱敏）
 
 ```text
 === Chunk parse (delta.content) ===
-Hy3 适合编程助手与 Agent 工作流。它在长上下文理解上表现稳定。复杂推理任务可开启思考模式。
+Hy3 适合处理复杂的多步骤推理任务，比如数学证明、代码生成与逻辑分析等需要深度思考的场景。
+它擅长在对话中保持长期上下文一致性，适用于需要连续交互的咨询、写作辅助或项目管理等任务。
+同时，Hy3 也适合用于知识整合与内容创作，能高效将分散信息转化为结构化的摘要、报告或教学材料。
 
-chunks_seen≈42 finish_reason=stop
-usage: prompt=22 completion=48 total=70
-assembled_content: Hy3 适合编程助手与 Agent 工作流。它在长上下文理解上表现稳定。复杂推理任务可开启思考模式。
+chunks_seen≈53 finish_reason=stop
+usage: prompt=25 completion=84 total=109
 ```
 
 原始 SSE 形态示意：
@@ -78,6 +79,6 @@ data: {"id":"REPLACED_ID","object":"chat.completion.chunk","choices":[{"delta":{
 data: {"id":"REPLACED_ID","choices":[{"delta":{"content":"Hy3"}}]}
 data: {"id":"REPLACED_ID","choices":[{"delta":{"content":" 适合"},"finish_reason":null}]}
 ...
-data: {"id":"REPLACED_ID","choices":[],"usage":{"prompt_tokens":22,"completion_tokens":48,"total_tokens":70}}
+data: {"id":"REPLACED_ID","choices":[],"usage":{"prompt_tokens":25,"completion_tokens":84,"total_tokens":109}}
 data: [DONE]
 ```

--- a/examples/api/02_streaming/main.py
+++ b/examples/api/02_streaming/main.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""02 — Streaming chat with per-chunk parsing."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common import get_client, get_config, with_retry
+
+
+def mock_stream():
+    chunks = ["你好", "！", "我是", " Hy3", "，", "很高兴", "为你服务", "。"]
+    for i, text in enumerate(chunks):
+        time.sleep(0.02)
+        yield type(
+            "Chunk",
+            (),
+            {
+                "choices": [
+                    type(
+                        "C",
+                        (),
+                        {
+                            "delta": type("D", (), {"content": text, "role": "assistant" if i == 0 else None})(),
+                            "finish_reason": "stop" if i == len(chunks) - 1 else None,
+                        },
+                    )()
+                ],
+                "usage": None,
+            },
+        )()
+    # trailing usage chunk
+    yield type(
+        "Chunk",
+        (),
+        {
+            "choices": [],
+            "usage": type("U", (), {"prompt_tokens": 16, "completion_tokens": 12, "total_tokens": 28})(),
+        },
+    )()
+
+
+def run_stream(client, model: str, mock: bool) -> str:
+    messages = [{"role": "user", "content": "用三句话介绍 Hy3 适合做什么。"}]
+    print("=== Streaming request ===")
+    print(
+        {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    )
+
+    if mock:
+        stream = mock_stream()
+    else:
+        stream = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.9,
+                top_p=1.0,
+                max_tokens=512,
+                stream=True,
+                stream_options={"include_usage": True},
+            ),
+            label="streaming",
+        )
+
+    print("\n=== Chunk parse (delta.content) ===")
+    parts: list[str] = []
+    finish_reason = None
+    usage = None
+    n = 0
+    for chunk in stream:
+        n += 1
+        if getattr(chunk, "usage", None):
+            usage = chunk.usage
+        if not chunk.choices:
+            continue
+        choice = chunk.choices[0]
+        delta = choice.delta
+        piece = getattr(delta, "content", None) or ""
+        if piece:
+            parts.append(piece)
+            print(piece, end="", flush=True)
+        if choice.finish_reason:
+            finish_reason = choice.finish_reason
+    print("\n")
+    print(f"chunks_seen≈{n} finish_reason={finish_reason}")
+    if usage:
+        print(
+            f"usage: prompt={usage.prompt_tokens} "
+            f"completion={usage.completion_tokens} total={usage.total_tokens}"
+        )
+    full = "".join(parts)
+    print(f"assembled_content: {full}")
+    return full
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+    run_stream(client, cfg.model, cfg.mock)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/03_latency_compare/README.md
+++ b/examples/api/03_latency_compare/README.md
@@ -51,16 +51,18 @@ for chunk in client.chat.completions.create(..., stream=True):
 total = time.perf_counter() - t0
 ```
 
-## 示例输出（脱敏样例）
+## 示例输出（2026-07-18 TokenHub 实测）
 
 ```text
 === Latency compare ===
-[non-stream] ttft_ms=1842.3  total_ms=1842.3  chars=42  preview='TTFT 是从发出请求到收到第一个输出 token 的时间。'
-[stream]     ttft_ms=312.7   total_ms=1905.1  chars=45  preview='TTFT 是从发出请求到收到第一个输出 token 的时间。'
+[non-stream] ttft_ms=1959.5  total_ms=1959.5  chars=81
+  preview='首 token 时延（TTFT）指用户发起请求到大模型生成第一个输出 token 所耗时间…'
+[stream]     ttft_ms=664.4   total_ms=1319.0  chars=77
+  preview='首 token 时延（TTFT）指用户发起请求到模型生成第一个输出 token 的等待时间…'
 
 === How to read ===
 - Non-stream: client waits for full JSON; TTFT ≈ total.
 - Stream: TTFT is usually much smaller; total may be similar or slightly higher.
 ```
 
-> 数值受网络、地域入口、负载与输出长度影响，请以本机实测为准。交互场景优先流式以降低体感等待。
+> 数值受网络、地域入口、负载与输出长度影响，请以本机实测为准。本次流式 TTFT（约 0.66s）明显低于非流式全文等待（约 1.96s）。

--- a/examples/api/03_latency_compare/README.md
+++ b/examples/api/03_latency_compare/README.md
@@ -1,0 +1,66 @@
+# 03 Latency Compare — 非流式 vs 流式时延
+
+对比同 prompt 下非流式与流式的 **首 token 时延（TTFT）** 与 **总耗时**。
+
+## 运行
+
+```bash
+cd examples/api
+python 03_latency_compare/main.py
+```
+
+## 指标定义
+
+| 指标 | 非流式 | 流式 |
+|---|---|---|
+| TTFT | 收到完整响应体的时间（首包即全文） | 收到第一个非空 `delta.content` 的时间 |
+| Total | 请求开始 → 响应结束 | 请求开始 → 流结束 |
+
+## 完整请求
+
+非流式：
+
+```json
+{
+  "model": "hy3",
+  "messages": [{"role": "user", "content": "用不超过 80 字说明什么是首 token 时延（TTFT）。"}],
+  "temperature": 0.9,
+  "max_tokens": 256,
+  "stream": false
+}
+```
+
+流式：同上，但 `"stream": true`。
+
+## 响应解析 / 计时伪代码
+
+```python
+# non-stream
+t0 = time.perf_counter()
+resp = client.chat.completions.create(..., stream=False)
+total = time.perf_counter() - t0
+ttft = total  # 全文一次性返回
+
+# stream
+t0 = time.perf_counter()
+ttft = None
+for chunk in client.chat.completions.create(..., stream=True):
+    piece = chunk.choices[0].delta.content if chunk.choices else None
+    if piece and ttft is None:
+        ttft = time.perf_counter() - t0
+total = time.perf_counter() - t0
+```
+
+## 示例输出（脱敏样例）
+
+```text
+=== Latency compare ===
+[non-stream] ttft_ms=1842.3  total_ms=1842.3  chars=42  preview='TTFT 是从发出请求到收到第一个输出 token 的时间。'
+[stream]     ttft_ms=312.7   total_ms=1905.1  chars=45  preview='TTFT 是从发出请求到收到第一个输出 token 的时间。'
+
+=== How to read ===
+- Non-stream: client waits for full JSON; TTFT ≈ total.
+- Stream: TTFT is usually much smaller; total may be similar or slightly higher.
+```
+
+> 数值受网络、地域入口、负载与输出长度影响，请以本机实测为准。交互场景优先流式以降低体感等待。

--- a/examples/api/03_latency_compare/main.py
+++ b/examples/api/03_latency_compare/main.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""03 — Non-streaming vs streaming latency (TTFT / total)."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common import MockMessage, MockResponse, get_client, get_config, with_retry
+
+
+PROMPT = "用不超过 80 字说明什么是首 token 时延（TTFT）。"
+
+
+def measure_non_stream(client, model: str, mock: bool) -> dict:
+    messages = [{"role": "user", "content": PROMPT}]
+    t0 = time.perf_counter()
+    if mock:
+        time.sleep(0.15)
+        resp = MockResponse(MockMessage("TTFT 是从发出请求到收到第一个输出 token 的时间。"))
+        text = resp.choices[0].message.content or ""
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.9,
+                max_tokens=256,
+                stream=False,
+            ),
+            label="non-stream",
+        )
+        text = resp.choices[0].message.content or ""
+    total_ms = (time.perf_counter() - t0) * 1000
+    # Non-stream: first token is only visible when full body arrives ≈ total
+    return {
+        "mode": "non-stream",
+        "ttft_ms": round(total_ms, 1),
+        "total_ms": round(total_ms, 1),
+        "chars": len(text),
+        "preview": text[:80],
+    }
+
+
+def measure_stream(client, model: str, mock: bool) -> dict:
+    messages = [{"role": "user", "content": PROMPT}]
+    t0 = time.perf_counter()
+    ttft_ms = None
+    parts: list[str] = []
+
+    if mock:
+        for i, piece in enumerate(["TTFT", " 是", " 从发请求", " 到首个", " token", " 的耗时。"]):
+            time.sleep(0.03 if i == 0 else 0.01)
+            if ttft_ms is None:
+                ttft_ms = (time.perf_counter() - t0) * 1000
+            parts.append(piece)
+    else:
+        stream = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.9,
+                max_tokens=256,
+                stream=True,
+            ),
+            label="stream",
+        )
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            piece = chunk.choices[0].delta.content or ""
+            if piece:
+                if ttft_ms is None:
+                    ttft_ms = (time.perf_counter() - t0) * 1000
+                parts.append(piece)
+
+    total_ms = (time.perf_counter() - t0) * 1000
+    text = "".join(parts)
+    return {
+        "mode": "stream",
+        "ttft_ms": round(ttft_ms or total_ms, 1),
+        "total_ms": round(total_ms, 1),
+        "chars": len(text),
+        "preview": text[:80],
+    }
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+
+    print("=== Latency compare ===")
+    print(f"prompt: {PROMPT}")
+    print("definition: TTFT = time until first visible content token; total = until completion\n")
+
+    non_stream = measure_non_stream(client, cfg.model, cfg.mock)
+    stream = measure_stream(client, cfg.model, cfg.mock)
+
+    for row in (non_stream, stream):
+        print(
+            f"[{row['mode']}] ttft_ms={row['ttft_ms']}  total_ms={row['total_ms']}  "
+            f"chars={row['chars']}  preview={row['preview']!r}"
+        )
+
+    print("\n=== How to read ===")
+    print("- Non-stream: client waits for full JSON; TTFT ≈ total.")
+    print("- Stream: TTFT is usually much smaller; total may be similar or slightly higher.")
+    print("- Numbers vary with network, region, load, and output length.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/04_tool_calling/README.md
+++ b/examples/api/04_tool_calling/README.md
@@ -1,0 +1,116 @@
+# 04 Tool Calling — 一次调用 + 多轮工具循环
+
+演示 Function Calling：模型提出 `tool_calls` → 业务执行 → 回填 `role=tool` → 模型给出最终答案。
+
+## 运行
+
+```bash
+cd examples/api
+python 04_tool_calling/main.py
+```
+
+## 完整请求（第 1 轮）
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "user", "content": "深圳今天天气怎么样？"}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "获取指定城市的当前天气",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string", "description": "城市名，如 深圳"}
+          },
+          "required": ["city"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}
+```
+
+## 响应解析（第 1 轮）
+
+| 字段 | 含义 |
+|---|---|
+| `finish_reason` | 常为 `tool_calls` |
+| `message.tool_calls[].id` | 工具调用 ID，回填时必须原样使用 |
+| `message.tool_calls[].function.name` | 函数名 |
+| `message.tool_calls[].function.arguments` | JSON 字符串参数 |
+| `message.reasoning_content` | 若开启思考，可能存在；**回写时务必保留** |
+
+示例（脱敏）：
+
+```json
+{
+  "role": "assistant",
+  "content": "我来查一下深圳天气。",
+  "tool_calls": [
+    {
+      "id": "chatcmpl-tool-REPLACED",
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "arguments": "{\"city\": \"深圳\"}"
+      }
+    }
+  ]
+}
+```
+
+## 完整请求（第 2 轮：工具循环）
+
+将第 1 轮 assistant 消息（含 `reasoning_content` / `tool_calls`）与工具结果一并回填：
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "user", "content": "深圳今天天气怎么样？"},
+    {
+      "role": "assistant",
+      "content": "我来查一下深圳天气。",
+      "reasoning_content": "（若有则原样保留）",
+      "tool_calls": [
+        {
+          "id": "chatcmpl-tool-REPLACED",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"city\": \"深圳\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "chatcmpl-tool-REPLACED",
+      "content": "多云，气温 24~30°C，湿度 70%"
+    }
+  ],
+  "tools": ["…同上…"]
+}
+```
+
+## 最终响应示例
+
+```json
+{
+  "role": "assistant",
+  "content": "根据查询，深圳今天多云，气温 24~30°C，湿度 70%。出门可适当防晒。"
+}
+```
+
+## 注意
+
+- 模型只“提议”调用，真正执行在业务侧。
+- 多轮循环可能继续返回 `tool_calls`，直到 `finish_reason=stop`。
+- 交错式思考场景下，丢失 `reasoning_content` 可能导致思维链断裂。详见 [quickstart.md](../../../quickstart.md)。

--- a/examples/api/04_tool_calling/README.md
+++ b/examples/api/04_tool_calling/README.md
@@ -47,12 +47,12 @@ python 04_tool_calling/main.py
 | `message.tool_calls[].function.arguments` | JSON 字符串参数 |
 | `message.reasoning_content` | 若开启思考，可能存在；**回写时务必保留** |
 
-示例（脱敏）：
+示例（2026-07-18 TokenHub 实测，tool id 已脱敏）：
 
 ```json
 {
   "role": "assistant",
-  "content": "我来查一下深圳天气。",
+  "content": "",
   "tool_calls": [
     {
       "id": "chatcmpl-tool-REPLACED",
@@ -66,6 +66,8 @@ python 04_tool_calling/main.py
 }
 ```
 
+`finish_reason` 为 `tool_calls`。
+
 ## 完整请求（第 2 轮：工具循环）
 
 将第 1 轮 assistant 消息（含 `reasoning_content` / `tool_calls`）与工具结果一并回填：
@@ -77,8 +79,7 @@ python 04_tool_calling/main.py
     {"role": "user", "content": "深圳今天天气怎么样？"},
     {
       "role": "assistant",
-      "content": "我来查一下深圳天气。",
-      "reasoning_content": "（若有则原样保留）",
+      "content": "",
       "tool_calls": [
         {
           "id": "chatcmpl-tool-REPLACED",
@@ -100,12 +101,13 @@ python 04_tool_calling/main.py
 }
 ```
 
-## 最终响应示例
+## 最终响应示例（实测）
 
 ```json
 {
   "role": "assistant",
-  "content": "根据查询，深圳今天多云，气温 24~30°C，湿度 70%。出门可适当防晒。"
+  "content": "深圳今天的天气情况如下：\n\n- **天气**：多云\n- **气温**：24~30°C\n- **湿度**：70%\n\n整体来看是比较舒适的多云天气，早晚稍凉、中午偏热，出门可以根据气温变化适当增减衣物。",
+  "reasoning_content": "用户问深圳今天天气怎么样，我已经调用了get_weather工具获取了深圳的天气信息……"
 }
 ```
 

--- a/examples/api/04_tool_calling/main.py
+++ b/examples/api/04_tool_calling/main.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""04 — Tool calling: one-shot + multi-turn tool loop."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common import (
+    MockMessage,
+    MockResponse,
+    MockToolCall,
+    dump_json,
+    get_client,
+    get_config,
+    message_to_dict,
+    with_retry,
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的当前天气",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "城市名，如 深圳"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def get_weather(city: str) -> str:
+    # Demo stub — replace with real API in production.
+    catalog = {
+        "深圳": "多云，气温 24~30°C，湿度 70%",
+        "北京": "晴，气温 18~28°C，湿度 35%",
+    }
+    return catalog.get(city, f"{city}：暂无数据（demo stub）")
+
+
+def run_one_shot(client, model: str, mock: bool):
+    messages = [{"role": "user", "content": "深圳今天天气怎么样？"}]
+    print("=== One-shot tool call request ===")
+    print(dump_json({"model": model, "messages": messages, "tools": TOOLS, "tool_choice": "auto"}))
+
+    if mock:
+        resp = MockResponse(
+            MockMessage(
+                "我来查一下深圳天气。",
+                tool_calls=[MockToolCall("get_weather", '{"city":"深圳"}')],
+            ),
+            finish_reason="tool_calls",
+        )
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=TOOLS,
+                tool_choice="auto",
+                temperature=0.9,
+            ),
+            label="tool-one-shot",
+        )
+
+    msg = resp.choices[0].message
+    print("\n=== Response parse ===")
+    print(f"finish_reason: {resp.choices[0].finish_reason}")
+    print(dump_json(message_to_dict(msg)))
+    return messages, msg
+
+
+def run_tool_loop(client, model: str, mock: bool, messages, first_msg) -> str:
+    """Append assistant + tool results, then ask model for the final answer."""
+    messages = list(messages)
+    messages.append(message_to_dict(first_msg))
+
+    for tc in first_msg.tool_calls or []:
+        args = json.loads(tc.function.arguments)
+        result = get_weather(**args) if tc.function.name == "get_weather" else "unknown tool"
+        tool_msg = {
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": result,
+        }
+        messages.append(tool_msg)
+        print("\n=== Tool executed ===")
+        print(dump_json(tool_msg))
+
+    print("\n=== Follow-up request (with tool results) ===")
+    print(dump_json({"model": model, "messages": messages, "tools": TOOLS}))
+
+    if mock:
+        resp = MockResponse(
+            MockMessage(
+                "根据查询，深圳今天多云，气温 24~30°C，湿度 70%。出门可适当防晒。",
+                reasoning_content="已拿到 get_weather 结果，整理成对用户友好的中文回复。",
+            )
+        )
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=TOOLS,
+                tool_choice="auto",
+                temperature=0.9,
+                extra_body={"reasoning_effort": "high"},
+            ),
+            label="tool-followup",
+        )
+
+    final = resp.choices[0].message
+    print("\n=== Final response parse ===")
+    print(dump_json(message_to_dict(final)))
+    return final.content or ""
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+    messages, first = run_one_shot(client, cfg.model, cfg.mock)
+    if not first.tool_calls:
+        print("Model answered without tools:", first.content)
+        return
+    run_tool_loop(client, cfg.model, cfg.mock, messages, first)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/05_reasoning_mode/README.md
+++ b/examples/api/05_reasoning_mode/README.md
@@ -72,28 +72,30 @@ print(msg.content)
 
 也可用单独的 `reasoning_effort`（`low` / `medium` / `high`）控制强度。官方文档默认约为 `low`。
 
-## 示例输出（脱敏）
+## 示例输出（2026-07-18 TokenHub 实测，思考过程已截断）
 
 ```text
 === Response parse (thinking-off) ===
 {
   "role": "assistant",
-  "content": "6。因为先减 2 再加 3。"
+  "content": "6个；5减2加3等于6。"
 }
-usage: prompt=42 completion=18 total=60
+usage: prompt=48 completion=12 total=60
 
 === Response parse (thinking-on) ===
 {
   "role": "assistant",
-  "content": "最终还剩 6 个苹果。",
-  "reasoning_content": "5-2=3，再 +3 → 6。…"
+  "content": "6\n因为5减2加3等于6。",
+  "reasoning_content": "用户要求：\n1. 小明有 5 个苹果。\n2. 给了小红 2 个 -> 5 - 2 = 3 个。\n3. 又买了 3 个 -> 3 + 3 = 6 个。……"
 }
-usage: prompt=42 completion=126 total=168
+usage: prompt=45 completion=316 total=361
 
 === Diff summary ===
 thinking-off has reasoning_content: False
 thinking-on  has reasoning_content: True
 ```
+
+开启思考后 `completion_tokens` 明显增加（本次 12 → 316），因为思考 token 与最终答案共享额度。
 
 ## 与本地部署的差异
 

--- a/examples/api/05_reasoning_mode/README.md
+++ b/examples/api/05_reasoning_mode/README.md
@@ -1,0 +1,105 @@
+# 05 Reasoning Mode — 思考过程开 / 关对比
+
+对比托管 API 上关闭 / 开启深度思考时，响应字段与 token 用量的差异。
+
+## 运行
+
+```bash
+cd examples/api
+python 05_reasoning_mode/main.py
+```
+
+## 完整请求
+
+### 关闭思考
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {
+      "role": "user",
+      "content": "小明有 5 个苹果，给了小红 2 个，又买了 3 个，最后还剩几个？只给最终数字和一句理由。"
+    }
+  ],
+  "temperature": 0.9,
+  "max_tokens": 512,
+  "thinking": {"type": "disabled"}
+}
+```
+
+### 开启思考
+
+```json
+{
+  "model": "hy3",
+  "messages": [
+    {
+      "role": "user",
+      "content": "小明有 5 个苹果，给了小红 2 个，又买了 3 个，最后还剩几个？只给最终数字和一句理由。"
+    }
+  ],
+  "temperature": 0.9,
+  "max_tokens": 8192,
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "high"
+}
+```
+
+Python SDK（非标字段走 `extra_body`）：
+
+```python
+resp = client.chat.completions.create(
+    model="hy3",
+    messages=[...],
+    max_tokens=8192,
+    extra_body={
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "high",
+    },
+)
+msg = resp.choices[0].message
+print(getattr(msg, "reasoning_content", None))
+print(msg.content)
+```
+
+## 响应解析
+
+| 模式 | `content` | `reasoning_content` | 建议 `max_tokens` |
+|---|---|---|---|
+| `thinking.type=disabled` | 最终答案 | 通常无 | 较小即可 |
+| `thinking.type=enabled` | 最终答案 | 思考过程文本 | 明显加大（思考与答案共享额度） |
+
+也可用单独的 `reasoning_effort`（`low` / `medium` / `high`）控制强度。官方文档默认约为 `low`。
+
+## 示例输出（脱敏）
+
+```text
+=== Response parse (thinking-off) ===
+{
+  "role": "assistant",
+  "content": "6。因为先减 2 再加 3。"
+}
+usage: prompt=42 completion=18 total=60
+
+=== Response parse (thinking-on) ===
+{
+  "role": "assistant",
+  "content": "最终还剩 6 个苹果。",
+  "reasoning_content": "5-2=3，再 +3 → 6。…"
+}
+usage: prompt=42 completion=126 total=168
+
+=== Diff summary ===
+thinking-off has reasoning_content: False
+thinking-on  has reasoning_content: True
+```
+
+## 与本地部署的差异
+
+| 场景 | 参数 |
+|---|---|
+| TokenHub 托管（本示例） | 顶层 `thinking` / `reasoning_effort` |
+| vLLM / SGLang 本地 | `extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think\|low\|high"}}` |
+
+不要把本地参数原样拷到托管 API。

--- a/examples/api/05_reasoning_mode/main.py
+++ b/examples/api/05_reasoning_mode/main.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""05 — Reasoning mode on vs off."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common import MockMessage, MockResponse, dump_json, get_client, get_config, message_to_dict, redact, with_retry
+
+QUESTION = "小明有 5 个苹果，给了小红 2 个，又买了 3 个，最后还剩几个？只给最终数字和一句理由。"
+
+
+def ask(client, model: str, mock: bool, *, thinking_enabled: bool, effort: str | None):
+    extra: dict = {}
+    if thinking_enabled:
+        extra["thinking"] = {"type": "enabled"}
+        if effort:
+            extra["reasoning_effort"] = effort
+    else:
+        extra["thinking"] = {"type": "disabled"}
+
+    label = "thinking-on" if thinking_enabled else "thinking-off"
+    print(f"\n=== Request ({label}) ===")
+    print(dump_json({"model": model, "messages": [{"role": "user", "content": QUESTION}], **extra}))
+
+    if mock:
+        if thinking_enabled:
+            resp = MockResponse(
+                MockMessage(
+                    "最终还剩 6 个苹果。",
+                    reasoning_content="5-2=3，再 +3 → 6。",
+                )
+            )
+        else:
+            resp = MockResponse(MockMessage("6。因为先减 2 再加 3。"))
+    else:
+        resp = with_retry(
+            lambda: client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": QUESTION}],
+                temperature=0.9,
+                max_tokens=8192 if thinking_enabled else 512,
+                extra_body=extra,
+            ),
+            label=label,
+        )
+
+    msg = resp.choices[0].message
+    parsed = message_to_dict(msg)
+    if "reasoning_content" in parsed:
+        parsed["reasoning_content"] = redact(parsed["reasoning_content"], keep=200)
+    print(f"=== Response parse ({label}) ===")
+    print(dump_json(parsed))
+    usage = getattr(resp, "usage", None)
+    if usage:
+        print(
+            f"usage: prompt={usage.prompt_tokens} completion={usage.completion_tokens} "
+            f"total={usage.total_tokens}"
+        )
+    return parsed
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+
+    print("Compare thinking disabled vs enabled (reasoning_effort=high).")
+    print("Hosted TokenHub uses top-level thinking / reasoning_effort via extra_body.")
+    print("Local vLLM uses chat_template_kwargs — see repo README, not this example.")
+
+    off = ask(client, cfg.model, cfg.mock, thinking_enabled=False, effort=None)
+    on = ask(client, cfg.model, cfg.mock, thinking_enabled=True, effort="high")
+
+    print("\n=== Diff summary ===")
+    print(f"thinking-off has reasoning_content: {'reasoning_content' in off}")
+    print(f"thinking-on  has reasoning_content: {'reasoning_content' in on}")
+    print(f"thinking-off content: {off.get('content')}")
+    print(f"thinking-on  content: {on.get('content')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/06_error_handling/README.md
+++ b/examples/api/06_error_handling/README.md
@@ -83,7 +83,7 @@ Retry-After: 2
 {"error": {"message": "rate limit exceeded", "type": "rate_limit_error"}}
 ```
 
-## 示例输出（脱敏）
+## 示例输出（2026-07-18 TokenHub 实测）
 
 ```text
 === Retry classification ===
@@ -96,10 +96,15 @@ Retry-After: 2
 
 === Backoff with Retry-After ===
   Retry-After honored → sleep 1.5s
+=== Backoff without Retry-After (exp + jitter) ===
+  attempt=1 suggested_wait≈1.05s
+  attempt=2 suggested_wait≈2.37s
+  attempt=3 suggested_wait≈4.31s
 
 === Wrapped live call (with_retry) ===
-  [retry] ping attempt 1/4 failed: RateLimitError: mock 429. sleep 0.10s
-  success content='mock ok after retry'
+  success content='pong'
 ```
+
+分类与退避为本地演示；最后的 `pong` 为真实 TokenHub 调用结果。离线可用 `HY3_MOCK=1` 观察模拟 429 重试。
 
 生产环境请把重试逻辑下沉到统一 HTTP 客户端，并打点监控 429 / 5xx 比例。更多错误码见 [TokenHub API 错误码](https://cloud.tencent.com/document/product/1823/131595)。

--- a/examples/api/06_error_handling/README.md
+++ b/examples/api/06_error_handling/README.md
@@ -1,0 +1,105 @@
+# 06 Error Handling & Retry — 超时 / 限流 / 网络错误
+
+演示如何识别可重试错误，遵守 `Retry-After`，并用指数退避做有限重试。
+
+## 运行
+
+```bash
+cd examples/api
+python 06_error_handling/main.py
+
+# 离线演示分类与 mock 429：
+HY3_MOCK=1 python 06_error_handling/main.py
+```
+
+## 策略
+
+| 错误 | 是否重试 | 说明 |
+|---|---|---|
+| `429` 限流 | ✅ | 优先读 `Retry-After`（秒） |
+| `408` / `502` / `503` / `504` | ✅ | 上游临时问题 |
+| 连接失败 / 读超时 | ✅ | 网络抖动 |
+| `400` 参数错误 | ❌ | 改请求后再发 |
+| `401` / `403` | ❌ | 检查 Key / 权限 |
+| `402` 额度 | ❌ | 调整套餐或配额 |
+
+实现要点（见 `../common.py` 中 `with_retry`）：
+
+1. `max_attempts` 限制次数  
+2. `max_total_wait` 限制总等待预算  
+3. 有 `Retry-After` 则按其等待；否则 `base * 2^(attempt-1) + jitter`
+
+## 完整请求（被包装的业务调用）
+
+```python
+resp = with_retry(
+    lambda: client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": "只回复：pong"}],
+        max_tokens=16,
+        temperature=0,
+    ),
+    max_attempts=4,
+    max_total_wait=20.0,
+    label="ping",
+)
+print(resp.choices[0].message.content)
+```
+
+等价 curl（失败时自行根据状态码决定是否重试）：
+
+```bash
+curl -sS -D - "$HY3_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "只回复：pong"}],
+    "max_tokens": 16
+  }'
+```
+
+## 响应解析
+
+成功：
+
+```json
+{
+  "choices": [
+    {
+      "message": {"role": "assistant", "content": "pong"},
+      "finish_reason": "stop"
+    }
+  ]
+}
+```
+
+限流示意：
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 2
+
+{"error": {"message": "rate limit exceeded", "type": "rate_limit_error"}}
+```
+
+## 示例输出（脱敏）
+
+```text
+=== Retry classification ===
+  RateLimitError   retryable=True
+  Timeout          retryable=True
+  Connection       retryable=True
+  Auth 401         retryable=False
+  Bad request 400  retryable=False
+  Upstream 503     retryable=True
+
+=== Backoff with Retry-After ===
+  Retry-After honored → sleep 1.5s
+
+=== Wrapped live call (with_retry) ===
+  [retry] ping attempt 1/4 failed: RateLimitError: mock 429. sleep 0.10s
+  success content='mock ok after retry'
+```
+
+生产环境请把重试逻辑下沉到统一 HTTP 客户端，并打点监控 429 / 5xx 比例。更多错误码见 [TokenHub API 错误码](https://cloud.tencent.com/document/product/1823/131595)。

--- a/examples/api/06_error_handling/main.py
+++ b/examples/api/06_error_handling/main.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""06 — Error handling & retry (timeout / rate limit / network)."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from openai import APIConnectionError, APIStatusError, APITimeoutError, RateLimitError
+
+from common import get_client, get_config, is_retryable, retry_after_seconds, with_retry
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, headers: dict | None = None) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.request = None
+
+
+def demo_classify() -> None:
+    print("=== Retry classification ===")
+    cases = [
+        ("RateLimitError", RateLimitError("rate limited", response=FakeResponse(429, {"Retry-After": "2"}), body=None)),
+        ("Timeout", APITimeoutError(request=None)),  # type: ignore[arg-type]
+        ("Connection", APIConnectionError(message="dns", request=None)),  # type: ignore[arg-type]
+        ("Auth 401", APIStatusError("unauthorized", response=FakeResponse(401), body=None)),
+        ("Bad request 400", APIStatusError("bad", response=FakeResponse(400), body=None)),
+        ("Upstream 503", APIStatusError("unavailable", response=FakeResponse(503), body=None)),
+    ]
+    for name, exc in cases:
+        print(f"  {name:16} retryable={is_retryable(exc)}")
+
+
+def demo_backoff() -> None:
+    print("\n=== Backoff with Retry-After ===")
+    exc = RateLimitError(
+        "too many requests",
+        response=FakeResponse(429, {"Retry-After": "1.5"}),
+        body=None,
+    )
+    wait = retry_after_seconds(exc, attempt=1)
+    print(f"  Retry-After honored → sleep {wait}s")
+    time.sleep(min(wait, 0.2))  # keep demo snappy
+
+    print("=== Backoff without Retry-After (exp + jitter) ===")
+    for attempt in range(1, 4):
+        w = retry_after_seconds(APITimeoutError(request=None), attempt=attempt)  # type: ignore[arg-type]
+        print(f"  attempt={attempt} suggested_wait≈{w:.2f}s")
+
+
+def demo_live_or_mock(client, model: str, mock: bool) -> None:
+    print("\n=== Wrapped live call (with_retry) ===")
+
+    def _call():
+        if mock:
+            # Simulate one transient failure then success
+            if not getattr(_call, "_failed_once", False):
+                _call._failed_once = True  # type: ignore[attr-defined]
+                raise RateLimitError(
+                    "mock 429",
+                    response=FakeResponse(429, {"Retry-After": "0.1"}),
+                    body=None,
+                )
+            return type(
+                "R",
+                (),
+                {
+                    "choices": [
+                        type("C", (), {"message": type("M", (), {"content": "mock ok after retry"})()})()
+                    ]
+                },
+            )()
+        return client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "只回复：pong"}],
+            max_tokens=16,
+            temperature=0,
+        )
+
+    resp = with_retry(_call, max_attempts=4, max_total_wait=20.0, label="ping")
+    content = resp.choices[0].message.content
+    print(f"  success content={content!r}")
+
+
+def main() -> None:
+    cfg = get_config()
+    client = get_client(cfg)
+
+    print("Policy:")
+    print("  - Retry: 408/429/5xx, timeout, connection errors")
+    print("  - Do NOT retry: 400/401/402/403 (fix request or credentials)")
+    print("  - Prefer Retry-After; else exponential backoff + jitter")
+    print("  - Cap max_attempts and max_total_wait\n")
+
+    demo_classify()
+    demo_backoff()
+    demo_live_or_mock(client, cfg.model, cfg.mock)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -51,4 +51,4 @@ HY3_MOCK=1 python 01_basic_chat/main.py
 
 - 不要把真实 Key 写进代码或提交 `.env`
 - 分享日志前脱敏 `Authorization`、request / response id
-- 示例输出为脱敏样例，真实运行结果会因模型采样而变化
+- 示例 README 中的输出为 **2026-07-18** 在 TokenHub（`model=hy3`）实测后脱敏写入；文案与时延每次运行可能变化

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,54 @@
+# Hy3 API Examples
+
+可运行示例集合，配合根目录 [quickstart.md](../../quickstart.md) 使用。
+
+## 环境准备
+
+```bash
+cd examples/api
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+cp .env.example .env
+# 编辑 .env，填入 HY3_API_KEY
+```
+
+必需环境变量：
+
+| 变量 | 说明 | 默认 |
+|---|---|---|
+| `HY3_API_KEY` | TokenHub API Key | （必填） |
+| `HY3_BASE_URL` | API 地址 | `https://tokenhub.tencentmaas.com/v1` |
+| `HY3_MODEL` | 模型名 | `hy3` |
+| `HY3_MOCK` | `1` 时离线 mock，不发真实请求 | 关闭 |
+
+## 示例列表
+
+| # | 目录 | 能力 |
+|---|---|---|
+| 01 | [01_basic_chat](./01_basic_chat/) | 单轮 / 多轮对话 |
+| 02 | [02_streaming](./02_streaming/) | 流式请求 + chunk 解析 |
+| 03 | [03_latency_compare](./03_latency_compare/) | 非流式 vs 流式时延 |
+| 04 | [04_tool_calling](./04_tool_calling/) | 工具调用 + 多轮循环 |
+| 05 | [05_reasoning_mode](./05_reasoning_mode/) | 思考模式开 / 关 |
+| 06 | [06_error_handling](./06_error_handling/) | 超时 / 限流 / 重试退避 |
+
+每个目录含 `README.md`（请求说明、响应解析、示例输出）与 `main.py`。
+
+```bash
+python 01_basic_chat/main.py
+python 02_streaming/main.py
+# ...
+```
+
+无 Key 时可先：
+
+```bash
+HY3_MOCK=1 python 01_basic_chat/main.py
+```
+
+## 安全提示
+
+- 不要把真实 Key 写进代码或提交 `.env`
+- 分享日志前脱敏 `Authorization`、request / response id
+- 示例输出为脱敏样例，真实运行结果会因模型采样而变化

--- a/examples/api/common.py
+++ b/examples/api/common.py
@@ -1,0 +1,198 @@
+"""Shared helpers for Hy3 TokenHub API examples."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from dotenv import load_dotenv
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI, RateLimitError
+
+# Load .env next to this file (examples/api/.env)
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+T = TypeVar("T")
+
+DEFAULT_BASE_URL = "https://tokenhub.tencentmaas.com/v1"
+DEFAULT_MODEL = "hy3"
+
+
+@dataclass(frozen=True)
+class Config:
+    api_key: str
+    base_url: str
+    model: str
+    mock: bool
+
+
+def get_config() -> Config:
+    mock = os.getenv("HY3_MOCK", "").strip().lower() in {"1", "true", "yes"}
+    api_key = os.getenv("HY3_API_KEY", "").strip()
+    if not api_key and not mock:
+        raise SystemExit(
+            "Missing HY3_API_KEY. Export it, or copy .env.example to .env.\n"
+            "For offline syntax check: HY3_MOCK=1 python <example>/main.py"
+        )
+    return Config(
+        api_key=api_key or "mock-key",
+        base_url=os.getenv("HY3_BASE_URL", DEFAULT_BASE_URL).rstrip("/"),
+        model=os.getenv("HY3_MODEL", DEFAULT_MODEL),
+        mock=mock,
+    )
+
+
+def get_client(cfg: Config | None = None) -> OpenAI:
+    cfg = cfg or get_config()
+    return OpenAI(api_key=cfg.api_key, base_url=cfg.base_url, timeout=60.0)
+
+
+def redact(text: str | None, keep: int = 120) -> str:
+    """Shorten long sample output for docs / console."""
+    if not text:
+        return ""
+    text = text.strip()
+    if len(text) <= keep:
+        return text
+    return text[:keep] + "…"
+
+
+def message_to_dict(msg: Any) -> dict[str, Any]:
+    """Serialize an assistant message, preserving reasoning_content for tool loops."""
+    data: dict[str, Any] = {
+        "role": msg.role,
+        "content": msg.content,
+    }
+    reasoning = getattr(msg, "reasoning_content", None)
+    if reasoning:
+        data["reasoning_content"] = reasoning
+
+    if getattr(msg, "tool_calls", None):
+        data["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": tc.type,
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in msg.tool_calls
+        ]
+    return data
+
+
+def dump_json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, indent=2)
+
+
+def is_retryable(exc: BaseException) -> bool:
+    if isinstance(exc, (APIConnectionError, APITimeoutError, RateLimitError)):
+        return True
+    if isinstance(exc, APIStatusError):
+        return exc.status_code in {408, 429, 500, 502, 503, 504}
+    return False
+
+
+def retry_after_seconds(exc: BaseException, attempt: int, base: float = 1.0) -> float:
+    """Prefer Retry-After; otherwise exponential backoff with jitter."""
+    if isinstance(exc, APIStatusError):
+        header = None
+        try:
+            header = exc.response.headers.get("Retry-After")
+        except Exception:
+            header = None
+        if header:
+            try:
+                return max(0.0, float(header))
+            except ValueError:
+                pass
+    # attempt starts at 1
+    delay = base * (2 ** (attempt - 1))
+    return delay + random.uniform(0, 0.5)
+
+
+def with_retry(
+    fn: Callable[[], T],
+    *,
+    max_attempts: int = 4,
+    max_total_wait: float = 30.0,
+    label: str = "request",
+) -> T:
+    """Run fn with limited retries for transient failures."""
+    started = time.monotonic()
+    last_exc: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 - surface retry decision clearly
+            last_exc = exc
+            if not is_retryable(exc) or attempt >= max_attempts:
+                raise
+            wait = retry_after_seconds(exc, attempt)
+            elapsed = time.monotonic() - started
+            if elapsed + wait > max_total_wait:
+                raise RuntimeError(
+                    f"{label} aborted: would exceed max_total_wait={max_total_wait}s"
+                ) from exc
+            print(
+                f"[retry] {label} attempt {attempt}/{max_attempts} failed: "
+                f"{type(exc).__name__}: {exc}. sleep {wait:.2f}s"
+            )
+            time.sleep(wait)
+    assert last_exc is not None
+    raise last_exc
+
+
+class MockMessage:
+    def __init__(
+        self,
+        content: str | None = None,
+        *,
+        role: str = "assistant",
+        reasoning_content: str | None = None,
+        tool_calls: list[Any] | None = None,
+    ) -> None:
+        self.role = role
+        self.content = content
+        self.reasoning_content = reasoning_content
+        self.tool_calls = tool_calls
+
+
+class MockToolCall:
+    def __init__(self, name: str, arguments: str, call_id: str = "call_mock_1") -> None:
+        self.id = call_id
+        self.type = "function"
+        self.function = type("Fn", (), {"name": name, "arguments": arguments})()
+
+
+class MockChoice:
+    def __init__(self, message: MockMessage, finish_reason: str = "stop") -> None:
+        self.message = message
+        self.finish_reason = finish_reason
+        self.delta = message  # reuse for stream-like demos when needed
+
+
+class MockUsage:
+    def __init__(self, prompt: int = 20, completion: int = 40) -> None:
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.total_tokens = prompt + completion
+
+
+class MockResponse:
+    def __init__(
+        self,
+        message: MockMessage,
+        *,
+        finish_reason: str = "stop",
+        model: str = DEFAULT_MODEL,
+    ) -> None:
+        self.id = "chatcmpl-mock"
+        self.model = model
+        self.choices = [MockChoice(message, finish_reason)]
+        self.usage = MockUsage()

--- a/examples/api/requirements.txt
+++ b/examples/api/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.40.0
+python-dotenv>=1.0.0

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,175 @@
+# Hy3 API Quickstart
+
+> 目标：5 分钟完成第一次调用，半小时上手主要能力。  
+> 本文面向 **腾讯云 TokenHub 托管 API**（OpenAI 兼容）。本地 vLLM / SGLang 部署请看仓库 [README](./README_CN.md)；两者参数不完全相同，请勿混用。
+
+## 1. 基础信息
+
+| 项 | 值 |
+|---|---|
+| Base URL（国内 / 广州） | `https://tokenhub.tencentmaas.com/v1` |
+| Base URL（国际 / 新加坡） | `https://tokenhub-intl.tencentmaas.com/v1` |
+| Chat Completions | `{BASE_URL}/chat/completions` |
+| Model | `hy3`（可选 `hy3-preview`） |
+| Auth | `Authorization: Bearer <API_KEY>` |
+| 推荐采样 | `temperature=0.9`，`top_p=1.0` |
+| 上下文 | 256K（最大输入约 192K，最大输出约 128K） |
+
+### 获取 API Key
+
+1. 打开 [TokenHub API Key 管理](https://cloud.tencent.com/document/product/1823/130090) 按文档创建 Key。
+2. 仅通过环境变量注入，不要写进代码、截图或提交到 Git。
+
+```bash
+export HY3_API_KEY='your-api-key'
+export HY3_BASE_URL='https://tokenhub.tencentmaas.com/v1'
+export HY3_MODEL='hy3'
+```
+
+### 速率限制
+
+QPM / RPM、TPM、TPD 与并发上限取决于套餐与 Key 配置，以控制台为准。触发限流时常见 HTTP `429`，响应可能带 `Retry-After`（秒）。生产环境应对 429 / 5xx / 超时做有限重试；401 / 403 / 402 等鉴权与额度错误应立刻修正，不要盲目重试。
+
+---
+
+## 2. 最小可运行示例
+
+### 2.1 curl
+
+```bash
+curl "$HY3_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "用一句话介绍你自己。"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 256
+  }'
+```
+
+成功时重点看：
+
+- `choices[0].message.content`：最终回答
+- `choices[0].finish_reason`：结束原因（如 `stop`）
+- `usage`：token 用量
+
+### 2.2 Python（OpenAI SDK）
+
+```bash
+pip install openai
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["HY3_API_KEY"],
+    base_url=os.environ.get("HY3_BASE_URL", "https://tokenhub.tencentmaas.com/v1"),
+)
+
+resp = client.chat.completions.create(
+    model=os.environ.get("HY3_MODEL", "hy3"),
+    messages=[{"role": "user", "content": "用一句话介绍你自己。"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+)
+print(resp.choices[0].message.content)
+```
+
+更完整的 6 个可运行示例见 [examples/api/](./examples/api/)。
+
+---
+
+## 3. 参数说明
+
+| 参数 | 说明 |
+|---|---|
+| `temperature` | `[0, 2]`，越高越随机。通常与 `top_p` 二选一细调。 |
+| `top_p` | `[0, 1]` 核采样阈值。官方推荐日常对话 `1.0`。 |
+| `max_tokens` | 生成上限；**思考 token 与最终答案共享额度**。开启深度思考时建议显著加大（如 ≥ 16000）。 |
+| `stop` | 停止串（string 或最多 4 个 string）；命中后停止，响应不含停止串本身。 |
+| `stream` | `true` 时 SSE 流式返回；可配 `stream_options={"include_usage": true}` 在末尾拿到 usage。 |
+| `tools` / `tool_choice` | OpenAI Function Calling。模型只提出 `tool_calls`，业务侧执行后以 `role=tool` 回填。 |
+| `thinking` | 托管 API 顶层字段：`{"type":"enabled"}` / `{"type":"disabled"}`。Python SDK 用 `extra_body` 传入。 |
+| `reasoning_effort` | 思考强度：`low` / `medium` / `high`（以及本地部署文档中的 `no_think`）。托管侧同样经 `extra_body` 透传。 |
+
+### 思考模式开关（托管 API）
+
+```python
+# 开启思考，并从响应读取 reasoning_content
+resp = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "小明有 5 个苹果，给了小红 2 个，又买了 3 个，还剩几个？"}],
+    extra_body={
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "high",
+    },
+)
+msg = resp.choices[0].message
+print("思考:", getattr(msg, "reasoning_content", None))
+print("回答:", msg.content)
+```
+
+> **注意**：仓库 README 里本地部署示例使用  
+> `extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}}`。  
+> 这是 vLLM / SGLang 路径；**TokenHub 托管请用顶层 `thinking` / `reasoning_effort`**。
+
+### 工具调用要点
+
+1. 请求带 `tools`，模型可能返回 `finish_reason=tool_calls`。
+2. 将 assistant 消息（含 `content`、`tool_calls`，以及若有的 `reasoning_content`）原样追加到 `messages`。
+3. 业务执行工具后追加 `{"role":"tool","tool_call_id": "...","content": "..."}`。
+4. 再次请求，直到得到最终文本答案。
+
+带 tools 时，若设置 `reasoning_effort=low`，官方说明 API 可能自动映射为 `high`（兼容自适应思考）。
+
+---
+
+## 4. 常见报错排查
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| `401` | Key 缺失 / 错误 / 过期 | 检查 `HY3_API_KEY` 是否在当前 shell 生效 |
+| `403` | 无模型权限、账号受限、IP 白名单 | 控制台核对模型授权与账号状态 |
+| `400` / 参数错误 | model 名错误、messages 格式非法 | 确认 `hy3`，messages 以 `user` 结尾 |
+| `429` | 限流 | 降并发，遵守 `Retry-After`，指数退避 |
+| `502` / `503` / `504` | 上游临时故障 | 有限重试；长期失败查服务状态 |
+| 连接失败 / DNS | Base URL 地域或路径错误 | 确认是否带 `/v1`，国内外入口是否一致 |
+| 空回答 / 截断 | `max_tokens` 过小 | 思考模式加大 `max_tokens` |
+| `finish_reason=length` | 触及生成上限 | 增大 `max_tokens` 或缩短任务 |
+| SDK 读不到思考字段 | 字段非标 | 用 `getattr(msg, "reasoning_content", None)` |
+
+完整错误码见 [TokenHub API 错误码](https://cloud.tencent.com/document/product/1823/131595)。
+
+---
+
+## 5. 下一步
+
+| 示例 | 说明 |
+|---|---|
+| [01_basic_chat](./examples/api/01_basic_chat/) | 单轮 / 多轮对话 |
+| [02_streaming](./examples/api/02_streaming/) | 流式请求与 chunk 解析 |
+| [03_latency_compare](./examples/api/03_latency_compare/) | 非流式 vs 流式时延 |
+| [04_tool_calling](./examples/api/04_tool_calling/) | 单次工具调用 + 多轮工具循环 |
+| [05_reasoning_mode](./examples/api/05_reasoning_mode/) | 思考开 / 关对比 |
+| [06_error_handling](./examples/api/06_error_handling/) | 超时 / 限流 / 网络错误重试 |
+
+```bash
+cd examples/api
+pip install -r requirements.txt
+cp .env.example .env   # 填入 HY3_API_KEY
+python 01_basic_chat/main.py
+```
+
+## 参考
+
+- [TokenHub 混元调用指南（含 Hy3）](https://cloud.tencent.com/document/product/1823/132252)
+- [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)
+- [深度思考](https://cloud.tencent.com/document/product/1823/131208)
+- [API 错误码](https://cloud.tencent.com/document/product/1823/131595)

--- a/quickstart.md
+++ b/quickstart.md
@@ -5,15 +5,17 @@
 
 ## 1. 基础信息
 
-| 项 | 值 |
-|---|---|
-| Base URL（国内 / 广州） | `https://tokenhub.tencentmaas.com/v1` |
+
+| 项                  | 值                                          |
+| ------------------ | ------------------------------------------ |
+| Base URL（国内 / 广州）  | `https://tokenhub.tencentmaas.com/v1`      |
 | Base URL（国际 / 新加坡） | `https://tokenhub-intl.tencentmaas.com/v1` |
-| Chat Completions | `{BASE_URL}/chat/completions` |
-| Model | `hy3`（可选 `hy3-preview`） |
-| Auth | `Authorization: Bearer <API_KEY>` |
-| 推荐采样 | `temperature=0.9`，`top_p=1.0` |
-| 上下文 | 256K（最大输入约 192K，最大输出约 128K） |
+| Chat Completions   | `{BASE_URL}/chat/completions`              |
+| Model              | `hy3`（可选 `hy3-preview`）                    |
+| Auth               | `Authorization: Bearer <API_KEY>`          |
+| 推荐采样               | `temperature=0.9`，`top_p=1.0`              |
+| 上下文                | 256K（最大输入约 192K，最大输出约 128K）                |
+
 
 ### 获取 API Key
 
@@ -26,13 +28,19 @@ export HY3_BASE_URL='https://tokenhub.tencentmaas.com/v1'
 export HY3_MODEL='hy3'
 ```
 
+
+
 ### 速率限制
 
 QPM / RPM、TPM、TPD 与并发上限取决于套餐与 Key 配置，以控制台为准。触发限流时常见 HTTP `429`，响应可能带 `Retry-After`（秒）。生产环境应对 429 / 5xx / 超时做有限重试；401 / 403 / 402 等鉴权与额度错误应立刻修正，不要盲目重试。
 
 ---
 
+
+
 ## 2. 最小可运行示例
+
+
 
 ### 2.1 curl
 
@@ -56,6 +64,8 @@ curl "$HY3_BASE_URL/chat/completions" \
 - `choices[0].message.content`：最终回答
 - `choices[0].finish_reason`：结束原因（如 `stop`）
 - `usage`：token 用量
+
+
 
 ### 2.2 Python（OpenAI SDK）
 
@@ -86,18 +96,24 @@ print(resp.choices[0].message.content)
 
 ---
 
+
+
 ## 3. 参数说明
 
-| 参数 | 说明 |
-|---|---|
-| `temperature` | `[0, 2]`，越高越随机。通常与 `top_p` 二选一细调。 |
-| `top_p` | `[0, 1]` 核采样阈值。官方推荐日常对话 `1.0`。 |
-| `max_tokens` | 生成上限；**思考 token 与最终答案共享额度**。开启深度思考时建议显著加大（如 ≥ 16000）。 |
-| `stop` | 停止串（string 或最多 4 个 string）；命中后停止，响应不含停止串本身。 |
-| `stream` | `true` 时 SSE 流式返回；可配 `stream_options={"include_usage": true}` 在末尾拿到 usage。 |
-| `tools` / `tool_choice` | OpenAI Function Calling。模型只提出 `tool_calls`，业务侧执行后以 `role=tool` 回填。 |
-| `thinking` | 托管 API 顶层字段：`{"type":"enabled"}` / `{"type":"disabled"}`。Python SDK 用 `extra_body` 传入。 |
-| `reasoning_effort` | 思考强度：`low` / `medium` / `high`（以及本地部署文档中的 `no_think`）。托管侧同样经 `extra_body` 透传。 |
+
+| 参数                      | 说明                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `temperature`           | `[0, 2]`，越高越随机。通常与 `top_p` 二选一细调。                                                      |
+| `top_p`                 | `[0, 1]` 核采样阈值。官方推荐日常对话 `1.0`。                                                         |
+| `max_tokens`            | 生成上限；**思考 token 与最终答案共享额度**。开启深度思考时建议显著加大（如 ≥ 16000）。                                  |
+| `stop`                  | 停止串（string 或最多 4 个 string）；命中后停止，响应不含停止串本身。                                            |
+| `stream`                | `true` 时 SSE 流式返回；可配 `stream_options={"include_usage": true}` 在末尾拿到 usage。             |
+| `tools` / `tool_choice` | OpenAI Function Calling。模型只提出 `tool_calls`，业务侧执行后以 `role=tool` 回填。                     |
+| `thinking`              | 托管 API 顶层字段：`{"type":"enabled"}` / `{"type":"disabled"}`。Python SDK 用 `extra_body` 传入。 |
+| `reasoning_effort`      | 思考强度：`low` / `medium` / `high`（以及本地部署文档中的 `no_think`）。托管侧同样经 `extra_body` 透传。          |
+
+
+
 
 ### 思考模式开关（托管 API）
 
@@ -118,7 +134,9 @@ print("回答:", msg.content)
 
 > **注意**：仓库 README 里本地部署示例使用  
 > `extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}}`。  
-> 这是 vLLM / SGLang 路径；**TokenHub 托管请用顶层 `thinking` / `reasoning_effort`**。
+> 这是 vLLM / SGLang 路径；**TokenHub 托管请用顶层** `thinking` **/** `reasoning_effort`。
+
+
 
 ### 工具调用要点
 
@@ -131,34 +149,42 @@ print("回答:", msg.content)
 
 ---
 
+
+
 ## 4. 常见报错排查
 
-| 现象 | 可能原因 | 处理 |
-|---|---|---|
-| `401` | Key 缺失 / 错误 / 过期 | 检查 `HY3_API_KEY` 是否在当前 shell 生效 |
-| `403` | 无模型权限、账号受限、IP 白名单 | 控制台核对模型授权与账号状态 |
-| `400` / 参数错误 | model 名错误、messages 格式非法 | 确认 `hy3`，messages 以 `user` 结尾 |
-| `429` | 限流 | 降并发，遵守 `Retry-After`，指数退避 |
-| `502` / `503` / `504` | 上游临时故障 | 有限重试；长期失败查服务状态 |
-| 连接失败 / DNS | Base URL 地域或路径错误 | 确认是否带 `/v1`，国内外入口是否一致 |
-| 空回答 / 截断 | `max_tokens` 过小 | 思考模式加大 `max_tokens` |
-| `finish_reason=length` | 触及生成上限 | 增大 `max_tokens` 或缩短任务 |
-| SDK 读不到思考字段 | 字段非标 | 用 `getattr(msg, "reasoning_content", None)` |
+
+| 现象                     | 可能原因                    | 处理                                          |
+| ---------------------- | ----------------------- | ------------------------------------------- |
+| `401`                  | Key 缺失 / 错误 / 过期        | 检查 `HY3_API_KEY` 是否在当前 shell 生效             |
+| `403`                  | 无模型权限、账号受限、IP 白名单       | 控制台核对模型授权与账号状态                              |
+| `400` / 参数错误           | model 名错误、messages 格式非法 | 确认 `hy3`，messages 以 `user` 结尾               |
+| `429`                  | 限流                      | 降并发，遵守 `Retry-After`，指数退避                   |
+| `502` / `503` / `504`  | 上游临时故障                  | 有限重试；长期失败查服务状态                              |
+| 连接失败 / DNS             | Base URL 地域或路径错误        | 确认是否带 `/v1`，国内外入口是否一致                       |
+| 空回答 / 截断               | `max_tokens` 过小         | 思考模式加大 `max_tokens`                         |
+| `finish_reason=length` | 触及生成上限                  | 增大 `max_tokens` 或缩短任务                       |
+| SDK 读不到思考字段            | 字段非标                    | 用 `getattr(msg, "reasoning_content", None)` |
+
 
 完整错误码见 [TokenHub API 错误码](https://cloud.tencent.com/document/product/1823/131595)。
 
 ---
 
+
+
 ## 5. 下一步
 
-| 示例 | 说明 |
-|---|---|
-| [01_basic_chat](./examples/api/01_basic_chat/) | 单轮 / 多轮对话 |
-| [02_streaming](./examples/api/02_streaming/) | 流式请求与 chunk 解析 |
-| [03_latency_compare](./examples/api/03_latency_compare/) | 非流式 vs 流式时延 |
-| [04_tool_calling](./examples/api/04_tool_calling/) | 单次工具调用 + 多轮工具循环 |
-| [05_reasoning_mode](./examples/api/05_reasoning_mode/) | 思考开 / 关对比 |
-| [06_error_handling](./examples/api/06_error_handling/) | 超时 / 限流 / 网络错误重试 |
+
+| 示例                                                       | 说明               |
+| -------------------------------------------------------- | ---------------- |
+| [01_basic_chat](./examples/api/01_basic_chat/)           | 单轮 / 多轮对话        |
+| [02_streaming](./examples/api/02_streaming/)             | 流式请求与 chunk 解析   |
+| [03_latency_compare](./examples/api/03_latency_compare/) | 非流式 vs 流式时延      |
+| [04_tool_calling](./examples/api/04_tool_calling/)       | 单次工具调用 + 多轮工具循环  |
+| [05_reasoning_mode](./examples/api/05_reasoning_mode/)   | 思考开 / 关对比        |
+| [06_error_handling](./examples/api/06_error_handling/)   | 超时 / 限流 / 网络错误重试 |
+
 
 ```bash
 cd examples/api
@@ -167,9 +193,12 @@ cp .env.example .env   # 填入 HY3_API_KEY
 python 01_basic_chat/main.py
 ```
 
+六个示例已于 **2026-07-18** 在 TokenHub 广州入口使用 `model=hy3` 实测通过；各目录 README 中的示例输出为脱敏后的实测结果。
+
 ## 参考
 
 - [TokenHub 混元调用指南（含 Hy3）](https://cloud.tencent.com/document/product/1823/132252)
 - [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)
 - [深度思考](https://cloud.tencent.com/document/product/1823/131208)
 - [API 错误码](https://cloud.tencent.com/document/product/1823/131595)
+


### PR DESCRIPTION
## Summary
- 新增 `quickstart.md`：TokenHub 接入、参数说明、常见报错
- 新增 `examples/api/` 六个可运行示例（对话/流式/时延/工具/思考/重试）
- 已在 TokenHub 用 `model=hy3` 实测，README 中为脱敏输出

Related to #1