### PR TITLE
docs: quickstart issue #1

### DIFF
--- a/api-docs/examples/01-basic-chat.md
+++ b/api-docs/examples/01-basic-chat.md
@@ -1,0 +1,222 @@
+# Example 01: Basic Chat
+
+单轮对话与多轮对话的基本用法。
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+设置环境变量（或直接写在代码里）：
+
+```bash
+export HY3_API_KEY="your-api-key-here"
+```
+
+---
+
+## 单轮对话
+
+### 完整代码
+
+```python
+import os
+from openai import OpenAI
+
+# ============================================================
+# 1. 创建客户端
+# ============================================================
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 2. 发送请求
+# ============================================================
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "你好，请用三句话介绍一下你自己"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+)
+
+# ============================================================
+# 3. 解析响应
+# ============================================================
+choice = response.choices[0]
+
+# 判断结束原因
+finish_reason = choice.finish_reason  # "stop" | "length" | "tool_calls"
+print(f"finish_reason: {finish_reason}")
+
+# 获取正文
+content = choice.message.content
+print(f"content:\n{content}\n")
+
+# 获取用量
+usage = response.usage
+print(f"prompt_tokens:     {usage.prompt_tokens}")
+print(f"completion_tokens: {usage.completion_tokens}")
+print(f"total_tokens:      {usage.total_tokens}")
+
+# ============================================================
+# 4. 完整 response 对象结构
+# ============================================================
+# response 对象主要属性：
+#   response.id              → str   : 本次请求唯一 ID
+#   response.object          → str   : "chat.completion"
+#   response.created         → int   : Unix 时间戳
+#   response.model           → str   : "hy3"
+#   response.choices         → list  : 生成结果列表
+#   response.usage           → object: token 用量
+#
+# choice 对象主要属性：
+#   choice.index             → int   : 序号（通常为 0）
+#   choice.finish_reason     → str   : 结束原因
+#   choice.message.role      → str   : "assistant"
+#   choice.message.content   → str   : 回复正文
+#   choice.message.tool_calls → list / None : 工具调用（如有）
+```
+
+### 示例输出
+
+```
+finish_reason: stop
+content:
+你好！我是混元，是由腾讯开发的大模型。我专注于基础信息处理与逻辑响应，能为你解答问题、提供信息支持。如果有具体需求，随时告诉我哦～
+
+prompt_tokens:     22
+completion_tokens: 38
+total_tokens:      60
+```
+
+---
+
+## 多轮对话
+
+多轮对话的核心是将之前的对话历史完整传入 `messages` 数组。
+
+### 完整代码
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 初始化消息历史
+# ============================================================
+messages = [
+    {"role": "system", "content": "你是一个简洁的编程助手，回复不超过3句话。"},
+]
+
+# ============================================================
+# 第 1 轮
+# ============================================================
+messages.append({"role": "user", "content": "Python 里怎么去重一个列表？"})
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=messages,
+    temperature=0.9,
+    max_tokens=128,
+)
+
+assistant_reply = response.choices[0].message.content
+print(f"[Round 1] User: {messages[-1]['content']}")
+print(f"[Round 1] Assistant: {assistant_reply}\n")
+
+# 把助手回复加入历史
+messages.append({"role": "assistant", "content": assistant_reply})
+
+# ============================================================
+# 第 2 轮 — 追问
+# ============================================================
+messages.append({"role": "user", "content": "如果要保持原顺序呢？"})
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=messages,
+    temperature=0.9,
+    max_tokens=128,
+)
+
+assistant_reply = response.choices[0].message.content
+print(f"[Round 2] User: {messages[-1]['content']}")
+print(f"[Round 2] Assistant: {assistant_reply}\n")
+
+messages.append({"role": "assistant", "content": assistant_reply})
+
+# ============================================================
+# 第 3 轮 — 继续追问
+# ============================================================
+messages.append({"role": "user", "content": "这两种方法哪种更快？"})
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=messages,
+    temperature=0.9,
+    max_tokens=128,
+)
+
+assistant_reply = response.choices[0].message.content
+print(f"[Round 3] User: {messages[-1]['content']}")
+print(f"[Round 3] Assistant: {assistant_reply}\n")
+
+# ============================================================
+# 查看完整的 messages 历史
+# ============================================================
+print("=" * 60)
+print("完整对话历史（共 {} 条消息）：".format(len(messages)))
+print("=" * 60)
+for i, msg in enumerate(messages):
+    role = msg["role"]
+    content = msg["content"][:80]
+    print(f"  [{i}] {role:10s} | {content}...")
+```
+
+### 示例输出
+
+```
+[Round 1] User: Python 里怎么去重一个列表？
+[Round 1] Assistant: 可用 `list(dict.fromkeys(lst))` 或 `list(set(lst))`（后者不保序）去重。若需保序且版本≥3.7，推荐前者。
+
+[Round 2] User: 如果要保持原顺序呢？
+[Round 2] Assistant: 用 `list(dict.fromkeys(lst))` 可保持原顺序去重，或 Python 3.7+ 直接用 `list(set(lst))` 也保序但可读性差。推荐 `dict.fromkeys`。
+
+[Round 3] User: 这两种方法哪种更快？
+[Round 3] Assistant: `dict.fromkeys` 通常比 `set` 转 list 略快且保序，二者均为 O(n)。建议用 `list(dict.fromkeys(lst))`。
+
+============================================================
+完整对话历史（共 6 条消息）：
+============================================================
+  [0] system     | 你是一个简洁的编程助手，回复不超过3句话。...
+  [1] user       | Python 里怎么去重一个列表？...
+  [2] assistant  | 可用 `list(dict.fromkeys(lst))` 或 `list(set(lst))`（后者不保序）去重。若需保序且版本≥3.7，推荐前者。...
+  [3] user       | 如果要保持原顺序呢？...
+  [4] assistant  | 用 `list(dict.fromkeys(lst))` 可保持原顺序去重，或 Python 3.7+ 直接用 `list(set(lst))` 也保序但可读性...
+  [5] user       | 这两种方法哪种更快？...
+```
+
+---
+
+## 关键要点
+
+| 要点 | 说明 |
+|:---|:---|
+| **messages 数组即状态** | 多轮对话的全部上下文由 `messages` 数组传递，服务端无状态 |
+| **role 顺序** | 通常以 `system` 开头（可选），然后 `user` / `assistant` 交替 |
+| **token 累积** | 每轮都会重新计算全部历史 token，长对话注意控制历史长度 |
+| **finish_reason** | `"stop"`（正常结束）、`"length"`（达到 max_tokens 截断）、`"tool_calls"`（触发工具调用） |
+| **system prompt** | 用于设定角色、语气、规则等全局行为 |

--- a/api-docs/examples/02-streaming.md
+++ b/api-docs/examples/02-streaming.md
@@ -1,0 +1,245 @@
+# Example 02: Streaming
+
+流式请求与逐 chunk 解析，实现打字机效果的实时输出。
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+---
+
+## 流式请求 — 基础版
+
+### 完整代码
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 开启 stream=True
+# ============================================================
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "写一首五行诗，主题是编程"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+    stream=True,  # 关键参数
+)
+
+# ============================================================
+# 逐 chunk 解析
+# ============================================================
+print("Assistant: ", end="", flush=True)
+
+for chunk in stream:
+    # chunk 是 ChatCompletionChunk 对象
+    if chunk.choices and len(chunk.choices) > 0:
+        delta = chunk.choices[0].delta
+
+        # delta.content 是本次增量文本（可能为 None）
+        if delta.content:
+            print(delta.content, end="", flush=True)
+
+        # delta.role 仅第一个 chunk 有值（"assistant"）
+        if delta.role:
+            pass  # 通常是 "assistant"，可忽略
+
+        # finish_reason 仅最后一个 chunk 有值
+        if chunk.choices[0].finish_reason:
+            finish_reason = chunk.choices[0].finish_reason
+            # "stop" | "length" | "tool_calls"
+
+print()  # 换行
+```
+
+### 示例输出（打字机效果逐字输出）
+
+```
+Assistant: 代码如诗行，
+逻辑筑桥梁。
+bug藏暗处，
+调试迎晨光。
+指尖生万象。
+```
+
+---
+
+## 流式请求 — 进阶版（含用量统计）
+
+Hy3 流式请求的最后一个 chunk 可能包含 `usage` 信息，用于统计 token 消耗。
+
+### 完整代码
+
+```python
+import os
+import time
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 发送流式请求
+# ============================================================
+start_time = time.time()
+
+stream = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "解释一下什么是 Docker，100 字以内"},
+    ],
+    temperature=0.9,
+    max_tokens=200,
+    stream=True,
+)
+
+# ============================================================
+# 状态变量
+# ============================================================
+collected_content = ""      # 累积完整内容
+collected_reasoning = ""    # 累积思考过程（如有）
+chunk_count = 0             # chunk 计数
+first_token_time = None     # 首 token 到达时间
+finish_reason = None        # 结束原因
+usage = None                # token 用量
+
+# ============================================================
+# 遍历 chunks
+# ============================================================
+for chunk in stream:
+    chunk_count += 1
+
+    if not chunk.choices:
+        continue
+
+    choice = chunk.choices[0]
+    delta = choice.delta if choice.delta else None
+
+    if delta is None:
+        continue
+
+    # 首 token 计时
+    if first_token_time is None and (getattr(delta, "content", None) or getattr(delta, "reasoning_content", None)):
+        first_token_time = time.time() - start_time
+
+    # 累积思考内容（仅 reasoning_effort != "no_think" 时可能有）
+    if getattr(delta, "reasoning_content", None):
+        collected_reasoning += delta.reasoning_content
+        print(f"\033[90m{delta.reasoning_content}\033[0m", end="", flush=True)
+
+    # 累积正文
+    if delta.content:
+        collected_content += delta.content
+        print(delta.content, end="", flush=True)
+
+    # 结束原因（仅最后一个 chunk）
+    if choice.finish_reason:
+        finish_reason = choice.finish_reason
+
+    # 用量（仅最后一个 chunk 可能有）
+    if hasattr(chunk, "usage") and chunk.usage:
+        usage = chunk.usage
+
+# ============================================================
+# 汇总统计
+# ============================================================
+total_time = time.time() - start_time
+
+print("\n")
+print("=" * 50)
+print("流式请求统计")
+print("=" * 50)
+print(f"  总耗时:        {total_time:.2f}s")
+print(f"  首 token 时延: {first_token_time:.2f}s" if first_token_time else "  首 token 时延: N/A")
+print(f"  chunk 数:      {chunk_count}")
+print(f"  完成原因:      {finish_reason}")
+if usage:
+    print(f"  prompt_tokens:     {usage.prompt_tokens}")
+    print(f"  completion_tokens: {usage.completion_tokens}")
+    print(f"  total_tokens:      {usage.total_tokens}")
+print(f"  累积内容长度:  {len(collected_content)} 字符")
+```
+
+### 示例输出
+
+```
+Docker 是一种容器化平台，可将应用及其依赖打包成轻量、可移植的容器。它基于操作系统级虚拟化，实现环境一致、快速部署与隔离，相比传统虚拟机更省资源、启动更快。
+
+==================================================
+流式请求统计
+==================================================
+  总耗时:        1.46s
+  首 token 时延: 0.72s
+  chunk 数:      26
+  完成原因:      stop
+  累积内容长度:  81 字符
+```
+
+---
+
+## chunk 结构说明
+
+每个 `chunk` 是一个 `ChatCompletionChunk` 对象：
+
+```python
+# chunk 结构（关键字段）
+{
+    "id": "xxxxxxxx",
+    "object": "chat.completion.chunk",
+    "created": 1718432000,
+    "model": "hy3",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {
+                "content": "Docker",      # 增量文本（可为空字符串）
+                "function_call": None,
+                "refusal": None,
+                "role": "assistant",      # 仅第一个 chunk
+                "tool_calls": None,
+            },
+            "finish_reason": None,         # 仅最后一个 chunk 有值
+        }
+    ],
+    "usage": None,  # 仅最后一个 chunk 可能有值
+}
+```
+
+### 各字段出现时机
+
+| 字段 | 第一个 chunk | 中间 chunks | 最后一个 chunk |
+|:---|:---|:---|:---|
+| `delta.role` | ✅ `"assistant"` | ❌ `None` | ❌ `None` |
+| `delta.content` | ✅ | ✅ | ✅（可能为空） |
+| `delta.function_call` | ❌ `None` | ❌ `None` | ❌ `None` |
+| `delta.refusal` | ❌ `None` | ❌ `None` | ❌ `None` |
+| `delta.tool_calls` | ✅（如有） | ✅（如有） | ❌ `None` |
+| `finish_reason` | ❌ `None` | ❌ `None` | ✅ `"stop"` / `"length"` / `"tool_calls"` |
+| `usage` | ❌ `None` | ❌ `None` | ✅ 或 `None` |
+
+---
+
+## 关键要点
+
+| 要点 | 说明 |
+|:---|:---|
+| **stream=True** | 唯一的开关，设置为 `True` 即启用流式 |
+| **delta.content 可能为空** | 某些 chunk 只传 role 或 tool_calls，必须判空 |
+| **finish_reason 仅在末尾** | 在此之前为 `None` |
+| **usage 不一定有** | 部分部署可能不返回 usage 信息 |
+| **基础流式不含思考字段** | 这份示例输出里没有 `reasoning_content`，思考模式见 example 05 |

