### PR TITLE
docs: add Hy3 API quickstart and runnable examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@
 Thumbs.db
 __pycache__/
 *.pyc
+.env
+.venv/
+venv/
+.pytest_cache/
+.ruff_cache/
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ print(response.choices[0].message.content)
 
 See the [Deployment](#deployment) section below for how to start the API server.
 
+For a copy-paste setup, parameter reference, troubleshooting guide, and six
+runnable examples, see the [Hy3 API quickstart](./quickstart.md) and
+[API examples](./examples/api/).
+
 ## Deployment
 
 Hy3 has 295B parameters in total. To serve it on 8 GPUs, we recommend using H20-3e or other GPUs with larger memory capacity.

--- a/README_CN.md
+++ b/README_CN.md
@@ -134,6 +134,9 @@ print(response.choices[0].message.content)
 
 具体部署方式请参考下方[推理和部署](#推理和部署)章节。
 
+如需可直接复制的环境配置、参数说明、故障排查和六组可运行示例，请参阅
+[Hy3 API 快速开始](./quickstart.md)与 [API 示例](./examples/api/)。
+
 ## 推理和部署
 
 Hy3 总参数量为 295B，当使用 8 张 GPU 时，建议使用 H20-3e 或其他有更大显存的卡型。

--- a/examples/api/.env.example
+++ b/examples/api/.env.example
@@ -1,0 +1,9 @@
+# Local vLLM or SGLang endpoint started from this repository's README.
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_TIMEOUT=120
+
+# Example-specific controls.
+HY3_BENCH_RUNS=3
+HY3_SHOW_REASONING=0

--- a/examples/api/01_basic_chat.md
+++ b/examples/api/01_basic_chat.md
@@ -1,0 +1,91 @@
+# 01 — Basic chat and conversation state
+
+Use this example to verify configuration, inspect a complete response, and see
+how chat history is carried into the next request.
+
+## Run
+
+```bash
+python examples/api/01_basic_chat.py
+```
+
+The script makes one single-turn request, followed by two calls that form a
+multi-turn conversation. That means one execution consumes three API requests.
+
+## Complete request
+
+The script builds the request explicitly before sending it:
+
+```python
+request = {
+    "model": config.model,
+    "messages": [
+        {
+            "role": "user",
+            "content": "Give three practical uses for a 256K context window.",
+        }
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 512,
+    "extra_body": {
+        "chat_template_kwargs": {"reasoning_effort": "no_think"}
+    },
+}
+response = client.chat.completions.create(**request)
+```
+
+For the second turn, append both the first assistant answer and the new user
+question. Sending only the newest question would discard conversation state:
+
+```python
+history.extend(
+    [
+        {"role": "assistant", "content": first_reply},
+        {"role": "user", "content": "Now name one trade-off, in the same context."},
+    ]
+)
+response = client.chat.completions.create(model=config.model, messages=history, ...)
+```
+
+## Complete response parsing
+
+```python
+choice = response.choices[0]
+message = choice.message
+
+print(message.content)              # final user-facing answer
+print(choice.finish_reason)         # normally "stop"; "length" means truncation
+if response.usage:
+    print(response.usage.prompt_tokens)
+    print(response.usage.completion_tokens)
+    print(response.usage.total_tokens)
+```
+
+The runnable script also detects separately returned `reasoning_content` without
+printing it by default.
+
+## Example output
+
+The text below illustrates the output format; generated wording and token counts
+will differ. Replace it with a dated, redacted live capture before claiming a
+specific endpoint was tested.
+
+```text
+=== Single turn ===
+Assistant: A long context window can support repository analysis, document synthesis, and long conversations.
+Finish reason: stop
+Tokens: prompt=<count>, completion=<count>, total=<count>
+
+=== Multi turn ===
+Assistant: Streaming lets a user see output before the full response is ready.
+Finish reason: stop
+Assistant: It requires incremental parsing and more careful error handling.
+Finish reason: stop
+```
+
+## Checks
+
+- Confirm the printed request contains no API key.
+- Treat `finish_reason="length"` as a signal to raise `max_tokens` or shorten the prompt.
+- Preserve roles and ordering when adding messages to history.

--- a/examples/api/01_basic_chat.py
+++ b/examples/api/01_basic_chat.py
@@ -1,0 +1,68 @@
+"""Hy3 API example 01: single-turn and stateful multi-turn chat."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hy3_client import Hy3Config, create_client, reasoning_options, split_message
+
+
+def send_chat(client: Any, config: Hy3Config, messages: list[dict[str, str]]) -> Any:
+    request = {
+        "model": config.model,
+        "messages": messages,
+        "temperature": 0.9,
+        "top_p": 1.0,
+        "max_tokens": 512,
+        "extra_body": reasoning_options("no_think"),
+    }
+    print("Request:\n" + json.dumps(request, ensure_ascii=False, indent=2))
+    return client.chat.completions.create(**request)
+
+
+def print_response(response: Any) -> str:
+    choice = response.choices[0]
+    reasoning, content = split_message(choice.message)
+    print(f"Assistant: {content}")
+    print(f"Finish reason: {choice.finish_reason}")
+    if reasoning:
+        print(f"Reasoning received: {len(reasoning)} characters")
+    if response.usage:
+        print(
+            "Tokens: "
+            f"prompt={response.usage.prompt_tokens}, "
+            f"completion={response.usage.completion_tokens}, "
+            f"total={response.usage.total_tokens}"
+        )
+    return content
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    print(f"Connecting with {config.safe_summary()}\n")
+
+    print("=== Single turn ===")
+    single_messages = [
+        {"role": "user", "content": "Give three practical uses for a 256K context window."}
+    ]
+    print_response(send_chat(client, config, single_messages))
+
+    print("\n=== Multi turn ===")
+    history = [
+        {"role": "system", "content": "You are a concise API design reviewer."},
+        {"role": "user", "content": "Name one benefit of streaming responses."},
+    ]
+    first_reply = print_response(send_chat(client, config, history))
+    history.extend(
+        [
+            {"role": "assistant", "content": first_reply},
+            {"role": "user", "content": "Now name one trade-off, in the same context."},
+        ]
+    )
+    print_response(send_chat(client, config, history))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/02_streaming.md
+++ b/examples/api/02_streaming.md
@@ -1,0 +1,83 @@
+# 02 — Streaming and incremental parsing
+
+Streaming improves perceived latency by exposing deltas as the server generates
+them. It also changes response handling: each event is partial and some terminal
+chunks contain usage metadata but no choices.
+
+## Run
+
+```bash
+python examples/api/02_streaming.py
+```
+
+## Complete request
+
+```python
+request = {
+    "model": config.model,
+    "messages": [
+        {
+            "role": "user",
+            "content": "Write a four-line checklist for reviewing an API integration.",
+        }
+    ],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 512,
+    "stream": True,
+    "extra_body": {
+        "chat_template_kwargs": {"reasoning_effort": "low"}
+    },
+}
+chunks = client.chat.completions.create(**request)
+```
+
+## Complete response parsing
+
+The shared iterator normalizes SDK models and dictionary-shaped test fixtures,
+skips empty `choices`, and keeps reasoning separate from final content:
+
+```python
+answer_parts = []
+reasoning_parts = []
+
+for chunk in chunks:
+    if not chunk.choices:
+        continue
+    delta = chunk.choices[0].delta
+    reasoning_delta = getattr(delta, "reasoning_content", "") or ""
+    answer_delta = delta.content or ""
+    if reasoning_delta:
+        reasoning_parts.append(reasoning_delta)
+    if answer_delta:
+        answer_parts.append(answer_delta)
+        print(answer_delta, end="", flush=True)
+
+answer = "".join(answer_parts)
+reasoning = "".join(reasoning_parts)
+```
+
+Time to first answer token (TTFT) is measured when the first non-empty
+`content` delta arrives, not when a role-only or reasoning-only chunk arrives.
+
+## Example output
+
+Illustrative format, not a live benchmark:
+
+```text
+Assistant: 1. Verify authentication and configuration.
+2. Validate success and error response schemas.
+3. Test timeouts, retries, and rate limits.
+4. Remove secrets from logs and fixtures.
+Time to first answer token: <seconds>s
+Total stream time: <seconds>s
+Answer characters: <count>
+Reasoning characters: <count>
+```
+
+## Checks
+
+- Do not assume every chunk has a choice or text.
+- Flush each printed delta so the terminal visibly streams.
+- Buffer the full answer if downstream code needs a complete string.
+- Keep TTFT and total-time start points consistent across measurements.

--- a/examples/api/02_streaming.py
+++ b/examples/api/02_streaming.py
@@ -1,0 +1,58 @@
+"""Hy3 API example 02: parse reasoning and answer deltas from a stream."""
+
+from __future__ import annotations
+
+import time
+
+from hy3_client import Hy3Config, create_client, reasoning_options, stream_fragments
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    print(f"Connecting with {config.safe_summary()}")
+
+    request = {
+        "model": config.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Write a four-line checklist for reviewing an API integration.",
+            }
+        ],
+        "temperature": 0.9,
+        "top_p": 1.0,
+        "max_tokens": 512,
+        "stream": True,
+        "extra_body": reasoning_options("low"),
+    }
+
+    started = time.perf_counter()
+    chunks = client.chat.completions.create(**request)
+    first_answer_at: float | None = None
+    reasoning_parts: list[str] = []
+    answer_parts: list[str] = []
+
+    print("\nAssistant: ", end="", flush=True)
+    for reasoning_delta, answer_delta in stream_fragments(chunks):
+        if reasoning_delta:
+            reasoning_parts.append(reasoning_delta)
+        if answer_delta:
+            if first_answer_at is None:
+                first_answer_at = time.perf_counter()
+            answer_parts.append(answer_delta)
+            print(answer_delta, end="", flush=True)
+
+    finished = time.perf_counter()
+    print()
+    if first_answer_at is not None:
+        print(f"Time to first answer token: {first_answer_at - started:.3f}s")
+    else:
+        print("Time to first answer token: unavailable (no answer delta received)")
+    print(f"Total stream time: {finished - started:.3f}s")
+    print(f"Answer characters: {len(''.join(answer_parts))}")
+    print(f"Reasoning characters: {len(''.join(reasoning_parts))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/03_latency_comparison.md
+++ b/examples/api/03_latency_comparison.md
@@ -1,0 +1,83 @@
+# 03 — Non-streaming versus streaming latency
+
+This example measures user-observable latency. It is an integration comparison,
+not a model-only benchmark: network, queueing, client work, and server generation
+are all included.
+
+## Run
+
+```bash
+HY3_BENCH_RUNS=3 python examples/api/03_latency_comparison.py
+```
+
+Each run sends the same prompt twice: once non-streaming and once streaming.
+Use a low run count on a metered endpoint.
+
+## Complete requests
+
+```python
+request = {
+    "model": config.model,
+    "messages": [
+        {
+            "role": "user",
+            "content": "Explain idempotency in HTTP APIs in about 120 words.",
+        }
+    ],
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "max_tokens": 256,
+    "extra_body": {
+        "chat_template_kwargs": {"reasoning_effort": "no_think"}
+    },
+}
+
+started = time.perf_counter()
+response = client.chat.completions.create(**request, stream=False)
+non_stream_total = time.perf_counter() - started
+
+started = time.perf_counter()
+chunks = client.chat.completions.create(**request, stream=True)
+first_token = None
+for _, answer_delta in stream_fragments(chunks):
+    if answer_delta and first_token is None:
+        first_token = time.perf_counter() - started
+stream_total = time.perf_counter() - started
+```
+
+## Complete response parsing
+
+The non-streaming call is complete when `create` returns. The streaming call is
+complete only after consuming its iterator. Store one total per mode and the
+first non-empty answer delta for TTFT, then compute arithmetic means:
+
+```python
+non_stream_average = statistics.fmean(item.total for item in non_stream_results)
+stream_ttft_average = statistics.fmean(
+    item.first_token for item in stream_results if item.first_token is not None
+)
+stream_total_average = statistics.fmean(item.total for item in stream_results)
+```
+
+## Example output
+
+Illustrative format only:
+
+```text
+Target: base_url=<redacted-host> model=hy3 timeout=120s; runs per mode=3
+Run 1: non-stream total=<seconds>s; stream TTFT=<seconds>s, total=<seconds>s
+Run 2: non-stream total=<seconds>s; stream TTFT=<seconds>s, total=<seconds>s
+Run 3: non-stream total=<seconds>s; stream TTFT=<seconds>s, total=<seconds>s
+
+Averages
+Non-stream total: <seconds>s
+Stream TTFT: <seconds>s
+Stream total: <seconds>s
+```
+
+## Interpretation
+
+- Streaming normally improves time to visible output, not necessarily total time.
+- A single run is easily distorted by cold starts and queueing.
+- Keep prompt, sampling, output cap, endpoint, and reasoning mode identical.
+- Record date, hardware or provider, and run count with any published result.

--- a/examples/api/03_latency_comparison.py
+++ b/examples/api/03_latency_comparison.py
@@ -1,0 +1,84 @@
+"""Hy3 API example 03: compare non-streaming latency with streaming TTFT."""
+
+from __future__ import annotations
+
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from hy3_client import Hy3Config, create_client, reasoning_options, stream_fragments
+
+
+@dataclass(frozen=True)
+class Timings:
+    first_token: float | None
+    total: float
+
+
+def non_streaming_run(client: Any, request: dict[str, Any]) -> Timings:
+    started = time.perf_counter()
+    client.chat.completions.create(**request, stream=False)
+    return Timings(first_token=None, total=time.perf_counter() - started)
+
+
+def streaming_run(client: Any, request: dict[str, Any]) -> Timings:
+    started = time.perf_counter()
+    chunks = client.chat.completions.create(**request, stream=True)
+    first_token: float | None = None
+    for _, answer_delta in stream_fragments(chunks):
+        if answer_delta and first_token is None:
+            first_token = time.perf_counter() - started
+    return Timings(first_token=first_token, total=time.perf_counter() - started)
+
+
+def average(values: list[float]) -> float:
+    return statistics.fmean(values) if values else float("nan")
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    runs = int(os.getenv("HY3_BENCH_RUNS", "3"))
+    if runs < 1:
+        raise ValueError("HY3_BENCH_RUNS must be at least 1")
+
+    request = {
+        "model": config.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Explain idempotency in HTTP APIs in about 120 words.",
+            }
+        ],
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_tokens": 256,
+        "extra_body": reasoning_options("no_think"),
+    }
+
+    non_stream_results: list[Timings] = []
+    stream_results: list[Timings] = []
+    print(f"Target: {config.safe_summary()}; runs per mode={runs}")
+    for index in range(1, runs + 1):
+        non_stream = non_streaming_run(client, request)
+        stream = streaming_run(client, request)
+        non_stream_results.append(non_stream)
+        stream_results.append(stream)
+        ttft = "n/a" if stream.first_token is None else f"{stream.first_token:.3f}s"
+        print(
+            f"Run {index}: non-stream total={non_stream.total:.3f}s; "
+            f"stream TTFT={ttft}, total={stream.total:.3f}s"
+        )
+
+    ttfts = [item.first_token for item in stream_results if item.first_token is not None]
+    print("\nAverages")
+    print(f"Non-stream total: {average([item.total for item in non_stream_results]):.3f}s")
+    print(f"Stream TTFT: {average(ttfts):.3f}s")
+    print(f"Stream total: {average([item.total for item in stream_results]):.3f}s")
+    print("Note: results include client/network/server time and are not a model-only benchmark.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/04_tool_calling.md
+++ b/examples/api/04_tool_calling.md
@@ -1,0 +1,108 @@
+# 04 — Tool calling with a bounded loop
+
+The model chooses tools, but application code owns execution. This example gives
+Hy3 one deterministic temperature-conversion function, validates its arguments,
+returns a tool result, and asks the model for the final explanation.
+
+The server must have automatic tool selection and the Hy3 tool-call parser
+enabled. See the repository deployment command before running this example.
+
+## Run
+
+```bash
+python examples/api/04_tool_calling.py
+```
+
+## Complete request
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "convert_temperature",
+            "description": "Convert a temperature between Celsius and Fahrenheit.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "number"},
+                    "to_unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                    },
+                },
+                "required": ["value", "to_unit"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+response = client.chat.completions.create(
+    model=config.model,
+    messages=[
+        {
+            "role": "user",
+            "content": "Convert 21 degrees Celsius to Fahrenheit, then explain the result.",
+        }
+    ],
+    tools=tools,
+    tool_choice="auto",
+    temperature=0.0,
+    max_tokens=512,
+    extra_body={
+        "chat_template_kwargs": {"reasoning_effort": "no_think"}
+    },
+)
+```
+
+## Complete response and tool loop
+
+A tool response normally contains an assistant message with `tool_calls` and no
+final prose. Preserve that assistant message, execute every requested call, and
+append results using the matching IDs:
+
+```python
+for _ in range(4):
+    response = client.chat.completions.create(..., messages=messages, tools=tools)
+    message = response.choices[0].message
+
+    if not message.tool_calls:
+        print(message.content)
+        break
+
+    messages.append(message.model_dump(exclude_none=True))
+    for tool_call in message.tool_calls:
+        arguments = json.loads(tool_call.function.arguments)
+        result = convert_temperature(**arguments)
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": json.dumps(result),
+            }
+        )
+else:
+    raise RuntimeError("tool loop exceeded its round limit")
+```
+
+The runnable script catches malformed JSON, missing arguments, and unknown tools
+and returns an error object to the model rather than executing arbitrary code.
+
+## Example output
+
+Illustrative format:
+
+```text
+Round 1: model requested 1 tool call(s)
+  convert_temperature({"value":21,"to_unit":"fahrenheit"}) -> {"value": 69.8, "unit": "°F"}
+Assistant: 21°C is 69.8°F, calculated by multiplying by 9/5 and adding 32.
+```
+
+## Production checks
+
+- Allow-list tool names; never evaluate model-generated code.
+- Validate arguments again in application code even when JSON Schema is strict.
+- Return one tool message for every `tool_call_id`, including error results.
+- Set a round limit and per-tool timeouts.
+- Require confirmation before a tool performs an external or destructive action.

--- a/examples/api/04_tool_calling.py
+++ b/examples/api/04_tool_calling.py
@@ -1,0 +1,111 @@
+"""Hy3 API example 04: execute tool calls in a bounded conversation loop."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hy3_client import Hy3Config, create_client, reasoning_options
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "convert_temperature",
+            "description": "Convert a temperature between Celsius and Fahrenheit.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "number", "description": "Temperature to convert."},
+                    "to_unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "Target unit.",
+                    },
+                },
+                "required": ["value", "to_unit"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def convert_temperature(value: float, to_unit: str) -> dict[str, float | str]:
+    if to_unit == "fahrenheit":
+        converted = value * 9 / 5 + 32
+        symbol = "°F"
+    elif to_unit == "celsius":
+        converted = (value - 32) * 5 / 9
+        symbol = "°C"
+    else:
+        raise ValueError(f"unsupported target unit: {to_unit}")
+    return {"value": round(converted, 2), "unit": symbol}
+
+
+def execute_tool_call(tool_call: Any) -> str:
+    if tool_call.function.name != "convert_temperature":
+        return json.dumps({"error": "unknown tool"})
+    try:
+        arguments = json.loads(tool_call.function.arguments or "{}")
+        result = convert_temperature(**arguments)
+        return json.dumps(result)
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        return json.dumps({"error": str(error)})
+
+
+def assistant_history_message(message: Any) -> dict[str, Any]:
+    if hasattr(message, "model_dump"):
+        return message.model_dump(exclude_none=True)
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": message.tool_calls,
+    }
+
+
+def run_tool_loop(client: Any, config: Hy3Config, max_rounds: int = 4) -> str:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": "Convert 21 degrees Celsius to Fahrenheit, then explain the result.",
+        }
+    ]
+    for round_number in range(1, max_rounds + 1):
+        response = client.chat.completions.create(
+            model=config.model,
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+            temperature=0.0,
+            max_tokens=512,
+            extra_body=reasoning_options("no_think"),
+        )
+        message = response.choices[0].message
+        if not message.tool_calls:
+            return message.content or ""
+
+        print(f"Round {round_number}: model requested {len(message.tool_calls)} tool call(s)")
+        messages.append(assistant_history_message(message))
+        for tool_call in message.tool_calls:
+            result = execute_tool_call(tool_call)
+            print(f"  {tool_call.function.name}({tool_call.function.arguments}) -> {result}")
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                }
+            )
+    raise RuntimeError(f"tool loop exceeded {max_rounds} rounds")
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    print(f"Connecting with {config.safe_summary()}")
+    print("Assistant: " + run_tool_loop(client, config))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/05_reasoning_modes.md
+++ b/examples/api/05_reasoning_modes.md
@@ -1,0 +1,92 @@
+# 05 — Comparing reasoning modes
+
+Hy3 accepts `no_think`, `low`, and `high` through its chat-template options.
+This example submits one availability problem in all three modes and reports
+latency plus the amount of separately returned reasoning text.
+
+## Run
+
+```bash
+python examples/api/05_reasoning_modes.py
+```
+
+Reasoning text is hidden by default. To inspect it in a private development
+terminal:
+
+```bash
+HY3_SHOW_REASONING=1 python examples/api/05_reasoning_modes.py
+```
+
+Do not place private reasoning, secrets, or user data in logs.
+
+## Complete request
+
+The request body is identical except for effort and output budget:
+
+```python
+prompt = (
+    "A service has 99.9% availability. Assuming independent downtime, what is the "
+    "probability that two redundant instances are both unavailable? Explain briefly."
+)
+
+response = client.chat.completions.create(
+    model=config.model,
+    messages=[{"role": "user", "content": prompt}],
+    temperature=0.0,
+    top_p=1.0,
+    max_tokens=2048 if effort == "high" else 768,
+    extra_body={
+        "chat_template_kwargs": {"reasoning_effort": effort}
+    },
+)
+```
+
+## Complete response parsing
+
+Some OpenAI-compatible SDK models preserve extension fields in `model_extra`.
+The example's helper supports both normal attributes and that fallback:
+
+```python
+message = response.choices[0].message
+reasoning = getattr(message, "reasoning_content", None)
+if reasoning is None and message.model_extra:
+    reasoning = message.model_extra.get("reasoning_content")
+
+final_answer = message.content or ""
+print("Reasoning characters returned:", len(reasoning or ""))
+print("Final answer:", final_answer)
+```
+
+Use `content`, not `reasoning_content`, as the normal user-facing result.
+
+## Example output
+
+Illustrative format only; latency and wording are endpoint-dependent:
+
+```text
+=== reasoning_effort=no_think ===
+Elapsed: <seconds>s
+Reasoning characters returned: <count>
+Final answer:
+<answer>
+
+=== reasoning_effort=low ===
+Elapsed: <seconds>s
+Reasoning characters returned: <count>
+Final answer:
+<answer>
+
+=== reasoning_effort=high ===
+Elapsed: <seconds>s
+Reasoning characters returned: <count>
+Final answer:
+<answer>
+```
+
+## Interpretation
+
+- `high` is not automatically better for simple questions.
+- Deep reasoning may require more time and a larger `max_tokens` budget.
+- Empty reasoning can mean `no_think`, a missing server parser, or an endpoint
+  that does not expose the field separately.
+- Compare final-answer correctness, not reasoning length alone.