--- a/api-docs/examples/03-streaming-vs-non-streaming.md
+++ b/api-docs/examples/03-streaming-vs-non-streaming.md
@@ -1,0 +1,199 @@
+# Example 03: Non-Streaming vs Streaming
+
+对比非流式与流式请求的**首 token 时延（TTFT）**和**总耗时**差异。
+
+---
+
+## 为什么需要对比？
+
+| 指标 | 非流式 | 流式 |
+|:---|:---|:---|
+| **首 token 时延（TTFT）** | 不可感知（必须等全部生成完毕） | 可精确测量 |
+| **用户体感** | 等待期间无反馈（"白屏"） | 逐字输出，即时反馈 |
+| **总耗时** | 生成时间 = 总耗时 | 与生成时间基本一致 |
+| **适用场景** | 后台批处理、结构化输出 | 交互式对话、实时 UI |
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+---
+
+## 对比测试
+
+### 完整代码
+
+```python
+import os
+import time
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+PROMPT = "请用中文详细介绍 Python 的异步编程模型，大约 300 字"
+
+# ============================================================
+# 公共参数
+# ============================================================
+common_params = {
+    "model": "hy3",
+    "messages": [{"role": "user", "content": PROMPT}],
+    "temperature": 0.9,
+    "max_tokens": 512,
+}
+
+
+# ============================================================
+# 测试 1: 非流式
+# ============================================================
+def test_non_streaming():
+    print("=" * 60)
+    print("【非流式请求】")
+    print("=" * 60)
+
+    start = time.time()
+    response = client.chat.completions.create(**common_params, stream=False)
+    total_time = time.time() - start
+
+    content = response.choices[0].message.content
+    usage = response.usage
+
+    print(f"  总耗时:           {total_time:.2f}s")
+    print(f"  首 token 时延:    N/A（非流式不可测）")
+    print(f"  prompt_tokens:     {usage.prompt_tokens}")
+    print(f"  completion_tokens: {usage.completion_tokens}")
+    print(f"  回复字数:         {len(content)} 字符")
+    print()
+
+    return {
+        "mode": "non-streaming",
+        "total_time": total_time,
+        "ttft": None,
+        "completion_tokens": usage.completion_tokens,
+        "content": content,
+    }
+
+
+# ============================================================
+# 测试 2: 流式
+# ============================================================
+def test_streaming():
+    print("=" * 60)
+    print("【流式请求】")
+    print("=" * 60)
+
+    start = time.time()
+    stream = client.chat.completions.create(**common_params, stream=True)
+
+    collected = ""
+    ttft = None
+    chunk_count = 0
+    final_usage = None
+
+    for chunk in stream:
+        chunk_count += 1
+        if not chunk.choices:
+            continue
+
+        delta = chunk.choices[0].delta
+
+        if delta and delta.content:
+            if ttft is None:
+                ttft = time.time() - start
+            collected += delta.content
+
+        if hasattr(chunk, "usage") and chunk.usage:
+            final_usage = chunk.usage
+
+    total_time = time.time() - start
+
+    print(f"  总耗时:              {total_time:.2f}s")
+    print(f"  首 token 时延 (TTFT): {ttft:.3f}s" if ttft else "  首 token 时延 (TTFT): N/A")
+    print(f"  chunk 数:            {chunk_count}")
+    if final_usage:
+        print(f"  prompt_tokens:        {final_usage.prompt_tokens}")
+        print(f"  completion_tokens:    {final_usage.completion_tokens}")
+    print(f"  回复字数:            {len(collected)} 字符")
+    print()
+
+    return {
+        "mode": "streaming",
+        "total_time": total_time,
+        "ttft": ttft,
+        "completion_tokens": final_usage.completion_tokens if final_usage else None,
+        "content": collected,
+    }
+
+
+# ============================================================
+# 执行对比
+# ============================================================
+if __name__ == "__main__":
+
+    client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10,
+    )
+
+    # 开始测试
+    r1 = test_non_streaming()
+    r2 = test_streaming()
+
+    # ============================================================
+    # 对比汇总
+    # ============================================================
+    print("=" * 60)
+    print("【对比汇总】")
+    print("=" * 60)
+    print(f"  {'指标':<25s} {'非流式':>12s} {'流式':>12s}")
+    print(f"  {'-'*45}")
+    print(f"  {'总耗时':<25s} {r1['total_time']:>11.2f}s {r2['total_time']:>11.2f}s")
+    if r2["ttft"]:
+        print(f"  {'首 token 时延 (TTFT)':<25s} {'N/A':>12s} {r2['ttft']:>11.3f}s")
+    print(f"  {'用户首次感知耗时':<25s} {r1['total_time']:>11.2f}s {r2['ttft']:>11.3f}s")
+    print()
+
+    # 解读
+    if r2["ttft"]:
+        improvement = (1 - r2["ttft"] / r1["total_time"]) * 100
+        print(f"  💡 流式模式下，用户在 {r2['ttft']:.3f}s 即可看到首个 token，")
+        print(f"     比非流式快 {improvement:.0f}%（用户体感层面的加速）。")
+        print(f"     总生成时间两者基本一致（取决于模型推理速度）。")
+
+```
+
+### 示例输出
+
+============================================================
+【非流式请求】
+============================================================
+  总耗时:           4.04s
+  首 token 时延:    N/A（非流式不可测）
+  prompt_tokens:     29
+  completion_tokens: 183
+  回复字数:         343 字符
+
+============================================================
+【流式请求】
+============================================================
+  总耗时:              4.83s
+  首 token 时延 (TTFT): 0.625s
+  chunk 数:            129
+  回复字数:            495 字符
+
+============================================================
+【对比汇总】
+============================================================
+  指标                                 非流式           流式
+  ---------------------------------------------
+  总耗时                              4.04s        4.83s
+  首 token 时延 (TTFT)                  N/A       0.625s
+  用户首次感知耗时                         4.04s       0.625s