--- a/examples/api/05_reasoning_modes.py
+++ b/examples/api/05_reasoning_modes.py
@@ -1,0 +1,47 @@
+"""Hy3 API example 05: compare no_think, low, and high reasoning modes."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from hy3_client import Hy3Config, create_client, reasoning_options, split_message
+
+PROMPT = (
+    "A service has 99.9% availability. Assuming independent downtime, what is the "
+    "probability that two redundant instances are both unavailable? Explain briefly."
+)
+
+
+def run_mode(client: Any, config: Hy3Config, effort: str) -> None:
+    started = time.perf_counter()
+    response = client.chat.completions.create(
+        model=config.model,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=2048 if effort == "high" else 768,
+        extra_body=reasoning_options(effort),
+    )
+    elapsed = time.perf_counter() - started
+    reasoning, content = split_message(response.choices[0].message)
+
+    print(f"\n=== reasoning_effort={effort} ===")
+    print(f"Elapsed: {elapsed:.3f}s")
+    print(f"Reasoning characters returned: {len(reasoning)}")
+    if os.getenv("HY3_SHOW_REASONING", "0") == "1" and reasoning:
+        print("Reasoning:\n" + reasoning)
+    print("Final answer:\n" + content)
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    print(f"Connecting with {config.safe_summary()}")
+    for effort in ("no_think", "low", "high"):
+        run_mode(client, config, effort)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/06_error_handling_retry.md
+++ b/examples/api/06_error_handling_retry.md
@@ -1,0 +1,97 @@
+# 06 — Error handling and bounded retry
+
+Retries help with transient failures but make permanent failures slower and can
+duplicate side effects. This example disables OpenAI SDK retries, then applies
+one visible, testable policy around a read-only chat request.
+
+## Run
+
+```bash
+python examples/api/06_error_handling_retry.py
+```
+
+## Complete request
+
+```python
+def request():
+    return client.chat.completions.create(
+        model=config.model,
+        messages=[
+            {
+                "role": "user",
+                "content": "Return one short sentence explaining exponential backoff.",
+            }
+        ],
+        temperature=0.0,
+        max_tokens=128,
+        extra_body={
+            "chat_template_kwargs": {"reasoning_effort": "no_think"}
+        },
+    )
+
+response = call_with_retry(request, attempts=4, on_retry=report_retry)
+```
+
+`create_client` uses `max_retries=0`. Without that setting, SDK retries and
+example retries would stack and make the real number of requests hard to see.
+
+## Retry classification
+
+The helper retries:
+
+- connection errors;
+- request timeouts;
+- rate-limit responses;
+- HTTP 408, 409, 429, 500, 502, 503, and 504.
+
+It does not retry authentication, malformed requests, missing models, or other
+client errors. Exponential backoff uses full jitter and a maximum delay:
+
+```python
+cap = min(max_delay, base_delay * (2 ** (attempt - 1)))
+delay = cap * random.random()
+delay = max(delay, retry_after_from_response or 0.0)
+time.sleep(delay)
+```
+
+Both numeric and HTTP-date `Retry-After` values are supported.
+
+## Complete response and error handling
+
+```python
+try:
+    response = call_with_retry(request, attempts=4, on_retry=report_retry)
+except AuthenticationError:
+    raise SystemExit("Authentication failed: check HY3_API_KEY.")
+except APITimeoutError:
+    raise SystemExit("The request timed out after all attempts.")
+except APIConnectionError:
+    raise SystemExit("Could not reach HY3_BASE_URL after all attempts.")
+except APIStatusError as error:
+    raise SystemExit(f"API returned HTTP {error.status_code}: {error.message}")
+
+print(response.choices[0].message.content or "")
+```
+
+## Example output
+
+Success after a transient failure, illustrative format:
+
+```text
+Attempt 1 failed with RateLimitError; retrying in <seconds>s
+Assistant: Exponential backoff increases the wait between repeated attempts.
+```
+
+Permanent failure, illustrative format:
+
+```text
+Authentication failed: check HY3_API_KEY (this error is not retried).
+```
+
+## Production checks
+
+- Cap attempts and individual request timeouts.
+- Honor `Retry-After` and reduce concurrency when rate limited.
+- Retry non-idempotent tool actions only with an idempotency strategy.
+- Log error class, status, attempt, and delay—never authorization headers.
+- Add circuit breaking or a queue when sustained overload is expected.

--- a/examples/api/06_error_handling_retry.py
+++ b/examples/api/06_error_handling_retry.py
@@ -1,0 +1,50 @@
+"""Hy3 API example 06: bounded retries for transient API failures."""
+
+from __future__ import annotations
+
+from hy3_client import Hy3Config, call_with_retry, create_client, reasoning_options
+from openai import APIConnectionError, APIStatusError, APITimeoutError, AuthenticationError
+
+
+def main() -> None:
+    config = Hy3Config.from_env()
+    client = create_client(config)
+    print(f"Connecting with {config.safe_summary()}")
+
+    def request():
+        return client.chat.completions.create(
+            model=config.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Return one short sentence explaining exponential backoff.",
+                }
+            ],
+            temperature=0.0,
+            max_tokens=128,
+            extra_body=reasoning_options("no_think"),
+        )
+
+    def report_retry(attempt: int, delay: float, error: BaseException) -> None:
+        print(f"Attempt {attempt} failed with {type(error).__name__}; retrying in {delay:.2f}s")
+
+    try:
+        response = call_with_retry(request, attempts=4, on_retry=report_retry)
+    except AuthenticationError:
+        raise SystemExit(
+            "Authentication failed: check HY3_API_KEY (this error is not retried)."
+        ) from None
+    except APITimeoutError:
+        raise SystemExit(
+            "The request timed out after all attempts; increase HY3_TIMEOUT if needed."
+        ) from None
+    except APIConnectionError:
+        raise SystemExit("Could not reach HY3_BASE_URL after all attempts.") from None
+    except APIStatusError as error:
+        raise SystemExit(f"API returned HTTP {error.status_code}: {error.message}") from error
+
+    print("Assistant: " + (response.choices[0].message.content or ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,55 @@
+# Hy3 API examples
+
+These examples accompany the repository-level [API quickstart](../../quickstart.md).
+They use the OpenAI-compatible endpoint documented by Hy3 and share only a small,
+tested transport helper. Every numbered script remains directly runnable from
+the repository root.
+
+## Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r examples/api/requirements.txt
+cp examples/api/.env.example examples/api/.env
+```
+
+Edit `.env` for the endpoint you actually operate. It is ignored by Git.
+
+## Index
+
+| # | Walkthrough | Script |
+| --- | --- | --- |
+| 01 | [Basic chat](./01_basic_chat.md) | [`01_basic_chat.py`](./01_basic_chat.py) |
+| 02 | [Streaming](./02_streaming.md) | [`02_streaming.py`](./02_streaming.py) |
+| 03 | [Latency comparison](./03_latency_comparison.md) | [`03_latency_comparison.py`](./03_latency_comparison.py) |
+| 04 | [Tool calling](./04_tool_calling.md) | [`04_tool_calling.py`](./04_tool_calling.py) |
+| 05 | [Reasoning modes](./05_reasoning_modes.md) | [`05_reasoning_modes.py`](./05_reasoning_modes.py) |
+| 06 | [Error handling and retry](./06_error_handling_retry.md) | [`06_error_handling_retry.py`](./06_error_handling_retry.py) |
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HY3_BASE_URL` | `http://127.0.0.1:8000/v1` | OpenAI-compatible root URL |
+| `HY3_API_KEY` | `EMPTY` | Non-empty local placeholder or hosted API key |
+| `HY3_MODEL` | `hy3` | Served model name |
+| `HY3_TIMEOUT` | `120` | Request timeout in seconds |
+| `HY3_BENCH_RUNS` | `3` | Runs per mode in example 03 |
+| `HY3_SHOW_REASONING` | `0` | Print reasoning text in example 05 only when set to `1` |
+
+The helper disables OpenAI SDK retries. Example 06 therefore demonstrates all
+retry behavior explicitly rather than stacking two retry policies.
+
+## Offline verification
+
+```bash
+python -m pip install -r examples/api/requirements-dev.txt
+ruff format --check --config examples/api/ruff.toml examples/api
+ruff check --config examples/api/ruff.toml examples/api
+pytest -q examples/api/tests
+```
+
+Offline checks validate parsing, retry policy, file contracts, and syntax. They
+do not prove that an endpoint or model works; run every script against Hy3 before
+publishing live-result claims.

--- a/examples/api/hy3_client.py
+++ b/examples/api/hy3_client.py
@@ -1,0 +1,199 @@
+"""Small, tested helpers shared by the runnable Hy3 API examples.
+
+The module deliberately contains transport concerns only. Each numbered example
+keeps its own request and response handling visible so readers can understand it
+without learning a framework first.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from typing import Any, TypeVar
+from urllib.parse import urlsplit
+
+from dotenv import load_dotenv
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI, RateLimitError
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+DEFAULT_MODEL = "hy3"
+RETRYABLE_STATUS_CODES = frozenset({408, 409, 429, 500, 502, 503, 504})
+REASONING_EFFORTS = frozenset({"no_think", "low", "high"})
+
+T = TypeVar("T")
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class Hy3Config:
+    """Connection settings loaded from environment variables."""
+
+    base_url: str = DEFAULT_BASE_URL
+    api_key: str = "EMPTY"
+    model: str = DEFAULT_MODEL
+    timeout: float = 120.0
+
+    @classmethod
+    def from_env(cls) -> Hy3Config:
+        """Load a nearby ``.env`` file, then read and validate settings."""
+
+        load_dotenv()
+        raw_timeout = os.getenv("HY3_TIMEOUT", "120")
+        try:
+            timeout = float(raw_timeout)
+        except ValueError as error:
+            raise ValueError("HY3_TIMEOUT must be a number of seconds") from error
+
+        config = cls(
+            base_url=os.getenv("HY3_BASE_URL", DEFAULT_BASE_URL).rstrip("/"),
+            api_key=os.getenv("HY3_API_KEY", "EMPTY"),
+            model=os.getenv("HY3_MODEL", DEFAULT_MODEL),
+            timeout=timeout,
+        )
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        parsed = urlsplit(self.base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError("HY3_BASE_URL must be an absolute http(s) URL")
+        if parsed.username or parsed.password:
+            raise ValueError("HY3_BASE_URL must not contain credentials")
+        if self.timeout <= 0:
+            raise ValueError("HY3_TIMEOUT must be greater than zero")
+        if not self.api_key:
+            raise ValueError("HY3_API_KEY must be non-empty; use EMPTY for a local server")
+        if not self.model:
+            raise ValueError("HY3_MODEL must be non-empty")
+
+    def safe_summary(self) -> str:
+        """Describe the target without printing credentials."""
+
+        return f"base_url={self.base_url} model={self.model} timeout={self.timeout:g}s"
+
+
+def create_client(config: Hy3Config) -> OpenAI:
+    """Create an OpenAI client with SDK retries disabled for predictable demos."""
+
+    return OpenAI(
+        base_url=config.base_url,
+        api_key=config.api_key,
+        timeout=config.timeout,
+        max_retries=0,
+    )
+
+
+def reasoning_options(effort: str) -> dict[str, Any]:
+    """Return Hy3's chat-template extension for one reasoning level."""
+
+    if effort not in REASONING_EFFORTS:
+        choices = ", ".join(sorted(REASONING_EFFORTS))
+        raise ValueError(f"reasoning effort must be one of: {choices}")
+    return {"chat_template_kwargs": {"reasoning_effort": effort}}
+
+
+def value_from(payload: Any, field: str, default: Any = None) -> Any:
+    """Read a field from SDK models, dictionaries, or ``model_extra``."""
+
+    if isinstance(payload, Mapping):
+        return payload.get(field, default)
+    value = getattr(payload, field, _MISSING)
+    if value is not _MISSING:
+        return value
+    model_extra = getattr(payload, "model_extra", None)
+    if isinstance(model_extra, Mapping):
+        return model_extra.get(field, default)
+    return default
+
+
+def split_message(message: Any) -> tuple[str, str]:
+    """Return ``(reasoning_content, final_content)`` with empty values normalized."""
+
+    reasoning = value_from(message, "reasoning_content", "") or ""
+    content = value_from(message, "content", "") or ""
+    return str(reasoning), str(content)
+
+
+def stream_fragments(chunks: Iterable[Any]) -> Iterable[tuple[str, str]]:
+    """Yield ``(reasoning_delta, content_delta)`` from non-empty stream chunks."""
+
+    for chunk in chunks:
+        choices = value_from(chunk, "choices", []) or []
+        if not choices:
+            continue
+        delta = value_from(choices[0], "delta")
+        if delta is None:
+            continue
+        reasoning = value_from(delta, "reasoning_content", "") or ""
+        content = value_from(delta, "content", "") or ""
+        if reasoning or content:
+            yield str(reasoning), str(content)
+
+
+def retry_after_seconds(error: BaseException, now: float | None = None) -> float | None:
+    """Read a numeric or HTTP-date ``Retry-After`` value from an SDK error."""
+
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if not headers or not hasattr(headers, "get"):
+        return None
+    value = headers.get("retry-after") or headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        pass
+    try:
+        parsed = parsedate_to_datetime(str(value))
+        return max(0.0, parsed.timestamp() - (time.time() if now is None else now))
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
+def is_retryable(error: BaseException) -> bool:
+    """Return whether retrying this client/API failure is normally safe."""
+
+    if isinstance(error, (APIConnectionError, APITimeoutError, RateLimitError)):
+        return True
+    if isinstance(error, APIStatusError):
+        return getattr(error, "status_code", None) in RETRYABLE_STATUS_CODES
+    status_code = getattr(error, "status_code", None)
+    return status_code in RETRYABLE_STATUS_CODES
+
+
+def call_with_retry(
+    operation: Callable[[], T],
+    *,
+    attempts: int = 4,
+    base_delay: float = 0.5,
+    max_delay: float = 8.0,
+    sleep: Callable[[float], None] = time.sleep,
+    random_value: Callable[[], float] = random.random,
+    on_retry: Callable[[int, float, BaseException], None] | None = None,
+) -> T:
+    """Run an operation with capped exponential backoff and full jitter."""
+
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if base_delay < 0 or max_delay < 0:
+        raise ValueError("retry delays must be non-negative")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except Exception as error:
+            if not is_retryable(error) or attempt == attempts:
+                raise
+            cap = min(max_delay, base_delay * (2 ** (attempt - 1)))
+            server_delay = retry_after_seconds(error)
+            delay = max(cap * random_value(), server_delay or 0.0)
+            if on_retry:
+                on_retry(attempt, delay, error)
+            sleep(delay)
+
+    raise AssertionError("unreachable")

--- a/examples/api/requirements-dev.txt
+++ b/examples/api/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0,<10
+ruff>=0.9,<1

--- a/examples/api/requirements.txt
+++ b/examples/api/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.40.0,<3
+python-dotenv>=1.0.1,<2

--- a/examples/api/ruff.toml
+++ b/examples/api/ruff.toml
@@ -1,0 +1,8 @@
+line-length = 100
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "I", "B", "UP"]
+
+[format]
+quote-style = "double"