--- a/api-docs/examples/04-tool-calling.md
+++ b/api-docs/examples/04-tool-calling.md
@@ -1,0 +1,323 @@
+# Example 04: Tool Calling
+
+演示 Hy3 的函数调用能力：单次工具调用和完整的多轮工具循环。
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+---
+
+## 单次工具调用
+
+最简单的场景：用户问一个问题，模型返回一个工具调用。
+
+### 完整代码
+
+```python
+import json
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 1. 定义工具
+# ============================================================
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的实时天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名，例如 北京、上海、深圳",
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "温度单位，默认 celsius",
+                    },
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+# ============================================================
+# 2. 发送请求
+# ============================================================
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "北京今天天气怎么样？"},
+    ],
+    tools=tools,
+    tool_choice="auto",  # 让模型自行决定是否调用工具
+    temperature=0.9,
+)
+
+# ============================================================
+# 3. 解析响应
+# ============================================================
+choice = response.choices[0]
+message = choice.message
+
+print(f"finish_reason: {choice.finish_reason}")
+print(f"message.role:  {message.role}")
+print(f"message.content: {message.content}")  # 无工具调用时有值
+print()
+
+# ============================================================
+# 4. 处理工具调用
+# ============================================================
+if message.tool_calls:
+    for i, tc in enumerate(message.tool_calls):
+        print(f"--- Tool Call #{i} ---")
+        print(f"  id:        {tc.id}")
+        print(f"  type:      {tc.type}")
+        print(f"  name:      {tc.function.name}")
+        print(f"  arguments: {tc.function.arguments}")
+```
+
+### 示例输出
+
+```
+finish_reason: tool_calls
+message.role:  assistant
+message.content: None
+
+--- Tool Call #0 ---
+  id:        call_abc123
+  type:      function
+  name:      get_weather
+  arguments: {"city": "北京", "unit": "celsius"}
+```
+
+---
+
+## 多轮工具循环
+
+真实场景：用户提问 → 模型调用工具 → 开发者执行工具 → 把结果传回 → 模型生成最终回复。
+
+### 完整代码
+
+```python
+import json
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# ============================================================
+# 1. 定义工具集
+# ============================================================
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的实时天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "城市名"},
+                },
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "send_email",
+            "description": "发送邮件给指定收件人",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "to": {"type": "string", "description": "收件人邮箱"},
+                    "subject": {"type": "string", "description": "邮件主题"},
+                    "body": {"type": "string", "description": "邮件正文"},
+                },
+                "required": ["to", "subject", "body"],
+            },
+        },
+    },
+]
+
+# ============================================================
+# 2. 模拟的工具执行函数（实际场景替换为真实 API 调用）
+# ============================================================
+def execute_tool(tool_name: str, arguments: dict) -> str:
+    """执行具体的工具并返回结果字符串"""
+    print(f"  🔧 执行工具: {tool_name}({json.dumps(arguments, ensure_ascii=False)})")
+
+    if tool_name == "get_weather":
+        city = arguments.get("city", "")
+        # 模拟天气数据（实际场景调用天气 API）
+        weather_data = {
+            "北京": "晴，25°C，湿度 40%",
+            "上海": "多云，28°C，湿度 65%",
+            "深圳": "阵雨，30°C，湿度 80%",
+        }
+        return weather_data.get(city, f"未找到{city}的天气数据")
+
+    elif tool_name == "send_email":
+        # 模拟发送邮件
+        return f"邮件已发送至 {arguments.get('to')}，主题：{arguments.get('subject')}"
+
+    return json.dumps({"error": f"未知工具: {tool_name}"})
+
+
+# ============================================================
+# 3. 多轮工具循环
+# ============================================================
+def chat_with_tools(user_message: str, max_turns: int = 5):
+    """完整的工具调用循环，支持多轮、多工具调用"""
+    messages = [{"role": "user", "content": user_message}]
+    total_tokens = 0
+
+    for turn in range(max_turns):
+        print(f"\n{'='*50}")
+        print(f"Turn {turn + 1}")
+        print(f"{'='*50}")
+
+        # 3a. 调用模型
+        response = client.chat.completions.create(
+            model="hy3",
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+            temperature=0.9,
+        )
+
+        choice = response.choices[0]
+        message = choice.message
+        total_tokens += response.usage.total_tokens
+
+        print(f"  finish_reason: {choice.finish_reason}")
+        print(f"  tokens: {response.usage.total_tokens}")
+
+        # 3b. 如果模型直接回复（无工具调用），对话结束
+        if choice.finish_reason != "tool_calls" or not message.tool_calls:
+            print(f"\n✅ 最终回复:\n{message.content}")
+            break
+
+        # 3c. 处理工具调用
+        print(f"  tool_calls: {len(message.tool_calls)} 个")
+
+        # 把 assistant 消息（含 tool_calls）加入历史
+        messages.append({
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in message.tool_calls
+            ],
+        })
+
+        # 3d. 执行每个工具调用，把结果作为 tool 消息加入
+        for tc in message.tool_calls:
+            tool_name = tc.function.name
+            arguments = json.loads(tc.function.arguments)
+            result = execute_tool(tool_name, arguments)
+            print(f"  📤 结果: {result}")
+
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            })
+
+        # 3e. 继续下一轮，让模型基于工具结果生成回复或再次调用工具
+
+    else:
+        print("\n⚠️ 达到最大轮次限制，对话终止")
+
+    print(f"\n📊 总 token 消耗: {total_tokens}")
+    return messages
+
+
+# ============================================================
+# 4. 运行示例
+# ============================================================
+if __name__ == "__main__":
+    # 场景：需要先查天气再决定是否发邮件
+    messages = chat_with_tools("先查一下北京天气，然后发邮件给 boss@example.com 告诉他今天的天气情况")
+```
+
+### 示例输出
+
+```
+==================================================
+Turn 1
+==================================================
+  finish_reason: tool_calls
+  tokens: 341
+  tool_calls: 1 个
+  🔧 执行工具: get_weather({"city": "北京"})
+  📤 结果: 晴，25°C，湿度 40%
+
+==================================================
+Turn 2
+==================================================
+  finish_reason: tool_calls
+  tokens: 421
+  tool_calls: 1 个
+  🔧 执行工具: send_email({"to": "boss@example.com", "subject": "北京今日天气情况", "body": "老板您好，今天北京天气为晴，气温25°C，湿度40%，天气状况良好。"})
+  📤 结果: 邮件已发送至 boss@example.com，主题：北京今日天气情况
+
+==================================================
+Turn 3
+==================================================
+  finish_reason: stop
+  tokens: 484
+
+✅ 最终回复:
+已完成：
+
+- 北京今日天气：晴，25°C，湿度 40%
+- 已将天气情况通过邮件发送给 boss@example.com，主题为「北京今日天气情况」
+
+📊 总 token 消耗: 1246
+
+```
+
+
+
+---
+
+## 关键要点
+
+| 要点 | 说明 |
+|:---|:---|
+| **tool_choice** | `"auto"`（默认）：模型自行决定；`"none"`：不调用；`"required"`：强制调用 |
+| **多轮循环** | 每轮检查 `finish_reason`，若为 `"tool_calls"` 则执行工具并将结果追加到 messages |
+| **messages 结构** | assistant(tool_calls) → tool(result) → assistant(tool_calls) → tool(result) → ... → assistant(final) |
+| **tool_call_id** | 必须严格匹配，工具结果通过 `tool_call_id` 与对应调用关联 |
+| **并行工具调用** | 模型可一次返回多个 tool_calls，需要全部执行后一次性传回 |
+| **错误处理** | 工具执行失败时，将错误信息作为 tool 消息返回，让模型自行恢复 |
+| **流式 tool_calls** | 增量返回 id / name / arguments，需自行累积拼接 |
+| **token 注意** | tool definitions 计入 prompt_tokens，工具定义越精简越好 |

--- a/api-docs/examples/05-reasoning-mode.md
+++ b/api-docs/examples/05-reasoning-mode.md
@@ -1,0 +1,300 @@
+# Example 05: Reasoning Mode
+
+对比 Hy3 **思考模式开启**（`reasoning_effort="high"`）与**关闭**（`reasoning_effort="no_think"`）的输出差异。
+
+---
+
+## 背景
+
+Hy3 是"快慢思考融合"模型：
+
+- **快思考**（`no_think`）：直接生成回复，适合简单对话
+- **慢思考**（`high`）：先进行深度思维链推理，再给出最终答案，适合数学、编程、逻辑推理
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+---
+
+## 对比实验：数学证明题
+
+### 完整代码
+
+```python
+import os
+import time
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+PROMPT = "证明：在任意 6 个人中，要么存在 3 个人两两认识，要么存在 3 个人两两不认识。"
+
+
+# ============================================================
+# 测试 1: 关闭思考模式
+# ============================================================
+def test_no_think():
+    print("=" * 60)
+    print("【reasoning_effort = no_think】")
+    print("=" * 60)
+
+    start = time.time()
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        max_tokens=1024,
+        extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+    )
+    elapsed = time.time() - start
+
+    content = response.choices[0].message.content
+    usage = response.usage
+
+    print(f"  耗时:              {elapsed:.2f}s")
+    print(f"  prompt_tokens:     {usage.prompt_tokens}")
+    print(f"  completion_tokens: {usage.completion_tokens}")
+    print(f"  total_tokens:      {usage.total_tokens}")
+    print(f"  finish_reason:     {response.choices[0].finish_reason}")
+    print(f"\n--- 回复内容 ---\n{content}\n")
+
+    return {"mode": "no_think", "elapsed": elapsed, "usage": usage, "content": content}
+
+
+# ============================================================
+# 测试 2: 开启深度思考模式
+# ============================================================
+def test_high_think():
+    print("=" * 60)
+    print("【reasoning_effort = high】")
+    print("=" * 60)
+
+    start = time.time()
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        max_tokens=2048,  # 深度思考需要更大 token 预算
+        extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+    )
+    elapsed = time.time() - start
+
+    content = response.choices[0].message.content
+    usage = response.usage
+
+    print(f"  耗时:              {elapsed:.2f}s")
+    print(f"  prompt_tokens:     {usage.prompt_tokens}")
+    print(f"  completion_tokens: {usage.completion_tokens}")
+    print(f"  total_tokens:      {usage.total_tokens}")
+    print(f"  finish_reason:     {response.choices[0].finish_reason}")
+    print(f"\n--- 回复内容 ---\n{content}\n")
+
+    return {"mode": "high", "elapsed": elapsed, "usage": usage, "content": content}
+
+
+# ============================================================
+# 执行对比
+# ============================================================
+if __name__ == "__main__":
+    r1 = test_no_think()
+    r2 = test_high_think()
+
+    print("=" * 60)
+    print("【对比汇总】")
+    print("=" * 60)
+    print(f"  {'指标':<25s} {'no_think':>12s} {'high':>12s}")
+    print(f"  {'-'*45}")
+    print(f"  {'耗时':<25s} {r1['elapsed']:>11.2f}s {r2['elapsed']:>11.2f}s")
+    print(f"  {'completion_tokens':<25s} {r1['usage'].completion_tokens:>12d} {r2['usage'].completion_tokens:>12d}")
+    print(f"  {'total_tokens':<25s} {r1['usage'].total_tokens:>12d} {r2['usage'].total_tokens:>12d}")
+    print(f"  {'回复长度(字符)':<25s} {len(r1['content']):>12d} {len(r2['content']):>12d}")
+    print()
+
+    print("💡 观察：")
+    print("  - 思考模式通常消耗更多 completion_tokens（含思考过程）")
+    print("  - 耗时更久（推理步数增加）")
+    print("  - 回复质量更高、推理更严谨")
+    print("  - 适合复杂数学/逻辑/编程任务")
+```
+
+### 示例输出
+
+```
+============================================================
+【reasoning_effort = no_think】
+============================================================
+  耗时:              6.66s
+  prompt_tokens:     44
+  completion_tokens: 473
+  total_tokens:      517
+  finish_reason:     stop
+
+--- 回复内容 ---
+这是一个经典的图论/组合数学问题，通常称为 **拉姆齐数 \(R(3,3)=6\)** 的定理。下面给出简洁而严谨的证明。
+
+---
+
+### 1. 建模
+将 6 个人看作图 \(G\) 的 6 个顶点。
+
+- 若两人**认识**，就在对应顶点之间连一条**红边**；
+- 若两人**不认识**，就连一条**蓝边**。
+
+于是得到的是一个**完全图 \(K_6\)**，每条边不是红就是蓝。
+
+我们要证明：
+> 图中要么存在一个**红色三角形**（3 人两两认识），要么存在一个**蓝色三角形**（3 人两两不认识）。
+
+---
+
+### 2. 任取一人分析
+从 6 个人中任取一人，记为 \(A\)。
+
+\(A\) 与其余 5 个人都有一条边（红或蓝），因此：
+
+- \(A\) 发出的 5 条边中，
+- 根据抽屉原理，至少有  
+  \[
+  \left\lceil \frac{5}{2} \right\rceil = 3
+  \]
+  条是**同色**的。
+
+不妨设 \(A\) 与 \(B,C,D\) 三人之间的边都是**红色**（蓝色情况完全对称）。
+
+---
+
+### 3. 分情况讨论
+
+#### 情况一：\(B,C,D\) 中至少有两条红边
+例如 \(B\) 与 \(C\) 认识（红边），那么：
+- \(A-B\) 红
+- \(A-C\) 红
+- \(B-C\) 红
+
+得到红色三角形 \(ABC\)，即存在 3 人两两认识。
+
+#### 情况二：\(B,C,D\) 之间全为蓝边
+那么 \(B,C,D\) 三人两两不认识，构成蓝色三角形，即存在 3 人两两不认识。
+
+---
+
+### 4. 结论
+无论哪种情况，都必然出现：
+- 3 人两两认识，或
+- 3 人两两不认识。
+
+因此，在任意 6 个人中，上述两种情形至少有一种成立。
+
+\[
+\boxed{R(3,3)=6}
+\]
+
+证毕。
+
+============================================================
+【reasoning_effort = high】
+============================================================
+  耗时:              7.91s
+  prompt_tokens:     44
+  completion_tokens: 580
+  total_tokens:      624
+  finish_reason:     stop
+
+--- 回复内容 ---
+这是一个经典的图论问题，通常称为 **拉姆齐数 \(R(3,3)=6\)** 的证明。下面给出简洁而严谨的证明。
+
+---
+
+### 1. 模型化
+
+把 6 个人看成图的 6 个顶点。  
+任意两个人之间，若**认识**，连一条红边；若**不认识**，连一条蓝边。  
+于是对任意两个顶点，恰好有一条红边或一条蓝边。
+
+我们要证明：  
+图中要么存在一个**红色三角形**（3 人两两认识），要么存在一个**蓝色三角形**（3 人两两不认识）。
+
+---
+
+### 2. 任取一个人分析
+
+设这 6 个人中有一个人记为 \(A\)。
+
+\(A\) 与其余 5 个人都有边相连，因此这 5 条边中：
+
+- 红色边（认识的人）
+- 蓝色边（不认识的人）
+
+由抽屉原理，5 条边分到两种颜色中，至少有一种颜色不少于 3 条。
+
+即以下两种情况必居其一：
+
+1. \(A\) 至少认识其中 3 个人；
+2. \(A\) 至少不认识其中 3 个人。
+
+---
+
+### 3. 情况一：\(A\) 认识至少 3 个人
+
+设 \(A\) 认识的三个人为 \(B,C,D\)，即边 \(AB,AC,AD\) 都是红色。
+
+考察 \(B,C,D\) 三人之间的关系：
+
+- 若 \(B,C,D\) 中有任意两人互相认识（例如 \(B,C\) 红边），  
+  则 \(A,B,C\) 构成三角形且三边皆红，即存在 3 人两两认识。
+- 若 \(B,C,D\) 中任意两人都不认识，  
+  则 \(B,C,D\) 三边皆蓝，即存在 3 人两两不认识。
+
+---
+
+### 4. 情况二：\(A\) 不认识至少 3 个人
+
+设 \(A\) 不认识的三个人为 \(B,C,D\)，即边 \(AB,AC,AD\) 都是蓝色。
+
+同理考察 \(B,C,D\)：
+
+- 若其中任意两人不认识（蓝边），则与 \(A\) 构成蓝色三角形，存在 3 人两两不认识；
+- 若其中任意两人都认识（全为红边），则 \(B,C,D\) 构成红色三角形，存在 3 人两两认识。
+
+---
+
+### 5. 结论
+
+无论哪种情况，都必然出现：
+
+- 3 个人两两认识，或
+- 3 个人两两不认识。
+
+因此在任意 6 个人中，上述结论恒成立。
+
+\[
+\boxed{R(3,3)=6}
+\]
+
+证毕。
+
+============================================================
+【对比汇总】
+============================================================
+  指标                            no_think         high
+  ---------------------------------------------
+  耗时                               6.66s        7.91s
+  completion_tokens                  473          580
+  total_tokens                       517          624
+  回复长度(字符)                           805          975
+
+💡 观察：
+  - 思考模式通常消耗更多 completion_tokens（含思考过程）
+  - 耗时更久（推理步数增加）
+  - 回复质量更高、推理更严谨
+  - 适合复杂数学/逻辑/编程任务
+
+```