--- a/examples/api/tests/conftest.py
+++ b/examples/api/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Make the adjacent example helper importable during repository-root tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+API_EXAMPLES = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(API_EXAMPLES))

--- a/examples/api/tests/test_examples_contract.py
+++ b/examples/api/tests/test_examples_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+API_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = API_DIR.parents[1]
+STEMS = (
+    "01_basic_chat",
+    "02_streaming",
+    "03_latency_comparison",
+    "04_tool_calling",
+    "05_reasoning_modes",
+    "06_error_handling_retry",
+)
+
+
+def test_every_example_has_script_and_walkthrough() -> None:
+    for stem in STEMS:
+        assert (API_DIR / f"{stem}.py").is_file()
+        assert (API_DIR / f"{stem}.md").is_file()
+
+
+def test_all_example_python_files_parse() -> None:
+    for path in sorted(API_DIR.rglob("*.py")):
+        ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_walkthroughs_cover_request_parsing_and_output() -> None:
+    for stem in STEMS:
+        text = (API_DIR / f"{stem}.md").read_text(encoding="utf-8").lower()
+        assert "request" in text
+        assert "response" in text
+        assert "example output" in text
+        assert "```" in text
+
+
+def test_local_markdown_links_resolve() -> None:
+    markdown_files = [REPO_ROOT / "quickstart.md", API_DIR / "README.md"]
+    markdown_files.extend(API_DIR / f"{stem}.md" for stem in STEMS)
+    link_pattern = re.compile(r"\[[^]]+\]\(([^)]+)\)")
+
+    for markdown_file in markdown_files:
+        for target in link_pattern.findall(markdown_file.read_text(encoding="utf-8")):
+            if "://" in target or target.startswith("#"):
+                continue
+            path_part = target.split("#", 1)[0]
+            resolved = (markdown_file.parent / path_part).resolve()
+            assert resolved.exists(), f"broken link in {markdown_file}: {target}"
+
+
+def test_tracked_content_has_no_key_shaped_secret() -> None:
+    key_pattern = re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b")
+    paths = [REPO_ROOT / "quickstart.md"]
+    paths.extend(API_DIR.rglob("*"))
+    for path in paths:
+        if not path.is_file() or path.suffix not in {".md", ".py", ".example"}:
+            continue
+        assert not key_pattern.search(path.read_text(encoding="utf-8")), path