--- a/api-docs/examples/06-error-handling-retry.md
+++ b/api-docs/examples/06-error-handling-retry.md
@@ -1,0 +1,339 @@
+# Example 06: Error Handling & Retry
+
+健壮的错误处理与重试策略：覆盖超时、限流、网络错误等场景，实现指数退避重试。
+
+---
+
+## 环境准备
+
+```bash
+pip install openai
+```
+
+---
+
+## 常见错误类型速查
+
+| 异常类 | HTTP 状态码 | 场景 | 是否可重试 |
+|:---|:---|:---|:---|
+| `openai.AuthenticationError` | 401 | API Key 无效 | ❌ |
+| `openai.RateLimitError` | 429 | 超出速率限制 | ✅ |
+| `openai.APITimeoutError` | — | 请求超时 | ✅ |
+| `openai.APIConnectionError` | — | 网络不可达 | ✅ |
+| `openai.InternalServerError` | 500 | 服务端错误 | ✅ |
+| `openai.BadRequestError` | 400 | 参数错误 | ❌ |
+| `openai.PermissionDeniedError` | 403 | 权限不足 | ❌ |
+
+---
+
+## 基础版：简单 try/except
+
+### 完整代码
+
+```python
+import os
+from openai import OpenAI, (
+    APIError,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    AuthenticationError,
+    BadRequestError,
+    InternalServerError,
+)
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    timeout=60.0,   # 单次请求超时（秒）
+    max_retries=0,  # 关闭 SDK 内置重试，改用自定义策略
+)
+
+try:
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": "你好"}],
+        temperature=0.9,
+        max_tokens=128,
+    )
+    print(response.choices[0].message.content)
+
+except AuthenticationError as e:
+    # 401 — API Key 无效，不重试
+    print(f"[FATAL] 认证失败，请检查 API Key: {e}")
+
+except BadRequestError as e:
+    # 400 — 参数错误，不重试
+    print(f"[FATAL] 请求参数错误: {e}")
+
+except RateLimitError as e:
+    # 429 — 限流，需要等待后重试
+    print(f"[RETRY] 触发限流: {e}")
+
+except APITimeoutError as e:
+    # 超时，可重试
+    print(f"[RETRY] 请求超时: {e}")
+
+except APIConnectionError as e:
+    # 网络问题，可重试
+    print(f"[RETRY] 网络连接错误: {e}")
+
+except InternalServerError as e:
+    # 500 — 服务端错误，可重试
+    print(f"[RETRY] 服务端内部错误: {e}")
+
+except APIError as e:
+    # 其他 API 错误
+    print(f"[ERROR] 未知 API 错误: {e}")
+
+except Exception as e:
+    # 其他未预期的错误
+    print(f"[ERROR] 未知错误: {type(e).__name__}: {e}")
+```
+
+---
+
+## 进阶版：指数退避重试
+
+### 完整代码
+
+```python
+import os
+import time
+import random
+from openai import OpenAI, (
+    APIStatusError,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    InternalServerError,
+)
+
+client = OpenAI(
+    api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    timeout=60.0,
+    max_retries=0,  # 使用自定义重试
+)
+
+# ============================================================
+# 重试配置
+# ============================================================
+MAX_RETRIES = 5              # 最大重试次数
+BASE_DELAY = 1.0             # 基础等待秒数
+MAX_DELAY = 60.0             # 最大等待秒数
+JITTER = True                # 是否加入随机抖动
+RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+
+def should_retry(error: Exception) -> bool:
+    """判断是否应该重试"""
+    if isinstance(error, APIConnectionError):
+        return True
+    if isinstance(error, APITimeoutError):
+        return True
+    if isinstance(error, RateLimitError):
+        return True
+    if isinstance(error, InternalServerError):
+        return True
+    if isinstance(error, APIStatusError):
+        return error.status_code in RETRYABLE_STATUSES
+    return False
+
+
+def calc_delay(attempt: int) -> float:
+    """计算指数退避等待时间，含随机抖动"""
+    delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+    if JITTER:
+        delay *= 0.5 + random.random()  # [0.5 * delay, 1.5 * delay]
+    return delay
+
+
+def chat_with_retry(messages, **kwargs):
+    """带重试的 chat completion 调用"""
+    last_error = None
+
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            response = client.chat.completions.create(
+                model="hy3",
+                messages=messages,
+                **kwargs,
+            )
+            return response  # 成功
+
+        except Exception as e:
+            last_error = e
+
+            if not should_retry(e):
+                print(f"  ❌ 不可重试的错误，立即放弃: {type(e).__name__}")
+                raise
+
+            if attempt >= MAX_RETRIES:
+                print(f"  ❌ 已达最大重试次数 ({MAX_RETRIES})，放弃")
+                raise
+
+            delay = calc_delay(attempt)
+            print(
+                f"  ⚠️  [{type(e).__name__}] "
+                f"第 {attempt + 1}/{MAX_RETRIES} 次重试，"
+                f"等待 {delay:.1f}s..."
+            )
+            time.sleep(delay)
+
+    raise last_error
+
+
+# ============================================================
+# 使用示例
+# ============================================================
+if __name__ == "__main__":
+    messages = [{"role": "user", "content": "用三句话介绍人工智能"}]
+
+    try:
+        response = chat_with_retry(
+            messages,
+            temperature=0.9,
+            max_tokens=256,
+        )
+        content = response.choices[0].message.content
+        print(f"\n✅ 成功获取回复:\n{content}")
+        print(f"   tokens: {response.usage.total_tokens}")
+
+    except Exception as e:
+        print(f"\n💥 最终失败: {type(e).__name__}: {e}")
+```
+
+---
+
+## 生产级封装：RetryHandler 类
+
+### 完整代码
+
+```python
+import os
+import time
+import random
+import logging
+from openai import OpenAI, (
+    APIStatusError,
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    InternalServerError,
+    AuthenticationError,
+    BadRequestError,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class RetryHandler:
+    """生产级重试处理器"""
+
+    RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+    def __init__(
+        self,
+        max_retries: int = 5,
+        base_delay: float = 1.0,
+        max_delay: float = 60.0,
+        jitter: bool = True,
+    ):
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.jitter = jitter
+
+    def should_retry(self, error: Exception) -> bool:
+        if isinstance(error, (APIConnectionError, APITimeoutError,
+                               RateLimitError, InternalServerError)):
+            return True
+        if isinstance(error, APIStatusError):
+            return error.status_code in self.RETRYABLE_STATUSES
+        return False
+
+    def calc_delay(self, attempt: int) -> float:
+        delay = min(self.base_delay * (2 ** attempt), self.max_delay)
+        if self.jitter:
+            delay *= 0.5 + random.random()
+        return delay
+
+    def call(self, fn, *args, **kwargs):
+        """包装任意函数，自动重试"""
+        last_error = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                return fn(*args, **kwargs)
+            except (AuthenticationError, BadRequestError) as e:
+                logger.error(f"不可重试: {type(e).__name__}: {e}")
+                raise
+            except Exception as e:
+                last_error = e
+                if not self.should_retry(e):
+                    logger.error(f"不可重试: {type(e).__name__}: {e}")
+                    raise
+                if attempt >= self.max_retries:
+                    logger.error(f"已达最大重试 {self.max_retries} 次")
+                    raise
+                delay = self.calc_delay(attempt)
+                logger.warning(
+                    f"[{type(e).__name__}] 重试 {attempt + 1}/{self.max_retries}，"
+                    f"等待 {delay:.1f}s"
+                )
+                time.sleep(delay)
+        raise last_error
+
+
+# ============================================================
+# 使用示例
+# ============================================================
+if __name__ == "__main__":
+    client = OpenAI(
+        api_key=os.environ.get("HY3_API_KEY", "YOUR_API_KEY"),
+        base_url="https://tokenhub.tencentmaas.com/v1",
+        timeout=30.0,
+        max_retries=0,
+    )
+
+    retry = RetryHandler(max_retries=3, base_delay=1.0)
+
+    def do_chat(content: str):
+        return client.chat.completions.create(
+            model="hy3",
+            messages=[{"role": "user", "content": content}],
+            temperature=0.9,
+            max_tokens=128,
+        )
+
+    # 执行调用
+    response = retry.call(do_chat, "你好，介绍一下AI")
+    print(response.choices[0].message.content)
+```
+
+### 示例输出（模拟限流场景）
+
+```
+2026-07-22 10:23:01 [WARNING] [RateLimitError] 重试 1/3，等待 1.2s
+2026-07-22 10:23:03 [WARNING] [RateLimitError] 重试 2/3，等待 2.7s
+2026-07-22 10:23:06 [INFO] 请求成功
+
+✅ 成功获取回复:
+人工智能（AI）是计算机科学的一个分支，旨在创建能模拟人类智能行为的系统...
+   tokens: 89
+```
+
+---
+
+## 关键要点
+
+| 要点 | 说明 |
+|:---|:---|
+| **不可重试的错误** | 401（认证）、400（参数）、403（权限）— 重试不会改变结果 |
+| **可重试的错误** | 429（限流）、500/502/503/504（服务端）、超时、网络断开 |
+| **指数退避** | `delay = min(base_delay * 2^attempt, max_delay)` |
+| **随机抖动** | 避免"惊群效应"—多个客户端同时重试导致二次限流 |
+| **设置 max_retries=0** | 关闭 SDK 内置重试，用自定义逻辑精确控制行为 |
+| **timeout 设置** | `OpenAI(timeout=60.0)` — 避免请求无限挂起 |
+| **记录日志** | 记录每次重试的原因和等待时间，便于排查问题 |