--- a/examples/api/tests/test_hy3_client.py
+++ b/examples/api/tests/test_hy3_client.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from hy3_client import (
+    Hy3Config,
+    call_with_retry,
+    is_retryable,
+    reasoning_options,
+    retry_after_seconds,
+    split_message,
+    stream_fragments,
+    value_from,
+)
+
+
+@dataclass
+class ExtraOnly:
+    model_extra: dict[str, str]
+
+
+class FakeHTTPError(Exception):
+    def __init__(self, status_code: int, retry_after: str | None = None):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+        headers = {} if retry_after is None else {"Retry-After": retry_after}
+        self.response = type("Response", (), {"headers": headers})()
+
+
+def test_config_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HY3_BASE_URL", "https://example.test/v1/")
+    monkeypatch.setenv("HY3_API_KEY", "test-only-key")
+    monkeypatch.setenv("HY3_MODEL", "served-hy3")
+    monkeypatch.setenv("HY3_TIMEOUT", "45.5")
+
+    config = Hy3Config.from_env()
+
+    assert config.base_url == "https://example.test/v1"
+    assert config.api_key == "test-only-key"
+    assert config.model == "served-hy3"
+    assert config.timeout == 45.5
+    assert "test-only-key" not in config.safe_summary()
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"base_url": "localhost:8000/v1"}, "absolute"),
+        ({"base_url": "https://user:pass@example.test/v1"}, "credentials"),
+        ({"timeout": 0}, "greater than zero"),
+        ({"api_key": ""}, "non-empty"),
+        ({"model": ""}, "non-empty"),
+    ],
+)
+def test_config_rejects_invalid_values(changes: dict[str, object], message: str) -> None:
+    values = {
+        "base_url": "http://127.0.0.1:8000/v1",
+        "api_key": "EMPTY",
+        "model": "hy3",
+        "timeout": 120.0,
+    }
+    values.update(changes)
+    with pytest.raises(ValueError, match=message):
+        Hy3Config(**values).validate()
+
+
+def test_config_rejects_non_numeric_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HY3_TIMEOUT", "later")
+    with pytest.raises(ValueError, match="number of seconds"):
+        Hy3Config.from_env()
+
+
+@pytest.mark.parametrize("effort", ["no_think", "low", "high"])
+def test_reasoning_options(effort: str) -> None:
+    assert reasoning_options(effort) == {"chat_template_kwargs": {"reasoning_effort": effort}}
+
+
+def test_reasoning_options_reject_unknown_level() -> None:
+    with pytest.raises(ValueError, match="reasoning effort"):
+        reasoning_options("maximum")
+
+
+def test_value_from_supports_extension_fields() -> None:
+    assert value_from(ExtraOnly({"reasoning_content": "steps"}), "reasoning_content") == "steps"
+    assert value_from({"content": "answer"}, "content") == "answer"
+
+
+def test_split_message_normalizes_missing_values() -> None:
+    assert split_message({"reasoning_content": None, "content": "done"}) == ("", "done")
+
+
+def test_stream_fragments_skips_metadata_and_empty_chunks() -> None:
+    chunks = [
+        {"choices": []},
+        {"choices": [{"delta": {"role": "assistant"}}]},
+        {"choices": [{"delta": {"reasoning_content": "think ", "content": None}}]},
+        {"choices": [{"delta": {"content": "answer"}}]},
+    ]
+    assert list(stream_fragments(chunks)) == [("think ", ""), ("", "answer")]
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [(408, True), (429, True), (503, True), (400, False), (401, False), (404, False)],
+)
+def test_retryable_statuses(status_code: int, expected: bool) -> None:
+    assert is_retryable(FakeHTTPError(status_code)) is expected
+
+
+def test_retry_after_numeric_seconds() -> None:
+    assert retry_after_seconds(FakeHTTPError(429, "2.5")) == 2.5
+
+
+def test_call_with_retry_recovers_and_reports_delay() -> None:
+    outcomes = [FakeHTTPError(503), "ok"]
+    delays: list[float] = []
+    reports: list[tuple[int, float, type[BaseException]]] = []
+
+    def operation() -> str:
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    result = call_with_retry(
+        operation,
+        attempts=3,
+        base_delay=2,
+        random_value=lambda: 0.25,
+        sleep=delays.append,
+        on_retry=lambda attempt, delay, error: reports.append((attempt, delay, type(error))),
+    )
+
+    assert result == "ok"
+    assert delays == [0.5]
+    assert reports == [(1, 0.5, FakeHTTPError)]
+
+
+def test_call_with_retry_does_not_retry_permanent_failure() -> None:
+    calls = 0
+
+    def operation() -> None:
+        nonlocal calls
+        calls += 1
+        raise FakeHTTPError(401)
+
+    with pytest.raises(FakeHTTPError):
+        call_with_retry(operation, attempts=4, sleep=lambda _: None)
+    assert calls == 1

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,265 @@
+# Hy3 API quickstart
+
+This guide gets a developer from a running Hy3 server to a first response in
+about five minutes, then introduces the main API capabilities through six
+runnable examples.
+
+Hy3 exposes an OpenAI-compatible Chat Completions API when served with vLLM or
+SGLang. The repository's [deployment guide](./README.md#deployment) explains how
+to start either server.
+
+## 1. Connection basics
+
+| Setting | Local default | Notes |
+| --- | --- | --- |
+| Base URL | `http://127.0.0.1:8000/v1` | Keep the `/v1` suffix. |
+| API key | `EMPTY` | Local servers normally accept any non-empty value. A hosted endpoint requires its real key. |
+| Model | `hy3` | Must match the server's `--served-model-name`. |
+| Timeout | `120` seconds | Increase for long context or `high` reasoning. |
+
+Self-hosted Hy3 has no fixed API-level QPS or token-per-minute quota. Effective
+throughput depends on GPU memory, server concurrency, context length, and
+generation length. A gateway or hosted provider may return HTTP `429`; follow
+its published quota and `Retry-After` header rather than assuming a universal
+limit.
+
+Never commit a real API key. The examples read all connection information from
+environment variables.
+
+## 2. First call in five minutes
+
+### Prerequisites
+
+- Python 3.10 or newer
+- A Hy3 vLLM or SGLang endpoint
+- `curl` for the HTTP example
+
+From the repository root:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r examples/api/requirements.txt
+
+cp examples/api/.env.example examples/api/.env
+```
+
+The default `.env` targets a local server. To use another endpoint, edit the
+copy without committing it:
+
+```dotenv
+HY3_BASE_URL=http://127.0.0.1:8000/v1
+HY3_API_KEY=EMPTY
+HY3_MODEL=hy3
+HY3_TIMEOUT=120
+```
+
+Confirm that the server advertises the model:
+
+```bash
+curl "$HY3_BASE_URL/models" \
+  -H "Authorization: Bearer $HY3_API_KEY"
+```
+
+If the variables only exist in `examples/api/.env`, export them before using
+`curl`; the Python examples load that file automatically.
+
+### Minimal curl request
+
+```bash
+curl --fail-with-body --silent --show-error \
+  "$HY3_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "model": "hy3",
+  "messages": [
+    {"role": "user", "content": "Explain what an API is in one sentence."}
+  ],
+  "temperature": 0.9,
+  "top_p": 1.0,
+  "max_tokens": 128,
+  "chat_template_kwargs": {"reasoning_effort": "no_think"}
+}
+JSON
+```
+
+### Minimal Python request
+
+```python
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv("examples/api/.env")
+
+client = OpenAI(
+    base_url=os.getenv("HY3_BASE_URL", "http://127.0.0.1:8000/v1"),
+    api_key=os.getenv("HY3_API_KEY", "EMPTY"),
+    timeout=float(os.getenv("HY3_TIMEOUT", "120")),
+)
+
+response = client.chat.completions.create(
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[
+        {"role": "user", "content": "Explain what an API is in one sentence."}
+    ],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+    extra_body={
+        "chat_template_kwargs": {"reasoning_effort": "no_think"}
+    },
+)
+
+choice = response.choices[0]
+print(choice.message.content)
+print("finish_reason:", choice.finish_reason)
+if response.usage:
+    print("total_tokens:", response.usage.total_tokens)
+```
+
+An OpenAI-compatible response has this shape (content and counts vary):
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "model": "hy3",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "An API is ..."},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 18,
+    "completion_tokens": 24,
+    "total_tokens": 42
+  }
+}
+```
+
+Treat the values above as a schema illustration, not a captured benchmark.
+
+## 3. Request parameters
+
+### `temperature`
+
+Controls sampling randomness. Lower values favor repeatability; higher values
+allow more variation. Hy3's repository recommends `0.9`. For latency comparisons
+and deterministic tool arguments, these examples use `0.0` where appropriate.
+
+### `top_p`
+
+Limits sampling to the smallest token set whose cumulative probability reaches
+the supplied value. Hy3's repository recommends `1.0`. Tune `temperature` first
+instead of changing both controls at once.
+
+### `max_tokens`
+
+Caps generated tokens. A small cap lowers latency and cost but may produce
+`finish_reason="length"`. Input plus generated tokens must fit the served
+context window. Reasoning modes also consume generation budget, so allow a
+larger cap for `high`.
+
+### `stop`
+
+A string or list of strings that ends generation when matched. Stop sequences
+are omitted from most examples because accidental matches can truncate prose.
+
+```python
+response = client.chat.completions.create(
+    ...,
+    stop=["END_OF_ANSWER"],
+)
+```
+
+### `tools`
+
+Declare functions with JSON Schema in the OpenAI `tools` format. The model may
+return `message.tool_calls`; the application must validate arguments, execute
+the named function, then append one `role="tool"` message per call.
+
+For vLLM, start Hy3 with:
+
+```text
+--tool-call-parser hy_v3 --enable-auto-tool-choice
+```
+
+For SGLang, use its Hy3 `hunyuan` tool-call parser as shown in the deployment
+recipe. See [example 04](./examples/api/04_tool_calling.md) for a bounded loop.
+
+### Reasoning mode
+
+Pass the Hy3 extension through `extra_body` when using the Python SDK:
+
+```python
+extra_body={
+    "chat_template_kwargs": {
+        "reasoning_effort": "no_think"  # or "low" / "high"
+    }
+}
+```
+
+| Value | Suggested use |
+| --- | --- |
+| `no_think` | Direct answers and lowest latency |
+| `low` | Moderate planning or multi-constraint tasks |
+| `high` | Math, coding, and difficult reasoning |
+
+The server must be started with the matching reasoning parser (`hy_v3` for
+vLLM or `hunyuan` for SGLang). When provided by the server, reasoning is exposed
+separately as `message.reasoning_content`. Applications should use
+`message.content` as the final user-facing answer.
+
+## 4. Runnable examples
+
+Run every script from the repository root:
+
+| Example | Command | Demonstrates |
+| --- | --- | --- |
+| Basic chat | `python examples/api/01_basic_chat.py` | Single and multi-turn history |
+| Streaming | `python examples/api/02_streaming.py` | Chunk parsing and TTFT |
+| Latency comparison | `python examples/api/03_latency_comparison.py` | Repeated non-stream/stream timing |
+| Tool calling | `python examples/api/04_tool_calling.py` | JSON arguments and bounded tool loop |
+| Reasoning modes | `python examples/api/05_reasoning_modes.py` | `no_think`, `low`, and `high` |
+| Error handling | `python examples/api/06_error_handling_retry.py` | Retry classification and backoff |
+
+Each script has a companion walkthrough under [`examples/api`](./examples/api/).
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Check or fix |
+| --- | --- | --- |
+| Connection refused | Server is not listening or URL is wrong | Run `curl $HY3_BASE_URL/models`; inspect server logs and port. |
+| HTTP 401/403 | Missing or invalid key | Set a non-empty local key or the hosted provider's real key. Do not log it. |
+| HTTP 404 / model not found | Wrong `/v1` path or served model name | List `/models`; align `HY3_MODEL` with `--served-model-name`. |
+| HTTP 429 | Gateway/concurrency quota | Honor `Retry-After`, reduce concurrency, and use bounded backoff. |
+| Timeout | Queueing, long context, or deep reasoning | Increase `HY3_TIMEOUT`, reduce input/output length, and inspect server load. |
+| Empty `reasoning_content` | Direct mode or missing parser | Use `low`/`high` and start the server with the Hy3 reasoning parser. |
+| No `tool_calls` | Parser not enabled or model answered directly | Enable the tool parser; use `tool_choice="auto"` and a precise tool description. |
+| `finish_reason="length"` | Output cap reached | Increase `max_tokens` or shorten the prompt. |
+| CUDA out of memory | Model/context/concurrency exceeds GPU memory | Reduce max model length or concurrency; follow the 8-GPU deployment recipe. |
+
+Do not retry malformed requests, authentication failures, or model-not-found
+responses. Fix those errors first. Example 06 retries only connection failures,
+timeouts, rate limits, and selected transient server responses.
+
+## 6. Validate the examples
+
+Offline checks do not require a model or API key:
+
+```bash
+python -m pip install -r examples/api/requirements-dev.txt
+ruff format --check --config examples/api/ruff.toml examples/api
+ruff check --config examples/api/ruff.toml examples/api
+pytest -q examples/api/tests
+```
+
+Then run all six scripts against the target endpoint. Record the endpoint type,
+date, and redacted outputs in a pull request; never claim a live verification
+from offline tests alone.


### PR DESCRIPTION
## Summary

- add a repository-level Hy3 API quickstart covering connection settings, curl and Python calls, parameters, reasoning modes, tool calling, rate limits, and troubleshooting
- add six runnable Python examples with companion walkthroughs for chat, streaming, latency comparison, tool calling, reasoning modes, and retry handling
- add shared configuration/parsing helpers, explicit bounded retry behavior, dependency files, and discoverability links from both repository READMEs
- add offline tests for configuration, stream parsing, retry classification, documentation links, file contracts, and secret-shaped content

## Validation

- `ruff format --check --config examples/api/ruff.toml examples/api`
- `ruff check --config examples/api/ruff.toml examples/api`
- `pytest -q examples/api/tests` (28 passed)
- `git diff --check`
- staged secret-pattern scan

A live Hy3 endpoint was not available during local verification, so sample output is explicitly marked illustrative rather than presented as a live capture.

Closes #1