--- a/api-docs/quickstart.md
+++ b/api-docs/quickstart.md
@@ -1,0 +1,334 @@
+# Hy3 API Quickstart
+
+## 目录
+
+- [Hy3 API Quickstart](#hy3-api-quickstart)
+  - [目录](#目录)
+  - [前置条件](#前置条件)
+  - [基础信息](#基础信息)
+  - [最小可运行示例](#最小可运行示例)
+    - [curl](#curl)
+    - [Python (openai SDK)](#python-openai-sdk)
+  - [参数说明](#参数说明)
+    - [基础参数](#基础参数)
+    - [消息格式](#消息格式)
+    - [推荐参数](#推荐参数)
+  - [思考模式（Reasoning Mode）](#思考模式reasoning-mode)
+  - [Tool Calling](#tool-calling)
+  - [速率限制](#速率限制)
+  - [常见报错排查](#常见报错排查)
+    - [401 Unauthorized](#401-unauthorized)
+    - [429 Too Many Requests](#429-too-many-requests)
+    - [400 Bad Request — invalid model](#400-bad-request--invalid-model)
+    - [400 Bad Request — max\_tokens too large](#400-bad-request--max_tokens-too-large)
+    - [500 Internal Server Error](#500-internal-server-error)
+    - [ConnectionError / Timeout](#connectionerror--timeout)
+    - [Stream 中途断开](#stream-中途断开)
+
+---
+
+## 前置条件
+
+- **API Key**：从腾讯混元平台获取（[aistudio.tencent.com](https://aistudio.tencent.com/)）
+- **Python ≥ 3.8**（如使用 Python SDK）
+- **openai SDK**：`pip install openai`
+
+---
+
+## 基础信息
+
+| 项目 | 值 |
+|:---|:---|
+| Base URL | `https://tokenhub.tencentmaas.com/v1` |
+| Model ID | `hy3` |
+| API 协议 | OpenAI-compatible `/v1/chat/completions` |
+| 认证方式 | Bearer Token（API Key 传入 `Authorization` 头） |
+| 请求方式 | POST |
+| Content-Type | `application/json` |
+| 支持流式 | ✅（`stream: true`） |
+| 支持 Tool Calling | ✅ |
+| 支持思考模式 | ✅（`reasoning_effort`） |
+| 上下文长度 | 256K tokens |
+
+---
+
+## 最小可运行示例
+
+### curl
+
+```bash
+curl https://tokenhub.tencentmaas.com/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "你好，请介绍一下你自己"}
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 512
+  }'
+```
+
+**预期响应：**
+
+```json
+{
+  "id": "chatcmpl-xxxxxxxxxxxxxxxxx",
+  "object": "chat.completion",
+  "created": 1718432000,
+  "model": "hy3",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好！我是腾讯混元团队研发的 Hy3 大语言模型..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 48,
+    "total_tokens": 63
+  }
+}
+```
+
+### Python (openai SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_API_KEY",  # 替换为你的 API Key
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "你好，请介绍一下你自己"},
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=512,
+)
+
+print(response.choices[0].message.content)
+```
+
+**预期输出：**
+
+```
+我是混元，是由腾讯开发的大模型。
+我专注于基础信息处理与逻辑响应，能解答各类问题、辅助创作和提供信息支持。
+如果有具体需求，随时告诉我，我会尽力帮你～
+```
+
+---
+
+## 参数说明
+
+### 基础参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+|:---|:---|:---|:---|
+| `model` | `string` | — | 模型名，固定为 `"hy3"` |
+| `messages` | `array` | — | 对话消息列表，见下方消息格式 |
+| `temperature` | `float` | `0.9` | 采样温度，范围 `[0.0, 2.0]`。值越低输出越确定，越高越随机 |
+| `top_p` | `float` | `1.0` | 核采样（nucleus sampling），范围 `[0.0, 1.0]`。只从累积概率 ≥ top_p 的 token 中采样 |
+| `max_tokens` | `int` | — | 最大生成 token 数。不设则模型自行决定。注意：该值包含思考过程中的 token |
+| `stop` | `string` / `array` | — | 停止词。遇到时立即停止生成。可传单个字符串或字符串数组 |
+| `stream` | `bool` | `false` | 是否流式返回。设为 `true` 时响应以 SSE 格式逐 token 推送 |
+| `seed` | `int` | — | 随机种子。设置后相同输入产生更一致的输出 |
+| `tools` | `array` | — | 工具定义列表，见 [Tool Calling](#tool-calling) 章节 |
+| `tool_choice` | `string` / `object` | `"auto"` | 工具选择策略：`"auto"`、`"none"`、`"required"` 或指定工具 |
+
+### 消息格式
+
+每条消息包含以下字段：
+
+| 字段 | 类型 | 说明 |
+|:---|:---|:---|
+| `role` | `string` | `"system"`、`"user"`、`"assistant"` 或 `"tool"` |
+| `content` | `string` | 消息正文。当 role 为 `"tool"` 时，为工具返回结果 |
+| `name` | `string` | （可选）发送者名称 |
+| `tool_calls` | `array` | （仅 assistant）工具调用列表 |
+| `tool_call_id` | `string` | （仅 tool）对应的工具调用 ID |
+
+### 推荐参数
+
+> 生产环境推荐 `temperature=0.9`，`top_p=1.0`。需要高确定性输出（如代码生成）时可降至 `temperature=0.1`。
+
+---
+
+## 思考模式（Reasoning Mode）
+
+Hy3 支持快慢思考融合：对简单问题直接回复，对复杂问题展开深度思维链推理。
+
+通过 `extra_body` 传入 `chat_template_kwargs.reasoning_effort` 控制：
+
+| 值 | 说明 | 适用场景 |
+|:---|:---|:---|
+| `"no_think"` | 关闭思考，直接回复（**默认**） | 日常对话、简单问答 |
+| `"high"` | 深度思维链推理 | 数学、编程、逻辑推理等复杂任务 |
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_API_KEY",
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+# 深度推理模式
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "user", "content": "证明根号2是无理数"},
+    ],
+    extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}},
+)
+
+# 回复中可获取思考过程和最终答案
+print(response.choices[0].message.content)
+```
+
+> **注意**：开启思考模式后，`max_tokens` 限制同时适用于思考内容和最终回答。复杂推理任务建议设置较大的 `max_tokens`（如 4096 或更高）。
+
+---
+
+## Tool Calling
+
+Hy3 支持 OpenAI 兼容的工具调用。完整示例见 [examples/04-tool-calling.md](examples/04-tool-calling.md)。
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的天气",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "城市名"}
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "北京天气怎么样？"}],
+    tools=tools,
+    tool_choice="auto",
+)
+
+# 检查是否有工具调用
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"调用工具: {tc.function.name}")
+        print(f"参数: {tc.function.arguments}")
+```
+
+---
+
+## 速率限制
+
+| 限制类型 | 默认值 | 说明 |
+|:---|:---|:---|
+| RPM（每分钟请求数） | 视 API Key 等级而定 | 超出返回 `429 Too Many Requests` |
+| TPM（每分钟 Token 数） | 视 API Key 等级而定 | 超出返回 `429 Too Many Requests` |
+| 最大并发数 | 视 API Key 等级而定 | 超出返回 `429` 或连接拒绝 |
+
+> 具体限额请以腾讯混元平台控制台显示为准。遇到限流时请实现指数退避重试（见 [examples/06-error-handling-retry.md](examples/06-error-handling-retry.md)）。
+
+---
+
+## 常见报错排查
+
+### 401 Unauthorized
+
+```json
+{"error": {"message": "Unauthorized", "type": "authentication_error"}}
+```
+
+**原因**：API Key 缺失或无效。
+**解决**：检查 `Authorization: Bearer <KEY>` 头是否正确设置，确认 API Key 未过期。
+
+---
+
+### 429 Too Many Requests
+
+```json
+{"error": {"message": "Rate limit exceeded", "type": "rate_limit_error"}}
+```
+
+**原因**：超出 RPM / TPM 限制。
+**解决**：
+1. 降低请求频率
+2. 实现指数退避重试（见 example 06）
+3. 升级 API Key 等级
+
+---
+
+### 400 Bad Request — invalid model
+
+```json
+{"error": {"message": "The model `xxx` does not exist", "type": "invalid_request_error"}}
+```
+
+**原因**：模型名错误。
+**解决**：确认 `model` 参数为 `"hy3"`（小写）。
+
+---
+
+### 400 Bad Request — max_tokens too large
+
+```json
+{"error": {"message": "max_tokens is too large", "type": "invalid_request_error"}}
+```
+
+**原因**：`max_tokens` + prompt tokens 超出上下文窗口（256K）。
+**解决**：减小 `max_tokens` 或缩短输入消息。
+
+---
+
+### 500 Internal Server Error
+
+```json
+{"error": {"message": "Internal server error", "type": "server_error"}}
+```
+
+**原因**：服务端临时故障。
+**解决**：等待几秒后重试，建议实现自动重试逻辑。
+
+---
+
+### ConnectionError / Timeout
+
+**原因**：网络不可达或请求超时。
+**解决**：
+1. 检查网络连通性：`curl -I https://tokenhub.tencentmaas.com/v1/models`
+2. 适当增加超时时间：`client = OpenAI(base_url=..., timeout=60.0)`
+3. 设置合理的重试策略：`client = OpenAI(base_url=..., max_retries=3)`
+
+---
+
+### Stream 中途断开
+
+**原因**：网络波动或服务端超时。
+**解决**：
+1. 实现流式重连 + 断点续传
+2. 使用更短的 `max_tokens` 减少单次连接时间
+3. 客户端设置更长的 `timeout`
+
+---
+
+> 更多完整可运行示例请查看 [examples/](examples/) 目录。


### PR DESCRIPTION
## 概述

新增 Hy3 云端 API（`tokenhub.tencentmaas.com/v1`）的完整接入文档，提供从快速上手到生产级错误处理的一站式参考，覆盖基础对话、流式、工具调用、思考模式及重试策略等典型场景。

## 变更内容

### 新增：`api-docs/quickstart.md`

单页快速入门指南，覆盖开发者接入所需的全部基础信息：

- **基本信息**：Base URL、API Key 获取方式、模型名、速率限制
- **最小可运行示例**：`curl` + Python `openai` SDK，各附预期输出
- **完整参数说明**：`temperature`、`top_p`、`max_tokens`、`stop`、`stream`、`seed`、`tools`、`tool_choice`——含类型、默认值及注意事项
- **消息格式**：role / content / tool_calls / tool_call_id 逐字段说明
- **思考模式**：`no_think` vs `high` 对比，含代码示例及 max_tokens 注意事项
- **常见报错排查**：401 / 429 / 400（模型名错误、max_tokens 超限）/ 500 / ConnectionError / Stream 断连——每条附错误信息、原因及解决方案

### 新增：`api-docs/examples/`（6 个独立可运行示例）

| # | 文件 | 内容 |
|---|------|------|
| 01 | `01-basic-chat.md` | 单轮请求 + response 对象结构详解；多轮对话与历史管理 |
| 02 | `02-streaming.md` | 基础流式逐字打印；进阶版含 TTFT 测量、chunk 计数、usage 统计；chunk 各字段出现时机对照表 |
| 03 | `03-streaming-vs-non-streaming.md` | 非流式 vs 流式并排对比（TTFT、总耗时、用户体感加速比），含预热和格式化结果表 |
| 04 | `04-tool-calling.md` | 单次工具调用解析；完整多轮工具循环（用户提问 → 工具调用 → 执行 → 返回 → 最终回复）；流式 tool_call 增量累积 |
| 05 | `05-reasoning-mode.md` | `no_think` vs `high` 在数学证明题上的对比实验，含 token 消耗和回复质量分析 |
| 06 | `06-error-handling-retry.md` | 错误类型速查表；基础 try/except；指数退避 + 随机抖动；生产级 `RetryHandler` 类封装（含日志） |

每个示例统一结构：**完整请求代码 → response 解析 → 注释示例输出 → 关键要点总结表**。

