### PR TITLE
docs: add Hy3 API quickstart and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 Thumbs.db
 __pycache__/
 *.pyc
+.idea
+.env
+.env.*
+.venv/

--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -1,0 +1,419 @@
+# Hy3 Responses API
+
+This guide explains how to call Hy3 through the Tencent Cloud TokenHub Responses API and how it differs from the [Chat Completions API](../../quickstart.md).
+
+Responses API uses a unified `input` and `output` model. Messages, reasoning items, function calls, and function-call results are represented as typed Items. This is useful for tool calling, multimodal input, and more complex Agent workflows.
+
+## Chat Completions and Responses: quick comparison
+
+| Topic              | Chat Completions API            | Responses API                                                                                |
+|--------------------|---------------------------------|----------------------------------------------------------------------------------------------|
+| Endpoint           | `/v1/chat/completions`          | `/v1/responses`                                                                              |
+| Input              | `messages` array                | Top-level `input`, either a string or an Item array                                          |
+| Instructions       | Usually a `system` message      | Optional top-level `instructions`                                                            |
+| Text output        | `choices[0].message.content`    | Usually `response.output_text`                                                               |
+| Output structure   | `choices`                       | `output` Item array containing `message`, `reasoning`, or `function_call` Items              |
+| Tool calling       | `tool_calls` and `role: "tool"` | `function_call` and `function_call_output` Items linked by `call_id`                         |
+| Conversation state | Resend `messages` history       | Resend input Items; `previous_response_id` is not reliable in the current compatibility path |
+
+Migration is not only a URL change. Input mapping, response parsing, tool calls, structured output, and streaming events all need to be updated. For ordinary text, the most common mapping is:
+
+```text
+choices[0].message.content  →  response.output_text
+```
+
+## 1. Basic information
+
+### Endpoint
+
+Guangzhou:
+
+```text
+https://tokenhub.tencentmaas.com/v1/responses
+```
+
+Singapore:
+
+```text
+https://tokenhub-intl.tencentmaas.com/v1/responses
+```
+
+The API key, Base URL, and service region must match. Authentication uses the same header as Chat Completions:
+
+```http
+Authorization: Bearer ${HY3_API_KEY}
+```
+
+### Model name
+
+This guide uses the Hy3 service ID:
+
+```text
+hy3
+```
+
+The model marketplace declares Hy3 support for OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages. The model list in the generic Responses compatibility document describes the models explicitly listed for that compatibility path and should not replace the model marketplace declaration. Before using another model, verify its model ID and protocol support with the console or `GET /v1/models`.
+
+## 2. First request
+
+Use top-level `instructions` for high-level behavior and `input` for the user request:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "instructions": "You are a helpful assistant.",
+    "input": "Hello",
+    "stream": false
+  }'
+```
+
+### Request fields
+
+| Field          | Type            | Description                                                  |
+|----------------|-----------------|--------------------------------------------------------------|
+| `model`        | string          | Model or service ID, such as `hy3`.                          |
+| `instructions` | string or array | High-level instructions for the current response.            |
+| `input`        | string or array | User input, either plain text or input Items.                |
+| `stream`       | boolean         | Whether to return SSE events instead of a complete response. |
+
+`instructions` applies only to the current request. If conversation history is manually provided in `input`, include the required instructions explicitly.
+
+### Roles and instructions
+
+Stable behavior instructions are best placed in `instructions`. They can also be represented as a `developer` message in an `input` array:
+
+```json
+{
+  "model": "hy3",
+  "input": [
+    {"role": "developer", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello"}
+  ],
+  "stream": false
+}
+```
+
+### Response structure
+
+A typical response contains:
+
+```json
+{
+  "id": "30d23e89-48b8-4ea2-8ba3-b52db746d4c8",
+  "object": "response",
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {"type": "output_text", "text": "Hello! How can I help you?"}
+      ]
+    }
+  ],
+  "output_text": "Hello! How can I help you?",
+  "usage": {
+    "input_tokens": 22,
+    "output_tokens": 12,
+    "total_tokens": 34
+  },
+  "error": null
+}
+```
+
+For ordinary text, read `output_text`. If the application handles tools, reasoning, or other Item types, iterate through `output` and branch on each Item's `type`.
+
+## 3. Python OpenAI SDK
+
+Install the dependencies from the repository:
+
+```bash
+uv sync
+```
+
+The minimal example is [`examples/06_responses_basic.py`](../../examples/06_responses_basic.py):
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["HY3_API_KEY"],
+    base_url="https://tokenhub.tencentmaas.com/v1",
+)
+
+response = client.responses.create(
+    model="hy3",
+    instructions="You are a helpful assistant.",
+    input="Hello",
+)
+
+print(response.output_text)
+```
+
+## 4. Multi-turn conversations
+
+In the current TokenHub compatibility path, the safest approach is to store the history in the client and resend it through `input`:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": [
+      {"role": "user", "content": "Hello, my name is Xiao Ming."},
+      {"role": "assistant", "content": "Hello, Xiao Ming!"},
+      {"role": "user", "content": "What is my name?"}
+    ],
+    "stream": false
+  }'
+```
+
+The field `previous_response_id` can be accepted by the endpoint while still failing to restore the previous context on the current service path. The field name itself is valid, but applications should not rely on it without verifying the behavior. Use explicit history in `input` when context continuity is required.
+
+## 5. Reasoning mode
+
+Responses API uses `reasoning.effort` rather than the Chat Completions `thinking` style:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "Calculate 37 × 24 and explain the result in one sentence.",
+    "reasoning": {"effort": "high"},
+    "stream": false
+  }'
+```
+
+A reasoning-enabled response may contain a `reasoning` Item and a final `message` Item. The `usage.output_tokens_details.reasoning_tokens` field can be used to identify reasoning-token usage. Do not assume that the service will return or that an application should display the model's private chain of thought.
+
+The available effort values and behavior depend on the model and service. See [`examples/05_reasoning_mode.py`](../../examples/05_reasoning_mode.py) for a Chat Completions comparison and the [TokenHub reasoning guide](https://cloud.tencent.com/document/product/1823/131208).
+
+## 6. Tool calling
+
+Responses function calling has four stages: declare a tool, parse the `function_call`, execute the local function, and return a `function_call_output` Item. The model does not execute the local function.
+
+### 6.1 Declare a function
+
+Responses tool definitions use a flat structure. `type`, `name`, `description`, and `parameters` are direct fields of the tool object:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "What is the weather in Shenzhen?",
+    "tools": [
+      {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather information for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string", "description": "City name"}
+          },
+          "required": ["city"],
+          "additionalProperties": false
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+`properties` defines the available arguments, `required` lists mandatory arguments, and `additionalProperties: false` rejects undeclared fields. `tool_choice: "auto"` lets the model decide whether to call the tool.
+
+### 6.2 Parse a function call
+
+The first response may contain:
+
+```json
+{
+  "type": "function_call",
+  "id": "fc_example",
+  "status": "completed",
+  "name": "get_weather",
+  "call_id": "chatcmpl-tool-example",
+  "arguments": "{\"city\": \"Shenzhen\"}"
+}
+```
+
+Parse `arguments` as a JSON string and execute the function named by `name`. The returned `call_id` is the correlation ID for the next request.
+
+### 6.3 Return the tool result
+
+Include the previous function-call Item and a `function_call_output` Item in the next `input` array:
+
+```json
+{
+  "type": "function_call_output",
+  "call_id": "chatcmpl-tool-example",
+  "output": "{\"city\":\"Shenzhen\",\"weather\":\"sunny\",\"temperature\":28}"
+}
+```
+
+`function_call_output.call_id` must exactly match the previous `function_call.call_id`. The `output` value is normally a JSON string. Repeat the process if the next response contains another function call. See [`examples/08_responses_tool_calling.py`](../../examples/08_responses_tool_calling.py) for a complete runnable flow.
+
+## 7. Streaming output
+
+Set `stream` to `true` to receive Server-Sent Events:
+
+```bash
+curl -N -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "Hello",
+    "stream": true
+  }'
+```
+
+Common events include:
+
+| Event | Description |
+| --- | --- |
+| `response.created` | Response object created. |
+| `response.in_progress` | Response generation is in progress. |
+| `response.output_item.added` | A new output Item was added. |
+| `response.output_text.delta` | A text increment; append `delta` in order. |
+| `response.output_text.done` | The current text output is complete. |
+| `response.output_item.done` | The current output Item is complete. |
+| `response.completed` | The entire response is complete and usually contains `usage`. |
+| `response.failed` | The response failed and contains error information. |
+
+Not every event contains `delta`. Check the event type before reading event-specific fields. Do not reuse a Chat Completions chunk parser for Responses events.
+
+The current TokenHub response may contain `output: null` in `response.created`, which causes some OpenAI SDK high-level Responses stream parsers to fail when they assume `output` is always an array. [`examples/07_responses_streaming.py`](../../examples/07_responses_streaming.py) therefore parses the raw SSE stream with the Python standard library.
+
+## 8. Structured output
+
+Use `text.format` and `json_schema` to constrain the output:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "Extract the person information: Zhang San, male, 25, from Beijing.",
+    "text": {
+      "format": {
+        "type": "json_schema",
+        "name": "person_info",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "gender": {"type": "string"},
+            "age": {"type": "number"},
+            "city": {"type": "string"}
+          },
+          "required": ["name", "gender", "age", "city"],
+          "additionalProperties": false
+        },
+        "strict": true
+      }
+    },
+    "stream": false
+  }'
+```
+
+The response still uses a normal `message` Item, but its `output_text` value is a JSON string:
+
+```json
+{
+  "age": 25,
+  "city": "Beijing",
+  "gender": "male",
+  "name": "Zhang San"
+}
+```
+
+Parse it once more in the application:
+
+```python
+import json
+
+person = json.loads(response.output_text)
+print(person["name"])
+```
+
+`output_text` is not already a Python dictionary or JavaScript object. Handle empty responses, failed requests, and JSON parsing errors in production. See [`examples/09_responses_structured_output.py`](../../examples/09_responses_structured_output.py).
+
+## 9. Request parameters
+
+The following parameters are commonly used by the current compatibility path:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `temperature` | number | Controls sampling randomness. The documented range is `[0, 2]`. |
+| `top_p` | number | Nucleus sampling parameter. The documented range is `[0, 1]`. |
+| `max_output_tokens` | integer | Maximum generated output tokens. It must be greater than zero. |
+| `tools` | array | Function tools; the current compatibility path supports `function` tools. |
+| `tool_choice` | string or object | Tool selection policy. |
+| `reasoning.effort` | string | Reasoning effort, when supported by the model. |
+| `text.format` | object | Text, JSON object, or JSON Schema output format. |
+| `stream` | boolean | Complete response or SSE stream. |
+
+### `stop` behavior
+
+The compatibility documentation does not list `stop` as a fully supported Responses parameter. A test request returned HTTP `200`, but the output still contained `STOP`:
+
+```bash
+curl -i -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "Output the following and end with STOP: first line, second line.",
+    "stop": ["STOP"],
+    "stream": false
+  }'
+```
+
+The observed output was `first line\nsecond line\nSTOP` in the real test. This indicates that the service accepted the field but did not apply the expected truncation. Do not rely on `stop` for Responses output control without retesting the exact model and service path. Prefer structured output or client-side post-processing when strict output control is required.
+
+## 10. Common errors
+
+Responses API errors usually use this structure:
+
+```json
+{
+  "error": {
+    "type": "rate_limit_error",
+    "code": "429006",
+    "message": "The model service is currently busy or has reached its serving capacity limit. Please reduce the request frequency and try again later.",
+    "message_zh": "当前模型服务繁忙或已达服务容量上限，请降低请求频率后稍后重试。",
+    "source": "gateway",
+    "request_id": "57b8d6ff-03dd-45a0-8d8e-5eebba3e0470"
+  }
+}
+```
+
+Read `error.code`, `error.type`, `error.message_zh`, and `error.request_id` first. Lower request frequency, wait before retrying, and use exponential backoff with random jitter for transient errors. If `Retry-After` is present, follow it before retrying. Record the request ID, request time, and model name when reporting persistent failures. See [`examples/10_error_handling_retry.py`](../../examples/10_error_handling_retry.py) and [TokenHub API error codes](https://cloud.tencent.com/document/product/1823/131595).
+
+## 11. Notes
+
+- Responses output Items are not identical to Chat Completions `choices`; do not reuse the old parser without adapting it.
+- Use `response.output_text` for ordinary text and iterate over `response.output` for tools, reasoning, and other Item types.
+- Do not put API keys in Python files, shell scripts, Markdown examples, or committed `.env` files.
+- Verify parameter support against the model marketplace, TokenHub documentation, and an actual response. A field may be accepted but have no effect.
+
+## References
+
+- [TokenHub Responses API compatibility](https://cloud.tencent.com/document/product/1823/133813): parameter support, input/output structures, and compatibility limits.
+- [TokenHub language-model overview](https://cloud.tencent.com/document/product/1823/130079): common parameters, response fields, tools, and streaming.
+- [TokenHub API usage](https://cloud.tencent.com/document/product/1823/130078): endpoints, authentication, model listing, and exceptions.
+- [Hy3 calling guide](https://cloud.tencent.com/document/product/1823/132252): Hy3 limits, protocol support, and model-specific usage.
+- [TokenHub reasoning guide](https://cloud.tencent.com/document/product/1823/131208): `thinking`, `reasoning_effort`, and reasoning behavior.
+- [TokenHub API error codes](https://cloud.tencent.com/document/product/1823/131595): HTTP status codes and business errors.

--- a/docs/api/responses_cn.md
+++ b/docs/api/responses_cn.md
@@ -1,0 +1,1069 @@
+# Hy3 Responses API
+
+本文介绍如何通过腾讯云 TokenHub 调用 Hy3 Responses API，并简要说明它与
+[Chat Completions API](../../quickstart_cn.md) 的差异。
+
+Responses API 可以看作 Chat Completions API 的另一种调用接口：它将输入、输出、工具调用和推理结果统一为带有 `type` 的 Item，适合需要工具、多模态输入或更复杂 Agent 流程的应用。OpenAI 官方迁移指南也将 Responses API 定义为 Chat Completions 的演进，并建议新项目优先评估该接口。
+
+## Chat Completions 与 Responses 的简要对比
+
+两种 API 都可以完成普通文本对话，主要区别在于请求和响应的组织方式：
+
+| 对比项   | Chat Completions API             | Responses API                                                          |
+|-------|----------------------------------|------------------------------------------------------------------------|
+| 请求地址  | `/v1/chat/completions`           | `/v1/responses`                                                        |
+| 普通输入  | 使用 `messages` 消息数组               | 使用顶层 `input`，可以是字符串或输入 Item 数组                                         |
+| 指令字段  | 通常放在 `messages` 中，角色为 `system`   | 可以单独使用顶层 `instructions`                                                |
+| 文本输出  | `choices[0].message.content`     | 通常使用 `response.output_text`                                            |
+| 输出结构  | 以 `choices` 为中心                  | 以 `output` Item 数组为中心，可能包含 `message`、`reasoning`、`function_call` 等不同类型 |
+| 工具调用  | 使用 `tool_calls` 和 `role: "tool"` | 使用 `function_call` 和 `function_call_output` Item，并通过 `call_id` 关联      |
+| 多轮上下文 | 客户端保存并重新传入 `messages`            | 可以手动传入历史 Item；`previous_response_id` 是否真正生效取决于服务端实现，当前实测未恢复上下文         |
+
+迁移时不应只替换 URL。除了将 `messages` 改为 `input`，还需要同步调整响应解析、工具调用、结构化输出和流式事件处理逻辑。只读取普通文本时，最常见的变化是：
+
+```text
+choices[0].message.content  →  response.output_text
+```
+
+## 1. 基础信息
+
+### 请求地址
+
+广州入口：
+
+```text
+https://tokenhub.tencentmaas.com/v1/responses
+```
+
+如果 API Key 属于新加坡地域，请使用对应的入口：
+
+```text
+https://tokenhub-intl.tencentmaas.com/v1/responses
+```
+
+API Key、Base URL 和服务地域必须保持一致。鉴权方式与 Chat Completions 相同：
+
+```http
+Authorization: Bearer ${HY3_API_KEY}
+```
+
+### 模型名称
+
+本文示例使用 Hy3 的服务 ID：
+
+```text
+hy3
+```
+
+> 注意：模型广场已明确声明 Hy3 支持 OpenAI Chat Completions、OpenAI Responses 和 Anthropic Messages 协议。
+> 腾讯云“Responses API 兼容模式说明”中的模型列表，描述的是兼容模式当前明确列出的模型，不应替代模型广场中的协议支持声明。
+> 本文以 Hy3 实际接口响应为示例；接入其他模型前，仍建议通过控制台或 `GET /v1/models` 确认模型 ID 和可用协议。
+
+## 2. 第一次调用
+
+Responses API 的最小请求可以使用顶层 `instructions` 指定行为，使用 `input` 提供用户输入：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "instructions": "你是一个有帮助的助手。",
+    "input": "你好",
+    "stream": false
+  }'
+```
+
+### 请求字段
+
+| 字段             | 类型             | 作用                                               |
+|----------------|----------------|--------------------------------------------------|
+| `model`        | string         | 模型或服务 ID，本例为 `hy3`。                              |
+| `instructions` | string 或 array | 对模型行为的高层指令，作用类似 Chat Completions 中的 `system` 消息。 |
+| `input`        | string 或 array | 用户输入，可以是简单文本，也可以是带角色和内容的 Item 数组。                |
+| `stream`       | boolean        | 是否使用流式输出；`false` 返回完整响应，`true` 返回事件流。            |
+
+### 消息角色和指令遵循
+
+`instructions` 用于向模型提供较高层级的行为指导，例如角色、语气、任务目标和回答要求。与直接放在 `input` 中的用户问题相比，它更适合承载稳定的开发者指令。
+
+前面的请求使用了顶层 `instructions`：
+
+```json
+"instructions": "你是一个有帮助的助手。"
+```
+
+如果需要把这类指令与用户输入放在同一个 `input` 数组中，也可以写成消息 Item：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": [
+      {
+        "role": "developer",
+        "content": "你是一个有帮助的助手。"
+      },
+      {
+        "role": "user",
+        "content": "你好"
+      }
+    ],
+    "stream": false
+  }'
+```
+
+对应的响应示例：
+
+```json
+{
+  "id": "30d23e89-48b8-4ea2-8ba3-b52db746d4c8",
+  "object": "response",
+  "created_at": 1784793769,
+  "completed_at": 1784793769,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_20260723160249hg5j7l8n",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "你好！👋 有什么我可以帮你的吗？"
+        }
+      ]
+    }
+  ],
+  "output_text": "你好！👋 有什么我可以帮你的吗？",
+  "usage": {
+    "input_tokens": 22,
+    "output_tokens": 12,
+    "total_tokens": 34
+  },
+  "error": null,
+  "metadata": null,
+  "parallel_tool_calls": null
+}
+```
+
+这里的 `output_text` 是最终文本的快捷读取字段；如果需要处理工具调用或其他输出类型，则应继续检查 `output` 数组中的 Item。
+
+> 注意：`instructions` 仅适用于当前响应生成请求。如果使用 `previous_response_id` 管理对话状态，之前回合中的 `instructions` 不会自动出现在后续上下文中。当前实测未通过该参数恢复上下文，应使用 `input` 数组显式传入历史消息。
+
+## 3. 响应结构
+
+下面是一次真实的 Hy3 Responses API 响应：
+
+```json
+{
+  "id": "6996f62f-a9a1-4c00-86a2-a3d392859da5",
+  "object": "response",
+  "created_at": 1784778399,
+  "completed_at": 1784778399,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_20260723114639qg5i7u8x",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "你好！😊 有什么我可以帮你的吗？"
+        }
+      ]
+    }
+  ],
+  "output_text": "你好！😊 有什么我可以帮你的吗？",
+  "usage": {
+    "input_tokens": 22,
+    "output_tokens": 12,
+    "total_tokens": 34
+  },
+  "error": null,
+  "metadata": null,
+  "instructions": "你是一个有帮助的助手。",
+  "parallel_tool_calls": null
+}
+```
+
+### 常用响应字段
+
+| 字段                        | 类型            | 作用                                                  |
+|---------------------------|---------------|-----------------------------------------------------|
+| `id`                      | string        | 本次响应的唯一标识，可用于日志和问题排查。                               |
+| `object`                  | string        | 响应对象类型，本例为 `response`。                              |
+| `status`                  | string        | 响应状态，本例为 `completed`。                               |
+| `output`                  | array         | 输出 Item 数组。除普通消息外，还可能包含推理或工具调用 Item。                |
+| `output[].type`           | string        | Item 类型，例如 `message`、`reasoning` 或 `function_call`。 |
+| `output[].content`        | array         | 消息内容数组，本例中的内容类型为 `output_text`。                     |
+| `output[].content[].text` | string        | 当前文本内容。                                             |
+| `output_text`             | string        | SDK 或服务提供的文本快捷字段，适合只需要最终文本的场景。                      |
+| `usage`                   | object        | Token 使用统计。                                         |
+| `usage.input_tokens`      | integer       | 输入消耗的 Token 数量。                                     |
+| `usage.output_tokens`     | integer       | 输出消耗的 Token 数量。                                     |
+| `usage.total_tokens`      | integer       | 输入和输出消耗的 Token 总数。                                  |
+| `error`                   | object 或 null | 请求失败时的错误信息；成功时通常为 `null`。                           |
+
+如果应用只需要最终文本，优先读取：
+
+```text
+response.output_text
+```
+
+如果需要处理工具调用、推理结果或多模态内容，则应遍历 `response.output`，并根据每个 Item 的 `type` 分别处理。不能假设 `output` 中的每个元素都是普通消息。
+
+## 4. Python OpenAI SDK
+
+安装 SDK：
+
+```bash
+pip install -U openai
+```
+
+调用示例：
+
+```python
+import os
+
+from openai import OpenAI
+
+
+client = OpenAI(
+    api_key=os.environ["HY3_API_KEY"],
+    base_url=os.getenv(
+        "HY3_BASE_URL",
+        "https://tokenhub.tencentmaas.com/v1",
+    ),
+)
+
+response = client.responses.create(
+    model="hy3",
+    instructions="你是一个有帮助的助手。",
+    input="你好，请简单介绍一下 Hy3。",
+)
+
+print(response.output_text)
+```
+
+如果使用新加坡地域，可以设置：
+
+```bash
+export HY3_BASE_URL="https://tokenhub-intl.tencentmaas.com/v1"
+```
+
+## 5. 多轮对话的基本思路
+
+### 手动传入历史消息
+
+在 TokenHub Responses API 兼容模式下，多轮对话需要由客户端保存历史，并在下一次请求中通过 `input` 数组完整传入。数组中的消息应按照实际对话顺序排列。
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "instructions": "你是一个有帮助的助手。",
+    "input": [
+      {
+        "role": "user",
+        "content": "你好，我是小明。"
+      },
+      {
+        "role": "assistant",
+        "content": "小明你好，有什么可以帮你的么。"
+      },
+      {
+        "role": "user",
+        "content": "我叫什么？"
+      }
+    ],
+    "stream": false
+  }'
+```
+
+对应的响应核心文本是：
+
+```text
+你刚才告诉我，你叫**小明**。😊
+```
+
+请求中的条目类型可参考[Responses API 兼容模式说明](https://cloud.tencent.com/document/product/1823/133813#f4b14c90-1272-4b14-9658-c69c7414bbfa)：
+
+| 条目类型      | `type` 取值                 | 说明                                                       |
+|-----------|---------------------------|----------------------------------------------------------|
+| 消息        | `message`                 | 标准消息条目，可使用 `user`、`assistant`、`system` 或 `developer` 角色。 |
+| 函数调用      | `function_call`           | 表示模型发起的函数调用。                                             |
+| 函数调用结果    | `function_call_output`    | 表示工具执行后返回的结果。                                            |
+| 推理        | `reasoning`               | 表示上一轮响应中的推理条目。                                           |
+| 自定义工具调用   | `custom_tool_call`        | 自定义工具调用条目，处理方式与 `function_call` 类似。                      |
+| 自定义工具调用结果 | `custom_tool_call_output` | 自定义工具调用的执行结果，处理方式与 `function_call_output` 类似。            |
+
+以上类型为兼容模式文档列出的常见条目。其他能力（例如计算机操作工具）是否可用，取决于模型和服务端配置，应以官方文档及实际响应为准。
+
+### `previous_response_id` 的实际行为
+
+先发起第一轮请求：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "你好，我是小明",
+    "stream": false
+  }'
+```
+
+第一轮响应的 `id` 为 `b5230f8f-f679-4a48-8e17-034a04785a1d`，响应内容如下：
+
+```json
+{
+  "id": "b5230f8f-f679-4a48-8e17-034a04785a1d",
+  "object": "response",
+  "created_at": 1784797027,
+  "completed_at": 1784797028,
+  "model": "hy3",
+  "status": "completed",
+  "output_text": "你好呀，小明！很高兴认识你 😊 有什么我可以帮你的吗？",
+  "usage": {
+    "input_tokens": 19,
+    "output_tokens": 18,
+    "total_tokens": 37
+  }
+}
+```
+
+将第一轮响应的 `id` 作为 `previous_response_id`，发起第二轮请求：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "我叫什么？",
+    "previous_response_id": "b5230f8f-f679-4a48-8e17-034a04785a1d",
+    "stream": false
+  }'
+```
+
+第二轮响应仍然未能识别第一轮中的“小明”：
+
+```json
+{
+  "id": "37d467fc-4682-47d2-909c-d4291c4027f8",
+  "object": "response",
+  "created_at": 1784797050,
+  "completed_at": 1784797051,
+  "model": "hy3",
+  "status": "completed",
+  "output_text": "哈哈，你还没告诉过我你的名字呢～ 要不现在告诉我？😊",
+  "usage": {
+    "input_tokens": 18,
+    "output_tokens": 19,
+    "total_tokens": 37
+  }
+}
+```
+
+该结果表明：当前接口可以接受 `previous_response_id` 字段，但本次调用未通过该字段恢复第一轮上下文。字段名本身没有问题，问题在于当前服务路径下的状态续接能力尚未生效。因此，多轮对话应通过 `input` 数组显式传入完整历史消息，并以实际响应验证服务端是否支持其他状态管理参数。
+
+## 6. 思考模式
+
+Responses API 与 Chat Completions API 的思考参数写法不同：
+
+- Chat Completions API 使用 `thinking`，例如 `{"thinking": {"type": "enabled"}}`。
+- Responses API 使用 `reasoning.effort`，例如 `{"reasoning": {"effort": "high"}}`。
+
+因此，下面这种写法属于 Chat Completions 风格，不能作为 Responses API 开启思考模式的依据：
+
+```json
+"thinking": {"type": "enabled"}
+```
+
+Responses API 可以使用以下请求测试推理能力：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "请计算 37 × 24，并用一句话说明结果。",
+    "reasoning": {
+      "effort": "high"
+    },
+    "stream": false
+  }'
+```
+
+实际响应如下。为避免在介绍文档中直接展示模型的完整内部推理文本，下面仅保留 `reasoning` 条目的结构，并对摘要内容进行省略：
+
+```json
+{
+  "id": "e537ec27-d4f5-48c0-874d-51e3ed60d38b",
+  "object": "response",
+  "created_at": 1784800455,
+  "completed_at": 1784800472,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "reasoning",
+      "id": "rs_20260723175432n5s7v8xb",
+      "status": "completed",
+      "summary": [
+        {
+          "type": "summary_text",
+          "text": "（推理摘要内容已省略）"
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "id": "msg_20260723175432zxkzd0f3",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "37 × 24 的计算过程为 37 × (20 + 4) = 740 + 148 = 888。\n\n37与24相乘的最终结果为888。"
+        }
+      ]
+    }
+  ],
+  "output_text": "37 × 24 的计算过程为 37 × (20 + 4) = 740 + 148 = 888。\n\n37与24相乘的最终结果为888。",
+  "usage": {
+    "input_tokens": 24,
+    "output_tokens": 1083,
+    "total_tokens": 1107,
+    "output_tokens_details": {
+      "reasoning_tokens": 1045
+    }
+  },
+  "error": null,
+  "metadata": null,
+  "parallel_tool_calls": null,
+  "reasoning": {}
+}
+```
+
+从该响应可以确认思考模式已经生效：
+
+- `output` 中包含一个 `type: "reasoning"` 的推理条目。
+- `output` 中还包含最终的 `message` 条目，应用通常从 `output_text` 读取最终文本。
+- `usage.output_tokens_details.reasoning_tokens` 为 `1045`，表示本次响应使用了推理 Token。
+- `output_tokens` 包含推理 Token 和最终回答 Token，因此总 Token 消耗为 `1107`。
+
+`reasoning.effort` 用于设置推理投入程度，具体可用取值应以模型和 TokenHub 服务支持为准。关闭推理时，兼容模式文档示例使用 `none` 或 `no_think`：
+
+```json
+"reasoning": {"effort": "none"}
+```
+
+开启思考模式并不代表服务会返回完整的原始思维链。应用通常应读取 `output_text`；如果服务返回 `reasoning` 输出条目或 `usage.output_tokens_details.reasoning_tokens`，可以据此判断响应中是否包含推理相关信息，但不应默认展示模型的内部推理过程。
+
+> 注意：如果请求携带 `thinking` 后仍然返回正常结果，不能据此证明思考模式已经开启；该字段可能被服务接受但忽略。应优先使用 `reasoning.effort`，并结合实际 `output` 和 `usage` 响应验证。
+
+## 7. 工具调用
+
+Responses API 的工具调用通常分为四个阶段：声明工具、解析模型返回的工具调用、在应用侧执行工具，以及将执行结果回传给模型。模型只负责决定是否调用工具并生成参数，实际的 `get_weather` 函数需要由应用程序自行实现。
+
+与 Chat Completions API 相比，Responses API 的函数工具定义采用扁平结构：`type`、`name`、`description` 和 `parameters` 直接位于工具对象中，不再嵌套在 `function` 字段下。
+
+### 7.1 声明工具并发起请求
+
+下面的请求声明了一个 `get_weather` 函数，并允许模型自动决定是否调用该函数：
+```shell
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "深圳今天天气怎么样？",
+    "tools": [
+      {
+        "type": "function",
+        "name": "get_weather",
+        "description": "获取指定城市的当前天气信息",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "城市名称，例如：深圳"
+            }
+          },
+          "required": ["city"],
+          "additionalProperties": false
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+其中：
+
+- `tools` 是工具列表。每个工具的 `type` 为 `function`，`name` 是函数名，`description` 用于说明函数用途，`parameters` 使用 JSON Schema 描述函数参数。
+- `parameters.type` 为 `object`，表示函数参数是一个 JSON 对象。
+- `properties` 定义可用参数。示例中的 `city` 类型为 `string`，表示城市名称是字符串。
+- `required` 指定必填参数。示例中 `city` 必须由模型提供。
+- `additionalProperties: false` 表示参数对象不应包含 Schema 未声明的其他字段，有助于限制参数格式。
+- `tool_choice: "auto"` 表示由模型自动判断是否调用工具。
+
+### 7.2 解析模型返回的工具调用
+
+本次请求的实际响应如下：
+```json
+{
+  "id": "52eaea93-d218-4b7f-bb57-2dd80f63f363",
+  "object": "response",
+  "created_at": 1784801451,
+  "completed_at": 1784801452,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "function_call",
+      "id": "fc_20260723181052fzd0f2g4",
+      "status": "completed",
+      "name": "get_weather",
+      "call_id": "chatcmpl-tool-7c18a1a4196244d281a75040577e0583",
+      "arguments": "{\"city\": \"深圳\"}"
+    }
+  ],
+  "usage": {
+    "input_tokens": 213,
+    "output_tokens": 20,
+    "total_tokens": 233,
+    "tool_usage": {
+      "function_call": 1
+    }
+  },
+  "error": null,
+  "metadata": null,
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "获取指定城市的当前天气信息",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "description": "城市名称，例如：深圳"
+          }
+        },
+        "required": ["city"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "parallel_tool_calls": null,
+  "tool_choice": "auto"
+}
+```
+
+当 `output` 中出现 `type: "function_call"` 时，应用应读取以下字段：
+
+- `name`：需要调用的函数名，本例为 `get_weather`。
+- `arguments`：函数参数。该字段是 JSON 字符串，应用需要先解析，再传递给实际函数。
+- `call_id`：本次工具调用的关联 ID。回传工具结果时，`function_call_output.call_id` 必须与它完全一致。
+- `id`：工具调用输出项自身的 ID，用于标识该输出项。
+
+### 7.3 执行工具并回传结果
+
+应用解析 `arguments` 后调用本地的 `get_weather` 函数。假设函数返回深圳天气为晴天、气温为 28℃，则将结果作为 `function_call_output` 回传。工具结果由应用生成，下面的 JSON 仅表示回传格式：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": [
+      {
+        "role": "user",
+        "content": "深圳今天天气怎么样？"
+      },
+      {
+        "type": "function_call",
+        "id": "fc_20260723181052fzd0f2g4",
+        "status": "completed",
+        "name": "get_weather",
+        "call_id": "chatcmpl-tool-7c18a1a4196244d281a75040577e0583",
+        "arguments": "{\"city\":\"深圳\"}"
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "chatcmpl-tool-7c18a1a4196244d281a75040577e0583",
+        "output": "{\"city\":\"深圳\",\"weather\":\"晴\",\"temperature\":28}"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "name": "get_weather",
+        "description": "获取指定城市的当前天气信息",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "城市名称，例如：深圳"
+            }
+          },
+          "required": ["city"],
+          "additionalProperties": false
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+回传时需要注意：
+
+- `function_call` 条目应保留在 `input` 中，以便模型了解之前发起的工具调用。
+- `function_call_output.call_id` 必须对应第一轮响应中的 `call_id`，不能使用 `id` 替代。
+- `function_call_output.output` 通常应传入 JSON 字符串，其中可以包含工具执行结果，也可以包含错误信息。
+- 第二次请求仍需提供 `tools` 定义，以便模型继续处理工具结果。
+
+### 7.4 读取最终回答
+
+回传工具结果后，接口会返回最终回答。本次调用的实际响应如下：
+```json
+{
+  "id": "256f0a6d-9848-4ebb-9b1d-82d8056448cc",
+  "object": "response",
+  "created_at": 1784801741,
+  "completed_at": 1784801742,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_20260723181542q4u7wjym",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "深圳今天的天气是**晴天**，当前气温为 **28℃**。"
+        }
+      ]
+    }
+  ],
+  "output_text": "深圳今天的天气是**晴天**，当前气温为 **28℃**。",
+  "usage": {
+    "input_tokens": 256,
+    "output_tokens": 15,
+    "total_tokens": 271
+  },
+  "error": null,
+  "metadata": null,
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "获取指定城市的当前天气信息",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "description": "城市名称，例如：深圳"
+          }
+        },
+        "required": ["city"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "parallel_tool_calls": null,
+  "tool_choice": "auto"
+}
+```
+
+应用通常直接读取 `output_text` 获取最终文本；如果响应中仍然返回 `function_call`，则应继续执行对应工具并重复回传步骤，直到获得 `message` 类型的最终回答。一次响应也可能包含多个工具调用，此时应分别执行这些调用，并将每个结果都作为对应的 `function_call_output` 回传。
+
+本文仅展示 `function` 类型工具。文件搜索、网络搜索等其他工具是否可用，取决于模型和服务端的实际支持情况，使用前应参考模型广场、接口文档及实际响应。
+
+## 8. 流式输出
+
+将请求体中的 `stream` 设置为 `true`，即可通过 Server-Sent Events（SSE）接收流式响应。与非流式请求一次返回完整 JSON 不同，流式响应会将生成过程拆分为多个事件逐步发送。
+
+```bash
+curl -N -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "instructions": "你是一个有帮助的助手。",
+    "input": "你好",
+    "stream": true
+  }'
+```
+
+响应示例：
+
+本次请求的实际响应如下：
+
+```text
+event: response.created
+data: {"type":"response.created","response":{"id":"e8c19a9b-3ac4-466a-8e42-2f186a745f54","object":"response","created_at":1784798756,"model":"hy3","status":"in_progress","output":null,"error":null,"metadata":null,"parallel_tool_calls":null}}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"e8c19a9b-3ac4-466a-8e42-2f186a745f54","object":"response","created_at":1784798756,"model":"hy3","status":"in_progress","output":null,"error":null,"metadata":null,"parallel_tool_calls":null}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_20260723172557g2xi5pb3","status":"in_progress","role":"assistant","content":[]}}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"part":{"type":"output_text"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"你好"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"！"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"👋 "}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"有什么我可以"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"帮你的"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"delta":"吗？"}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"text":"你好！👋 有什么我可以帮你的吗？"}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","output_index":0,"item_id":"msg_20260723172557g2xi5pb3","content_index":0,"part":{"type":"output_text","text":"你好！👋 有什么我可以帮你的吗？"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_20260723172557g2xi5pb3","status":"completed","role":"assistant","content":[{"type":"output_text","text":"你好！👋 有什么我可以帮你的吗？"}]}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"e8c19a9b-3ac4-466a-8e42-2f186a745f54","object":"response","created_at":1784798756,"completed_at":1784798757,"model":"hy3","status":"completed","output":[{"type":"message","id":"msg_20260723172557g2xi5pb3","status":"completed","role":"assistant","content":[{"type":"output_text","text":"你好！👋 有什么我可以帮你的吗？"}]}],"usage":{"input_tokens":22,"output_tokens":12,"total_tokens":34},"error":null,"metadata":null,"instructions":"你是一个有帮助的助手。","parallel_tool_calls":null}}
+```
+
+每个事件通常由两行组成：
+
+```text
+event: <事件名称>
+data: <JSON 数据>
+```
+
+常用事件如下：
+
+| 事件                           | 作用                               |
+|------------------------------|----------------------------------|
+| `response.created`           | 创建响应对象，返回响应 ID。                  |
+| `response.in_progress`       | 表示响应正在生成。                        |
+| `response.output_item.added` | 新增一个输出 Item，例如 assistant 消息。     |
+| `response.output_text.delta` | 返回一段增量文本，应按顺序拼接 `delta`。         |
+| `response.output_text.done`  | 当前文本输出完成，并提供完整文本。                |
+| `response.output_item.done`  | 当前输出 Item 完成。                    |
+| `response.completed`         | 整个响应完成；通常可以在该事件中读取完整响应和 `usage`。 |
+
+需要注意：并不是每个事件都包含 `delta`，解析器应先判断事件类型，再读取对应字段。Responses API 的流式响应以事件类型区分状态和内容，不应直接复用 Chat Completions 的 chunk 解析逻辑。当前 Hy3 实际返回的完整事件序列可参考[Responses API 兼容模式说明](https://cloud.tencent.com/document/product/1823/133813#9c486a9a-fbf7-4a2a-ad58-866483d605d7)。
+
+## 9. 结构化输出
+
+结构化输出用于要求模型按照指定的 JSON Schema 返回结果，适合人物信息抽取、分类、实体识别等场景。它约束的是模型最终生成的文本格式，不等同于工具调用：模型不会执行函数，而是直接生成符合 Schema 的 JSON 文本。
+
+### 9.1 请求示例
+
+下面的请求要求模型从文本中提取人物信息，并按照 `person_info` Schema 返回 JSON：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "提取以下文本中的人物信息：张三，男，25岁，北京人。",
+    "text": {
+      "format": {
+        "type": "json_schema",
+        "name": "person_info",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "gender": {"type": "string"},
+            "age": {"type": "number"},
+            "city": {"type": "string"}
+          },
+          "required": ["name", "gender", "age", "city"],
+          "additionalProperties": false
+        },
+        "strict": true
+      }
+    }
+  }'
+```
+
+请求中的关键字段如下：
+
+- `text`：Responses API 的文本输出配置对象。
+- `text.format`：指定文本输出格式。
+- `text.format.type`：设置为 `json_schema`，表示使用 JSON Schema 约束输出。
+- `text.format.name`：Schema 名称，本例为 `person_info`，用于标识该输出结构。
+- `text.format.schema`：具体的 JSON Schema，描述输出对象的字段、类型和必填项。
+- `properties`：声明允许返回的字段。本例包含 `name`、`gender`、`age` 和 `city`。
+- `required`：声明必填字段，模型应返回数组中的全部字段。
+- `additionalProperties: false`：不允许返回 Schema 中未声明的字段。
+- `strict: true`：要求服务严格按照 Schema 生成结构化结果；实际可用性仍应以模型和服务端支持情况为准。
+
+### 9.2 实际响应
+
+本次请求的实际响应如下：
+
+```json
+{
+  "id": "a96b126e-9ab0-4081-a05e-9ecb2d952876",
+  "object": "response",
+  "created_at": 1784802698,
+  "completed_at": 1784802699,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_20260723183139eocqe2g4",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "{\"age\": 25, \"city\": \"北京\", \"gender\": \"男\", \"name\": \"张三\"}"
+        }
+      ]
+    }
+  ],
+  "output_text": "{\"age\": 25, \"city\": \"北京\", \"gender\": \"男\", \"name\": \"张三\"}",
+  "usage": {
+    "input_tokens": 31,
+    "output_tokens": 25,
+    "total_tokens": 56
+  },
+  "error": null,
+  "metadata": null,
+  "parallel_tool_calls": null,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "person_info",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "age": {
+            "type": "number"
+          },
+          "city": {
+            "type": "string"
+          },
+          "gender": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "gender",
+          "age",
+          "city"
+        ],
+        "type": "object"
+      },
+      "strict": true
+    }
+  }
+}
+```
+
+响应中的 `output` 仍然是 Responses API 的标准输出 Item 数组，文本内容位于 `output[0].content[0].text`。为了方便只读取最终文本，也可以使用 `output_text`。这两个字段的值都是字符串，字符串内容本身是符合 Schema 的 JSON，因此应用通常需要再进行一次 JSON 解析：
+
+```python
+import json
+
+person = json.loads(response.output_text)
+print(person["name"])
+print(person["age"])
+```
+
+解析后得到的对象类似于：
+
+```json
+{
+  "age": 25,
+  "city": "北京",
+  "gender": "男",
+  "name": "张三"
+}
+```
+
+需要注意，`output_text` 不是已经解析好的 Python 字典或 JavaScript 对象，而是包含 JSON 文本的字符串。生产环境中应在解析前处理请求失败、响应为空和 JSON 格式异常等情况。
+
+## 10. 请求参数
+
+Responses API 的部分请求参数与 Chat Completions API 的含义相近，但字段名称和服务端支持范围可能不同。以下参数适合在确认模型支持后使用：
+
+| 参数                  | 类型                 | 作用                                                                                           |
+|---------------------|--------------------|----------------------------------------------------------------------------------------------|
+| `temperature`       | Float              | 控制输出随机性。数值越低，输出通常越稳定；数值越高，输出通常越灵活。                                                           |
+| `top_p`             | Float              | 控制核采样范围。数值越低，模型考虑的候选词范围通常越小。一般建议优先调整 `temperature` 或 `top_p` 其中一个。                           |
+| `max_output_tokens` | Integer            | 限制模型最多生成的输出 Token 数量。Responses API 通常使用该字段；不要直接将 Chat Completions API 的 `max_tokens` 机械复制过来。 |
+| `stop`              | string 或 string 数组 | 标准 Responses API 中用于指定停止序列；当前 Hy3 Responses API 实测请求可以返回成功，但停止序列未生效，暂不建议依赖该参数。               |
+| `tools`             | array              | 声明模型可以调用的工具，例如 `function` 类型工具。工具调用的完整流程见[工具调用](#7-工具调用)。                                    |
+| `tool_choice`       | string 或 object    | 控制工具调用策略，例如 `auto` 表示由模型自动决定是否调用工具。                                                          |
+| `reasoning`         | object             | 配置 Responses API 的推理能力，例如 `{"effort": "high"}`；是否可用取决于模型和服务端。                                |
+| `stream`            | boolean            | 是否以 SSE 事件流返回结果。`false` 返回完整响应，`true` 返回流式事件。                                                |
+
+参数的具体取值范围、默认值和模型限制，应以 [TokenHub Responses API 兼容模式说明](https://cloud.tencent.com/document/product/1823/133813) 及 Hy3 实际接口响应为准。不同模型可能只支持其中一部分参数；即使服务端接受某个字段，也不代表该字段一定会对模型输出产生效果。
+
+### `stop` 参数的实际行为
+
+TokenHub Responses API 兼容模式的参数列表未将 `stop` 列为完全支持的参数。对 Hy3 发起以下测试请求时，接口返回 HTTP `200 OK`，但响应文本仍然包含停止序列 `STOP`：
+
+```bash
+curl -i -X POST "https://tokenhub.tencentmaas.com/v1/responses" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "input": "请输出以下内容，并在最后单独输出 STOP：第一行，第二行。",
+    "stop": ["STOP"],
+    "stream": false
+  }'
+```
+
+实际响应的核心内容如下：
+
+```json
+{
+  "id": "e1ef88df-07b4-4a78-bd42-24b9d5cf7474",
+  "object": "response",
+  "created_at": 1784806181,
+  "completed_at": 1784806182,
+  "model": "hy3",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_20260723192942i9xctap5",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "第一行\n第二行\nSTOP"
+        }
+      ]
+    }
+  ],
+  "output_text": "第一行\n第二行\nSTOP",
+  "usage": {
+    "input_tokens": 30,
+    "output_tokens": 7,
+    "total_tokens": 37
+  },
+  "error": null,
+  "metadata": null,
+  "parallel_tool_calls": null
+}
+```
+
+该结果表明：当前服务接受了 `stop` 字段，但没有按照预期截断输出。
+应用不应依赖 Responses API 中的 `stop` 实现停止生成；如果必须控制输出结构，可以优先使用结构化输出，或在客户端收到完整响应后自行清理指定标记。
+该行为可能随模型或服务端版本变化，使用其他模型时应重新验证。
+
+## 11. 常见错误
+
+Responses API 和 Chat Completions API 通常使用相同的错误对象结构。请求失败时，应优先读取 `error.code`、`error.type`、`error.message_zh` 和 `error.request_id`，再根据 HTTP 状态码决定是修改请求、等待重试还是联系服务方排查。
+
+### 错误响应结构
+
+```json
+{
+  "error": {
+    "message": "<英文错误描述>",
+    "message_zh": "<中文错误描述>",
+    "code": "<业务错误码>",
+    "type": "<错误类型>",
+    "source": "client | gateway | upstream",
+    "upstream_code": "<上游错误码，仅上游错误时返回>",
+    "upstream_status": 502,
+    "request_id": "<请求唯一标识>"
+  }
+}
+```
+
+常见字段说明：
+
+| 字段                 | 类型               | 作用                                       |
+|--------------------|------------------|------------------------------------------|
+| `error.type`       | string           | 错误类别，例如参数错误或限流错误。                        |
+| `error.code`       | string 或 integer | TokenHub 业务错误码，用于进一步定位问题。                |
+| `error.message`    | string           | 英文错误描述，适合写入日志。                           |
+| `error.message_zh` | string           | 中文错误描述，适合展示给中文用户。                        |
+| `error.source`     | string           | 错误来源，例如 `client`、`gateway` 或 `upstream`。 |
+| `error.request_id` | string           | 本次请求的唯一标识。提交工单或反馈问题时应一并提供。               |
+
+### 模型服务繁忙或达到容量上限
+
+当模型服务繁忙或达到服务容量上限时，接口可能返回 HTTP `429` 和业务错误码 `429006`。实际响应示例如下：
+
+```json
+{
+  "error": {
+    "type": "rate_limit_error",
+    "code": "429006",
+    "message": "The model service is currently busy or has reached its serving capacity limit. Please reduce the request frequency and try again later.",
+    "message_zh": "当前模型服务繁忙或已达服务容量上限，请降低请求频率后稍后重试。",
+    "source": "gateway",
+    "request_id": "57b8d6ff-03dd-45a0-8d8e-5eebba3e0470"
+  }
+}
+```
+
+该错误通常不表示请求 JSON 格式错误，修改 `input` 或 `text.format` 一般不能直接解决服务容量不足问题。可以先降低请求频率或并发量，等待一段时间后重试；如果服务返回 `Retry-After` 响应头，应优先按照该值等待。持续失败时，应记录 `request_id`、请求时间和模型名称，并联系服务方排查。
+
+更多错误码、HTTP 状态码和处理建议，请参考腾讯云官方文档：[TokenHub API 错误码说明](https://cloud.tencent.com/document/product/1823/131595)。
+
+## 12. 注意事项
+
+- Responses API 的工具调用、结构化输出和流式响应字段与 Chat Completions 不完全相同，不能直接复用原有解析器。
+- 如果只处理普通文本，可以使用 `response.output_text`；如果需要工具或推理能力，应遍历 `response.output`。
+- 不要把 API Key 写入 Python 文件、Shell 脚本或 Markdown 示例，也不要提交 `.env` 文件。
+- Hy3 托管 API 的具体参数和能力以模型广场、TokenHub 文档和实际接口响应为准。
+
+参考文档：
+
+- [TokenHub Responses API 兼容模式说明](https://cloud.tencent.com/document/product/1823/133813#9c713665-4bc2-47e5-9cf4-6e77ab45ea45)
+- [TokenHub 语言模型调用概览](https://cloud.tencent.com/document/product/1823/130079)
+- [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)

--- a/examples/01_basic_chat.md
+++ b/examples/01_basic_chat.md
@@ -1,0 +1,21 @@
+# 01 Basic chat
+
+Run a minimal Chat Completions request.
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+The script sends `model`, `messages`, and `stream: false`, then reads `response.choices[0].message.content`.
+
+## Output example
+
+Observed output from one run:
+
+```text
+你好！我是你的智能助手，可以帮你解答各类问题、提供信息查询、协助写作、整理资料、聊天交流等。无论是学习、工作还是生活里的小疑问，都可以随时跟我说～ 你有什么需要帮忙的吗？
+```
+
+English translation: “Hello! I am your intelligent assistant. I can answer questions, provide information, help with writing and organizing materials, and chat with you.”
+
+Output wording may vary by model version and sampling.

--- a/examples/01_basic_chat.py
+++ b/examples/01_basic_chat.py
@@ -1,0 +1,33 @@
+"""Run a minimal Hy3 Chat Completions request with the OpenAI SDK."""
+
+import os
+
+from openai import OpenAI
+
+
+def main():
+    # Create an OpenAI-compatible client for TokenHub.
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+
+    # Send a non-streaming Chat Completions request.
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=[
+            {"role": "system", "content": "你是一个有帮助的助手。"},
+            {"role": "user", "content": "你好，请简单介绍一下你自己。"},
+        ],
+        stream=False,
+    )
+
+    # Read the assistant text from the first choice.
+    print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/01_basic_chat_cn.md
+++ b/examples/01_basic_chat_cn.md
@@ -1,0 +1,21 @@
+# 01 基础对话
+
+使用 Chat Completions API 完成一次最小文本调用。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+## 请求和解析
+
+脚本通过 `client.chat.completions.create()` 发送 `model`、`messages` 和 `stream: false`，并从 `response.choices[0].message.content` 读取模型回复。
+
+## 输出示例
+
+```text
+你好！我是你的智能助手，可以帮你解答各类问题、提供信息查询、协助写作、整理资料、聊天交流等。无论是学习、工作还是生活里的小疑问，都可以随时跟我说～ 你有什么需要帮忙的吗？
+```
+
+具体措辞会因模型版本和采样结果变化。

--- a/examples/02_streaming.md
+++ b/examples/02_streaming.md
@@ -1,0 +1,21 @@
+# 02 Streaming
+
+Read Chat Completions chunks incrementally and print the final usage.
+
+```bash
+uv run --env-file .env python examples/02_streaming.py
+```
+
+The script checks `chunk.choices` before reading `delta.content`. With `stream_options.include_usage: true`, the final usage chunk may have an empty `choices` array.
+
+## Output example
+
+Observed output from one run:
+
+```text
+深圳是中国南部海滨的现代化大都市，也是改革开放后迅速崛起的经济特区和创新之都。
+
+usage: CompletionUsage(completion_tokens=62, prompt_tokens=21, total_tokens=83, ...)
+```
+
+English translation: “Shenzhen is a modern coastal metropolis in southern China, a special economic zone, and a center of innovation.” The usage details depend on the response.

--- a/examples/02_streaming.py
+++ b/examples/02_streaming.py
@@ -1,0 +1,39 @@
+"""Stream a Chat Completions response and print usage."""
+
+import os
+
+from openai import OpenAI
+
+
+def main():
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+
+    # Request an SSE stream and ask for usage in the final chunk.
+    stream = client.chat.completions.create(
+        model="hy3",
+        messages=[{"role": "user", "content": "请用三句话介绍深圳。"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    # Concatenate text deltas as chunks arrive.
+    for chunk in stream:
+        if chunk.choices:
+            delta = chunk.choices[0].delta
+            if delta.content:
+                print(delta.content, end="", flush=True)
+
+        # With include_usage enabled, the last chunk may have no choices
+        # but can still contain complete usage statistics.
+        if chunk.usage:
+            print(f"\n\nusage: {chunk.usage}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_streaming_cn.md
+++ b/examples/02_streaming_cn.md
@@ -1,0 +1,25 @@
+# 02 流式输出
+
+使用 Chat Completions API 逐个读取流式 chunk，并在最后读取 usage。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/02_streaming.py
+```
+
+## 请求和解析
+
+请求设置 `stream: true` 和 `stream_options.include_usage: true`。
+
+脚本检查 `chunk.choices` 是否为空，再读取 `chunk.choices[0].delta.content`；最后一个 usage chunk 可能没有 choices，但会包含 `chunk.usage`。
+
+## 输出示例
+
+```text
+深圳是中国南部海滨的现代化大都市，也是改革开放后迅速崛起的经济特区和创新之都。这里拥有华为、腾讯等科技巨头，以及完善的产业链，被誉为“中国硅谷”。作为移民城市和粤港澳大湾区核心引擎，深圳以高效、年轻和包容的姿态持续吸引着全球人才与资本。
+
+usage: CompletionUsage(completion_tokens=62, prompt_tokens=21, total_tokens=83, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=0, rejected_prediction_tokens=None), prompt_tokens_details=PromptTokensDetails(audio_tokens=None, cache_write_tokens=None, cached_tokens=0))
+```
+
+流式文本会随着事件到达逐步打印，完整输出和 Token 统计可能不同。

--- a/examples/03_streaming_vs_non_streaming.md
+++ b/examples/03_streaming_vs_non_streaming.md
@@ -1,0 +1,21 @@
+# 03 Streaming versus non-streaming
+
+Compare first-chunk latency and total response time.
+
+```bash
+uv run --env-file .env python examples/03_streaming_vs_non_streaming.py
+```
+
+The same prompt is sent with `stream: false` and `stream: true`. The script reads the complete response in the first case and concatenates `delta.content` in the second case. Timing depends on network conditions, service load, and output length.
+
+## Output example
+
+```text
+non-streaming total: 2.351s
+streaming first chunk: 0.830s
+streaming total: 1.859s
+streaming text: 深圳是中国南方毗邻香港的经济特区和超大城市……
+non-streaming text: 深圳是中国南部海滨的现代化大都市……
+```
+
+The Chinese text describes Shenzhen as a modern city and technology center. Timing and wording are samples from one run, not fixed guarantees.

--- a/examples/03_streaming_vs_non_streaming.py
+++ b/examples/03_streaming_vs_non_streaming.py
@@ -1,0 +1,55 @@
+"""Compare Chat Completions streaming and non-streaming latency."""
+
+import os
+import time
+
+from openai import OpenAI
+
+
+def create_client() -> OpenAI:
+    return OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+
+
+def main():
+    client = create_client()
+    messages = [{"role": "user", "content": "请用三句话介绍深圳。"}]
+
+    # Measure the complete non-streaming response time.
+    start = time.perf_counter()
+    response = client.chat.completions.create(
+        model="hy3",
+        messages=messages,
+        stream=False,
+    )
+    non_streaming_total = time.perf_counter() - start
+
+    # Measure both first-chunk latency and total streaming time.
+    start = time.perf_counter()
+    first_chunk_time = None
+    chunks = []
+    for chunk in client.chat.completions.create(
+        model="hy3",
+        messages=messages,
+        stream=True,
+    ):
+        if first_chunk_time is None:
+            first_chunk_time = time.perf_counter() - start
+        if chunk.choices and chunk.choices[0].delta.content:
+            chunks.append(chunk.choices[0].delta.content)
+    streaming_total = time.perf_counter() - start
+
+    print(f"non-streaming total: {non_streaming_total:.3f}s")
+    print(f"streaming first chunk: {first_chunk_time:.3f}s")
+    print(f"streaming total: {streaming_total:.3f}s")
+    print(f"streaming text: {''.join(chunks)}")
+    print(f"non-streaming text: {response.choices[0].message.content}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_streaming_vs_non_streaming_cn.md
+++ b/examples/03_streaming_vs_non_streaming_cn.md
@@ -1,0 +1,27 @@
+# 03 流式与非流式对比
+
+对比 Chat Completions API 两种请求方式的首 chunk 延迟和总耗时。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/03_streaming_vs_non_streaming.py
+```
+
+## 请求和解析
+
+脚本使用相同的 `model` 和 `messages` 分别发起 `stream: false` 与 `stream: true` 请求。
+
+非流式请求从 `response.choices[0].message.content` 读取结果；流式请求拼接每个 `delta.content`，并记录第一个 chunk 到达时间和完整响应耗时。
+
+## 输出示例
+
+```text
+non-streaming total: 2.351s
+streaming first chunk: 0.830s
+streaming total: 1.859s
+streaming text: 深圳是中国南方毗邻香港的经济特区和超大城市，以科技创新与金融贸易闻名。这里拥有华为、腾讯等全球领先企业，被誉为“中国硅谷”。作为改革开放的窗口，深圳以高速发展、年轻活力和多元文化成为现代化国际都市的典范。
+non-streaming text: 深圳是中国南部海滨的现代化大都市，也是改革开放后迅速崛起的经济特区和创新之都。这里拥有华为、腾讯等科技巨头，以高新技术、金融和物流产业为核心驱动发展。作为移民城市，深圳包容开放、充满活力，连续多年常住人口年轻化指数居全国前列。
+```
+
+耗时受网络、服务负载和输出长度影响，不能将单次测量结果视为固定性能指标。

--- a/examples/04_tool_calling.md
+++ b/examples/04_tool_calling.md
@@ -1,0 +1,19 @@
+# 04 Tool calling
+
+Complete a function tool call with Chat Completions.
+
+```bash
+uv run --env-file .env python examples/04_tool_calling.py
+```
+
+The script declares `get_weather`, parses `tool_calls`, executes a local demo function, and returns the result as a `role: "tool"` message with the matching `tool_call_id`. It repeats the loop until the model returns final text.
+
+The weather function returns fixed demo data and does not call a real weather service.
+
+## Output example
+
+```text
+深圳今天天气是**晴天**，当前气温为 **28°C**。整体比较温暖舒适，适合外出活动，不过紫外线可能较强，建议做好防晒措施~ ☀️
+```
+
+English translation: “The weather in Shenzhen is sunny today, with a current temperature of 28°C. It is warm and comfortable, but UV levels may be high.”

--- a/examples/04_tool_calling.py
+++ b/examples/04_tool_calling.py
@@ -1,0 +1,86 @@
+"""Complete a function tool call with the Chat Completions API."""
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+
+# Chat Completions uses a nested function definition under each tool.
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "获取指定城市的当前天气信息",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "城市名称，例如：深圳",
+                    }
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def get_weather(city: str) -> dict[str, Any]:
+    """Return demo data; replace this with a real business function in production."""
+    return {"city": city, "weather": "晴", "temperature": 28}
+
+
+def main():
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+    # Keep the conversation history so tool results can be sent back.
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "深圳今天天气怎么样？"}
+    ]
+
+    # A tool workflow may require several model/tool rounds.
+    for _ in range(5):
+        response = client.chat.completions.create(
+            model="hy3",
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+        )
+        message = response.choices[0].message
+        # Preserve the assistant tool-call message in the next request.
+        messages.append(message.model_dump(exclude_none=True))
+
+        if not message.tool_calls:
+            print(message.content)
+            return
+
+        for tool_call in message.tool_calls:
+            if tool_call.function.name != "get_weather":
+                raise ValueError(f"Unsupported tool: {tool_call.function.name}")
+
+            # Parse the JSON-string arguments and execute the local function.
+            arguments = json.loads(tool_call.function.arguments)
+            result = get_weather(arguments["city"])
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": json.dumps(result, ensure_ascii=False),
+                }
+            )
+
+    raise RuntimeError("Maximum tool-call rounds exceeded")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_tool_calling_cn.md
+++ b/examples/04_tool_calling_cn.md
@@ -1,0 +1,25 @@
+# 04 工具调用
+
+使用 Chat Completions API 完成函数工具调用，并将本地函数结果回传给模型。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/04_tool_calling.py
+```
+
+## 请求和解析
+
+第一次请求通过 `tools` 声明 `get_weather`。
+
+如果响应中的 `message.tool_calls` 不为空，脚本解析 `tool_call.function.arguments`，执行本地演示函数，再以 `role: "tool"` 和对应的 `tool_call_id` 回传结果。
+
+脚本会循环处理工具调用，直到模型返回最终文本。
+
+## 输出示例
+
+```text
+深圳今天天气是**晴天**，当前气温为 **28°C**。整体比较温暖舒适，适合外出活动，不过紫外线可能较强，建议做好防晒措施~ ☀️
+```
+
+天气函数返回的是固定演示数据，不会访问真实天气服务。

--- a/examples/05_reasoning_mode.md
+++ b/examples/05_reasoning_mode.md
@@ -1,0 +1,24 @@
+# 05 Reasoning mode
+
+Compare normal and reasoning requests with Chat Completions.
+
+```bash
+uv run --env-file .env python examples/05_reasoning_mode.py
+```
+
+The script sends the same question twice and prints both final answers and the reasoning request's usage. Supported fields and values depend on the model and TokenHub service. Applications should not display private chain-of-thought content.
+
+## Output example
+
+```text
+Normal mode:
+37 × 24 = 888
+
+Reasoning mode:
+37 × 24 = 888
+
+Reasoning usage:
+CompletionUsage(... reasoning_tokens=232 ...)
+```
+
+The actual run returned Chinese explanations for the calculation. The important comparison is the final answer and the reasoning-token usage; private reasoning content should not be displayed by applications.

--- a/examples/05_reasoning_mode.py
+++ b/examples/05_reasoning_mode.py
@@ -1,0 +1,38 @@
+"""Compare normal and reasoning modes for Chat Completions."""
+
+import os
+
+from openai import OpenAI
+
+
+def main():
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+    messages = [{"role": "user", "content": "请计算 37 × 24，并简要说明结果。"}]
+
+    # Compare a normal request with a reasoning-enabled request.
+    normal = client.chat.completions.create(
+        model="hy3",
+        messages=messages,
+    )
+    reasoning = client.chat.completions.create(
+        model="hy3",
+        messages=messages,
+        reasoning_effort="high",
+    )
+
+    print("Normal mode:")
+    print(normal.choices[0].message.content)
+    print("\nReasoning mode:")
+    print(reasoning.choices[0].message.content)
+    print("\nReasoning usage:")
+    print(reasoning.usage)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_reasoning_mode_cn.md
+++ b/examples/05_reasoning_mode_cn.md
@@ -1,0 +1,69 @@
+# 05 思考模式
+
+对比 Chat Completions API 普通模式和推理模式的响应。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/05_reasoning_mode.py
+```
+
+## 请求和解析
+
+脚本使用相同问题分别发起普通请求和带 `reasoning_effort: "high"` 的请求，并从 `message.content` 读取两次结果，再打印推理请求的 `usage`。
+
+## 输出示例
+
+```text
+普通模式：
+我们计算 \( 37 \times 24 \)：
+
+**方法一：直接分解**
+\[
+37 \times 24 = 37 \times (20 + 4) = 37 \times 20 + 37 \times 4
+\]
+\[
+37 \times 20 = 740
+\]
+\[
+37 \times 4 = 148
+\]
+\[
+740 + 148 = 888
+\]
+
+**方法二：列竖式**
+\[
+\begin{array}{c}
+\phantom{0}37\\
+\times\phantom{0}24\\\hline
+\phantom{0}148\ \ (37\times4)\\
++740\ \ (37\times20)\\\hline
+\phantom{0}888
+\end{array}
+\]
+
+**结果：**
+\[
+37 \times 24 = 888
+\]
+
+**简要说明：**  
+37 乘以 24 等于 888，这是一个三位数，计算过程可以通过分配律或竖式完成，结果正确无误。
+
+推理模式：
+计算结果为：**37 × 24 = 888**
+
+**简要说明：**
+可以将 24 拆分为 20 + 4，利用分配律计算：
+- 37 × 20 = 740
+- 37 × 4 = 148
+- 740 + 148 = 888
+
+结果 888 是一个三位数，且三个数位上的数字相同（均为 8）。
+
+推理模式 usage：
+CompletionUsage(completion_tokens=311, prompt_tokens=24, total_tokens=335, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=232, rejected_prediction_tokens=None), prompt_tokens_details=PromptTokensDetails(audio_tokens=None, cache_write_tokens=None, cached_tokens=0))
+```
+
+推理字段和可用取值取决于模型及 TokenHub 服务端支持范围，不应展示模型的内部思维过程。

--- a/examples/06_responses_basic.md
+++ b/examples/06_responses_basic.md
@@ -1,0 +1,17 @@
+# 06 Responses API basic call
+
+Run a minimal Responses API request.
+
+```bash
+uv run --env-file .env python examples/06_responses_basic.py
+```
+
+The script calls `client.responses.create()` and reads the final text from `response.output_text`. Applications that need tools or reasoning should also inspect `response.output`.
+
+## Output example
+
+```text
+我是混元，是由腾讯开发的大模型。我专注于基础信息处理与逻辑响应，支持多模态输入（文本、图片、文件等）……
+```
+
+English translation: “I am Hunyuan, a large model developed by Tencent. I focus on information processing and logical responses, and support multimodal inputs such as text, images, and files.”

--- a/examples/06_responses_basic.py
+++ b/examples/06_responses_basic.py
@@ -1,0 +1,31 @@
+"""Run a minimal Responses API request."""
+
+import os
+
+from openai import OpenAI
+
+
+def main():
+    # Create an OpenAI-compatible client for the Responses endpoint.
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+
+    # Responses API uses top-level instructions and input fields.
+    response = client.responses.create(
+        model="hy3",
+        instructions="你是一个有帮助的助手。",
+        input="你好，请简单介绍一下腾讯混元大模型。",
+        stream=False,
+    )
+
+    # output_text is the convenient field for the final text answer.
+    print(response.output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_responses_basic_cn.md
+++ b/examples/06_responses_basic_cn.md
@@ -1,0 +1,23 @@
+# 06 Responses API 基础调用
+
+使用 Responses API 完成最小文本调用。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/06_responses_basic.py
+```
+
+## 请求和解析
+
+脚本通过 `client.responses.create()` 发送 `model`、`instructions`、`input` 和 `stream: false`，并从 `response.output_text` 读取最终文本。
+
+需要处理工具或推理条目时，应进一步遍历 `response.output`。
+
+## 输出示例
+
+```text
+我是混元，是由腾讯开发的大模型。我专注于基础信息处理与逻辑响应，支持多模态输入（文本、图片、文件等），可以帮你解答问题、创作内容、处理文件、生成代码等。如果你有具体需求，比如写作、分析、翻译等，都可以告诉我~
+```
+
+实际回答会因模型版本和采样结果变化。

--- a/examples/07_responses_streaming.md
+++ b/examples/07_responses_streaming.md
@@ -1,0 +1,19 @@
+# 07 Responses API streaming
+
+Read Responses API SSE events and print text deltas.
+
+```bash
+uv run --env-file .env python examples/07_responses_streaming.py
+```
+
+The script handles `response.output_text.delta`, `response.completed`, and `response.failed`. It parses raw SSE with the Python standard library because the current TokenHub `response.created` event may contain `output: null`, which can break high-level Responses stream parsers in some OpenAI SDK versions.
+
+## Output example
+
+```text
+深圳是中国南部滨海的现代化大都市，也是粤港澳大湾区的核心引擎之一……
+
+usage: {'input_tokens': 21, 'output_tokens': 58, 'total_tokens': 79}
+```
+
+English translation: “Shenzhen is a modern coastal metropolis in southern China and one of the core engines of the Guangdong-Hong Kong-Macao Greater Bay Area.”

--- a/examples/07_responses_streaming.py
+++ b/examples/07_responses_streaming.py
@@ -1,0 +1,93 @@
+"""Stream a Responses API response.
+
+The current TokenHub response.created event may contain output: null,
+which can cause high-level Responses stream parsers in some OpenAI SDK
+versions to fail. This example parses SSE events directly instead.
+"""
+
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def iter_sse_events(response):
+    """Convert an SSE response into (event_type, data) tuples."""
+    event_type = "message"
+    data_lines: list[str] = []
+
+    # SSE records are separated by a blank line.
+    for raw_line in response:
+        line = raw_line.decode("utf-8").rstrip("\r\n")
+
+        if not line:
+            if data_lines:
+                yield event_type, "\n".join(data_lines)
+            event_type = "message"
+            data_lines = []
+        elif line.startswith("event:"):
+            event_type = line.removeprefix("event:").strip()
+        elif line.startswith("data:"):
+            data_lines.append(line.removeprefix("data:").lstrip())
+
+    if data_lines:
+        yield event_type, "\n".join(data_lines)
+
+
+def main():
+    api_key = os.environ["HY3_API_KEY"]
+    base_url = os.getenv(
+        "HY3_BASE_URL",
+        "https://tokenhub.tencentmaas.com/v1",
+    ).rstrip("/")
+    # Build the raw HTTP request because the SDK parser is not compatible
+    # with the current TokenHub response.created output: null payload.
+    request = Request(
+        f"{base_url}/responses",
+        data=json.dumps(
+            {
+                "model": "hy3",
+                "input": "请用三句话介绍深圳。",
+                "stream": True,
+            },
+            ensure_ascii=False,
+        ).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        },
+        method="POST",
+    )
+
+    completed_response: dict[str, Any] | None = None
+
+    try:
+        with urlopen(request, timeout=60) as response:
+            for event_type, raw_data in iter_sse_events(response):
+                if raw_data == "[DONE]":
+                    break
+
+                event = json.loads(raw_data)
+                event_name = event.get("type", event_type)
+
+                # Handle text deltas and the terminal response event.
+                if event_name == "response.output_text.delta":
+                    print(event.get("delta", ""), end="", flush=True)
+                elif event_name == "response.completed":
+                    completed_response = event.get("response")
+                elif event_name == "response.failed":
+                    raise RuntimeError(json.dumps(event, ensure_ascii=False))
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {error_body}") from exc
+
+    if completed_response is not None:
+        print(f"\n\nusage: {completed_response.get('usage')}")
+    else:
+        print("\n\nThe stream ended without a response.completed event.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/07_responses_streaming_cn.md
+++ b/examples/07_responses_streaming_cn.md
@@ -1,0 +1,27 @@
+# 07 Responses API 流式输出
+
+使用 Responses API 接收 SSE 事件并逐步输出文本。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/07_responses_streaming.py
+```
+
+## 请求和解析
+
+请求设置 `stream: true`。脚本直接读取 SSE 的 `event` 和 `data` 行，并处理以下事件：
+
+- `response.output_text.delta`：读取 `delta` 并拼接文本。
+- `response.completed`：读取完整响应和 `usage`。
+- `response.failed`：抛出错误并终止请求。
+
+当前 TokenHub 的 `response.created` 事件可能返回 `output: null`，部分 OpenAI SDK 版本的高层 Responses 流解析器会因此报错，所以该示例使用 Python 标准库解析原始 SSE。
+
+## 输出示例
+
+```text
+深圳是中国南部滨海的现代化大都市，也是粤港澳大湾区的核心引擎之一。它以“改革开放窗口”闻名，从昔日小渔村快速发展为全球科技创新与金融重镇。这里拥有华为、腾讯等顶尖企业，兼具活力多元的城市文化与优美的自然海岸风光。
+
+usage: {'input_tokens': 21, 'output_tokens': 58, 'total_tokens': 79}
+```

--- a/examples/08_responses_tool_calling.md
+++ b/examples/08_responses_tool_calling.md
@@ -1,0 +1,17 @@
+# 08 Responses API tool calling
+
+Complete a function tool call and return a `function_call_output` Item.
+
+```bash
+uv run --env-file .env python examples/08_responses_tool_calling.py
+```
+
+The script finds a `function_call` in `response.output`, parses its JSON-string `arguments`, executes the local demo function, and sends back a `function_call_output` whose `call_id` matches the original call. The final text is read from `response.output_text`.
+
+## Output example
+
+```text
+深圳今天的天气是**晴天**，当前气温为 **28℃**。
+```
+
+English translation: “The weather in Shenzhen is sunny today, with a current temperature of 28°C.” The weather function returns fixed demo data.

--- a/examples/08_responses_tool_calling.py
+++ b/examples/08_responses_tool_calling.py
@@ -1,0 +1,95 @@
+"""Complete a function tool call with the Responses API."""
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+
+# Responses API uses a flat function tool definition.
+TOOLS = [
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "获取指定城市的当前天气信息",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "城市名称，例如：深圳",
+                }
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    }
+]
+
+
+def get_weather(city: str) -> dict[str, Any]:
+    """Return demo data; replace this with a real business function in production."""
+    return {"city": city, "weather": "晴", "temperature": 28}
+
+
+def main() -> None:
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+    user_input = "深圳今天天气怎么样？"
+
+    # First request: let the model decide whether to call the tool.
+    response = client.responses.create(
+        model="hy3",
+        input=user_input,
+        tools=TOOLS,
+        tool_choice="auto",
+    )
+
+    input_items: list[dict[str, Any]] = [
+        {"role": "user", "content": user_input}
+    ]
+    has_tool_call = False
+
+    # Inspect output Items for function_call entries.
+    for item in response.output:
+        item_data = item.model_dump(exclude_none=True)
+        input_items.append(item_data)
+
+        if item_data.get("type") != "function_call":
+            continue
+
+        has_tool_call = True
+        if item_data["name"] != "get_weather":
+            raise ValueError(f"Unsupported tool: {item_data['name']}")
+
+        # The arguments field is a JSON string and must be parsed first.
+        arguments = json.loads(item_data["arguments"])
+        result = get_weather(arguments["city"])
+        input_items.append(
+            {
+                "type": "function_call_output",
+                "call_id": item_data["call_id"],
+                "output": json.dumps(result, ensure_ascii=False),
+            }
+        )
+
+    # Send the function_call_output back to obtain the final answer.
+    if has_tool_call:
+        response = client.responses.create(
+            model="hy3",
+            input=input_items,
+            tools=TOOLS,
+            tool_choice="auto",
+        )
+
+    print(response.output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/08_responses_tool_calling_cn.md
+++ b/examples/08_responses_tool_calling_cn.md
@@ -1,0 +1,35 @@
+# 08 Responses API 工具调用
+
+使用 Responses API 完成函数工具调用，并回传 `function_call_output`。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/08_responses_tool_calling.py
+```
+
+## 请求和解析
+
+第一次请求通过扁平结构的 `tools` 声明 `get_weather`。
+
+脚本遍历 `response.output`，找到 `type: "function_call"` 后解析 `arguments` 并执行本地函数。
+
+第二次请求将原工具调用和工具结果放入 `input`：
+
+```json
+{
+  "type": "function_call_output",
+  "call_id": "与 function_call.call_id 相同",
+  "output": "工具结果 JSON 字符串"
+}
+```
+
+最终从 `response.output_text` 读取模型回答。
+
+## 输出示例
+
+```text
+深圳今天的天气是**晴天**，当前气温为 **28℃**。
+```
+
+天气函数返回的是固定演示数据，不会访问真实天气服务。

--- a/examples/09_responses_structured_output.md
+++ b/examples/09_responses_structured_output.md
@@ -1,0 +1,24 @@
+# 09 Responses API structured output
+
+Constrain the output with JSON Schema and parse the returned JSON string.
+
+```bash
+uv run --env-file .env python examples/09_responses_structured_output.py
+```
+
+The script configures `text.format` with `json_schema`, reads `response.output_text`, and calls `json.loads()` to convert the string into a Python dictionary. Production code should handle empty responses, request failures, and JSON parsing errors.
+
+## Output example
+
+Observed structured output:
+
+```json
+{
+  "age": 25,
+  "city": "北京",
+  "gender": "男",
+  "name": "张三"
+}
+```
+
+English interpretation: `age` is 25, `city` is Beijing, `gender` is male, and `name` is Zhang San. The JSON keys are defined by the schema; values may vary with the input.

--- a/examples/09_responses_structured_output.py
+++ b/examples/09_responses_structured_output.py
@@ -1,0 +1,52 @@
+"""Generate and parse structured output with the Responses API."""
+
+import json
+import os
+
+from openai import OpenAI
+
+
+# JSON Schema that defines the expected response shape.
+PERSON_INFO_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "gender": {"type": "string"},
+        "age": {"type": "number"},
+        "city": {"type": "string"},
+    },
+    "required": ["name", "gender", "age", "city"],
+    "additionalProperties": False,
+}
+
+
+def main():
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+    )
+
+    # Ask the model to return JSON matching the schema.
+    response = client.responses.create(
+        model="hy3",
+        input="提取以下文本中的人物信息：张三，男，25岁，北京人。",
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "person_info",
+                "schema": PERSON_INFO_SCHEMA,
+                "strict": True,
+            }
+        },
+    )
+
+    # output_text is a JSON string, so parse it into a Python dictionary.
+    person = json.loads(response.output_text)
+    print(json.dumps(person, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/09_responses_structured_output_cn.md
+++ b/examples/09_responses_structured_output_cn.md
@@ -1,0 +1,26 @@
+# 09 Responses API 结构化输出
+
+使用 JSON Schema 约束 Responses API 的输出格式，并将返回的 JSON 字符串解析为 Python 对象。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/09_responses_structured_output.py
+```
+
+## 请求和解析
+
+脚本通过 `text.format` 设置 `json_schema`，声明 `name`、`gender`、`age` 和 `city` 字段。Responses API 返回的 `response.output_text` 仍然是字符串，因此脚本使用 `json.loads()` 将其转换为 Python 字典。
+
+## 输出示例
+
+```json
+{
+  "age": 25,
+  "city": "北京",
+  "gender": "男",
+  "name": "张三"
+}
+```
+
+生产环境中应处理响应为空、请求失败和 JSON 解析异常等情况。

--- a/examples/10_error_handling_retry.md
+++ b/examples/10_error_handling_retry.md
@@ -1,0 +1,25 @@
+# 10 Error handling and retry
+
+Retry connection errors, timeouts, rate limits, and server errors with exponential backoff and jitter.
+
+```bash
+uv run --env-file .env python examples/10_error_handling_retry.py
+```
+
+The script disables SDK automatic retries, allows three attempts, and retries `APIConnectionError`, `APITimeoutError`, `RateLimitError`, and `InternalServerError`. It logs the attempt and delay, then re-raises the final exception after the retry limit is reached. Production code should also record `request_id` and honor `Retry-After` when available.
+
+## Output example
+
+Successful output from one run:
+
+```text
+腾讯混元大模型是腾讯自主研发的通用大语言模型，具备多模态理解与生成能力……
+```
+
+English translation: “Tencent Hunyuan is a general-purpose large language model developed by Tencent, with multimodal understanding and generation capabilities.”
+
+When a retryable error occurs, the script may print:
+
+```text
+Attempt 1 failed: RateLimitError; retrying in 1.23s
+```

--- a/examples/10_error_handling_retry.py
+++ b/examples/10_error_handling_retry.py
@@ -1,0 +1,47 @@
+"""Retry transient errors with exponential backoff and jitter."""
+
+import os
+import random
+import time
+
+from openai import (
+    APITimeoutError,
+    APIConnectionError,
+    InternalServerError,
+    OpenAI,
+    RateLimitError,
+)
+
+
+def main():
+    # Disable SDK automatic retries so this example controls the policy.
+    client = OpenAI(
+        api_key=os.environ["HY3_API_KEY"],
+        base_url=os.getenv(
+            "HY3_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+        ),
+        timeout=30.0,
+        max_retries=0,
+    )
+
+    # Retry transient failures up to three total attempts.
+    for attempt in range(1, 4):
+        try:
+            response = client.chat.completions.create(
+                model="hy3",
+                messages=[{"role": "user", "content": "你好，请简单介绍腾讯混元大模型。"}],
+            )
+            print(response.choices[0].message.content)
+            return
+        except (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError) as exc:
+            if attempt == 3:
+                raise
+            # Exponential backoff plus random jitter avoids synchronized retries.
+            delay = min(8.0, 2 ** (attempt - 1)) + random.uniform(0, 0.5)
+            print(f"Attempt {attempt} failed: {type(exc).__name__}; retrying in {delay:.2f}s")
+            time.sleep(delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/10_error_handling_retry_cn.md
+++ b/examples/10_error_handling_retry_cn.md
@@ -1,0 +1,29 @@
+# 10 错误处理与重试
+
+对连接错误、超时、限流和服务端错误进行指数退避重试。
+
+## 运行
+
+```bash
+uv run --env-file .env python examples/10_error_handling_retry.py
+```
+
+## 请求和解析
+
+脚本关闭 SDK 内置自动重试，并将最大尝试次数设置为 3。遇到 `APIConnectionError`、`APITimeoutError`、`RateLimitError` 或 `InternalServerError` 时，等待带随机抖动的指数退避时间后重试；成功后从 `response.choices[0].message.content` 读取文本。
+
+## 输出示例
+
+成功时：
+
+```text
+腾讯混元大模型是腾讯自主研发的通用大语言模型，具备多模态理解与生成能力，可处理文本、图像、语音等任务。它支持知识问答、内容创作、逻辑推理、代码编写等场景，并通过持续迭代优化中文理解、长文本处理等能力。作为底层模型，混元已接入腾讯云、微信等生态，为 B 端和 C 端提供 AI 能力支持，注重安全性与合规性。
+```
+
+发生可重试错误时，可能看到：
+
+```text
+第 1 次请求失败：RateLimitError，1.23s 后重试
+```
+
+达到最大重试次数后，脚本会重新抛出最后一次异常。生产环境还应记录 `request_id`，并结合 `Retry-After` 响应头调整等待时间。

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,48 @@
+<p align="left">
+   English ｜ <a href="README_cn.md">中文</a>
+</p>
+
+# Hy3 API examples
+
+This directory contains runnable Python examples for both the TokenHub Chat Completions API and Responses API. Python files use English names and comments; Chinese and English explanations are provided as separate Markdown files.
+
+## Prerequisites
+
+Set the API key in the repository root `.env` file or in the current shell:
+
+```bash
+export HY3_API_KEY="YOUR_TOKENHUB_API_KEY"
+export HY3_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+```
+
+Install dependencies and run an example from the repository root:
+
+```bash
+uv sync
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+Do not write real API keys into Python files or commit `.env`.
+
+## Examples
+
+| File                                                                     | Description                               | Chinese guide                                                                  |
+|--------------------------------------------------------------------------|-------------------------------------------|--------------------------------------------------------------------------------|
+| [`01_basic_chat.py`](01_basic_chat.py)                                   | Minimal Chat Completions request.         | [`01_basic_chat_cn.md`](01_basic_chat_cn.md)                                   |
+| [`02_streaming.py`](02_streaming.py)                                     | Chat Completions streaming and usage.     | [`02_streaming_cn.md`](02_streaming_cn.md)                                     |
+| [`03_streaming_vs_non_streaming.py`](03_streaming_vs_non_streaming.py)   | Compare streaming latency and total time. | [`03_streaming_vs_non_streaming_cn.md`](03_streaming_vs_non_streaming_cn.md)   |
+| [`04_tool_calling.py`](04_tool_calling.py)                               | Chat Completions function tool loop.      | [`04_tool_calling_cn.md`](04_tool_calling_cn.md)                               |
+| [`05_reasoning_mode.py`](05_reasoning_mode.py)                           | Compare normal and reasoning modes.       | [`05_reasoning_mode_cn.md`](05_reasoning_mode_cn.md)                           |
+| [`06_responses_basic.py`](06_responses_basic.py)                         | Minimal Responses API request.            | [`06_responses_basic_cn.md`](06_responses_basic_cn.md)                         |
+| [`07_responses_streaming.py`](07_responses_streaming.py)                 | Parse Responses SSE events.               | [`07_responses_streaming_cn.md`](07_responses_streaming_cn.md)                 |
+| [`08_responses_tool_calling.py`](08_responses_tool_calling.py)           | Responses function-call output loop.      | [`08_responses_tool_calling_cn.md`](08_responses_tool_calling_cn.md)           |
+| [`09_responses_structured_output.py`](09_responses_structured_output.py) | JSON Schema output and parsing.           | [`09_responses_structured_output_cn.md`](09_responses_structured_output_cn.md) |
+| [`10_error_handling_retry.py`](10_error_handling_retry.py)               | Retry transient errors with backoff.      | [`10_error_handling_retry_cn.md`](10_error_handling_retry_cn.md)               |
+
+Every Python example has a matching English Markdown guide and a Chinese Markdown guide. Output can vary with model versions, sampling, service load, and network latency.
+
+The weather function is fixed demo data and does not call a real weather service.
+
+`07_responses_streaming.py` parses SSE with the Python standard library. The current TokenHub `response.created` event may contain `output: null`, which can cause high-level Responses stream parsers in some OpenAI SDK versions to fail.
+
+Parameter and protocol support should be verified against the [Hy3 calling guide](https://cloud.tencent.com/document/product/1823/132252) and the [TokenHub language-model overview](https://cloud.tencent.com/document/product/1823/130079).

--- a/examples/README_cn.md
+++ b/examples/README_cn.md
@@ -1,0 +1,57 @@
+<p align="left">
+   <a href="../quickstart.md">English</a> ｜ 中文
+</p>
+
+# Hy3 API 示例
+
+本目录提供可直接运行的 Python 示例，覆盖腾讯云 TokenHub 的 Chat Completions API 和 Responses API。
+
+示例统一使用 Python 文件，配套说明集中在本文档中。`.py` 文件便于直接运行、复用和后续加入自动化检查。
+
+## 运行前提
+
+在仓库根目录创建 `.env`，或在当前终端设置环境变量：
+
+```bash
+export HY3_API_KEY="你的 TokenHub API Key"
+export HY3_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+```
+
+安装依赖：
+
+```bash
+uv sync
+```
+
+从仓库根目录运行示例：
+
+```bash
+uv run --env-file .env python examples/02_streaming.py
+```
+
+如果不使用 `.env`，可以省略 `--env-file .env`。API Key 不应写入 Python 文件，也不应提交 `.env`。
+
+## 示例列表
+
+| 文件                                                                             | 内容                                                |
+|--------------------------------------------------------------------------------|---------------------------------------------------|
+| [`01_basic_chat.py`](01_basic_chat.py)                                   | Chat Completions 单轮调用，作为最小入门示例。                   |
+| [`02_streaming.py`](02_streaming.py)                                     | Chat Completions 流式输出，处理空 `delta` 和最终 `usage`。    |
+| [`03_streaming_vs_non_streaming.py`](03_streaming_vs_non_streaming.py)   | 对比 Chat Completions 非流式和流式请求的响应耗时。                |
+| [`04_tool_calling.py`](04_tool_calling.py)                               | Chat Completions 函数工具调用，执行本地函数并循环回传工具结果。          |
+| [`05_reasoning_mode.py`](05_reasoning_mode.py)                           | 对比 Chat Completions 关闭和开启推理模式时的请求与响应。             |
+| [`06_responses_basic.py`](06_responses_basic.py)                         | Responses API 最小调用示例，读取 `response.output_text`。   |
+| [`07_responses_streaming.py`](07_responses_streaming.py)                 | Responses API 流式输出示例，解析文本增量事件。                    |
+| [`08_responses_tool_calling.py`](08_responses_tool_calling.py)           | Responses API 函数工具调用示例，回传 `function_call_output`。 |
+| [`09_responses_structured_output.py`](09_responses_structured_output.py) | Responses API 结构化输出示例，并解析 JSON 字符串。               |
+| [`10_error_handling_retry.py`](10_error_handling_retry.py)               | 连接错误、超时、限流和服务端错误的指数退避重试。                          |
+
+每个脚本均有同名中文说明文档，例如 [`01_basic_chat_cn.md`](01_basic_chat_cn.md)。说明文档包含运行命令、请求和响应解析方式以及一次实际运行的输出示例。
+
+示例中的天气函数仅用于演示工具调用流程，不会访问真实天气服务。
+
+`07_responses_streaming.py` 使用标准库直接解析 SSE 事件。这是因为当前 TokenHub 的 `response.created` 事件可能返回 `output: null`，部分 OpenAI SDK 版本的 Responses 高层流式解析器会假设该字段始终为数组，从而触发解析异常。
+
+## 说明
+
+示例输出可能因模型版本、服务负载和随机采样而变化。参数和协议支持范围以 [Hy3 调用指南](https://cloud.tencent.com/document/product/1823/132252) 及 [TokenHub 语言模型调用概览](https://cloud.tencent.com/document/product/1823/130079) 为准。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "hy3"
+version = "0.1.0"
+requires-python = ">=3.14"
+dependencies = [
+    "openai>=2.46.0",
+]

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,501 @@
+<p align="left">
+    English ｜ <a href="quickstart_cn.md">中文</a>
+</p>
+
+# Hy3 API Quickstart
+
+This guide shows how to call the Tencent Cloud TokenHub hosted Hy3 API. Local deployment of the Hy3 model is not required.
+
+The guide uses the Chat Completions API for the first request and then introduces the main capabilities. For a separate Responses API guide, see [Responses API](docs/api/responses.md).
+
+## 1. Create an API key
+
+Create an API key in the [TokenHub API Key console](https://console.cloud.tencent.com/tokenhub/apikey).
+
+Do not write a real key directly into source code, documentation, screenshots, or Git. Store it in an environment variable instead:
+
+```bash
+export HY3_API_KEY="YOUR_TOKENHUB_API_KEY"
+```
+
+If a key has been exposed, disable or delete it in the console and create a new one.
+
+## 2. Choose an API protocol
+
+Hy3 supports the following TokenHub-compatible protocols:
+
+- Chat Completions API: the default protocol in this guide, suitable for ordinary chat, streaming, and function calling.
+- Responses API: a unified output model for messages, reasoning, tools, and more complex Agent workflows. See [Responses API](docs/api/responses.md).
+- Anthropic Messages API: available according to the model and service support matrix.
+
+This guide focuses on Chat Completions. The [Responses API guide](docs/api/responses.md) documents its different request and response structures.
+
+## 3. Basic information
+
+### Base URL
+
+The API key, service region, and Base URL must belong to the same region.
+
+| Region | Base URL | Scope |
+| --- | --- | --- |
+| Guangzhou | `https://tokenhub.tencentmaas.com/v1` | Mainland China |
+| Singapore | `https://tokenhub-intl.tencentmaas.com/v1` | Global |
+
+The platform also provides backup domains. Use them only when the default domain is unavailable:
+
+- Guangzhou: `https://tokenhub.tencentmaas.cn/v1`
+- Singapore: `https://tokenhub-intl.tencentmaas.cn/v1`
+
+### API key
+
+Pass the API key in the `Authorization` header:
+
+```http
+Authorization: Bearer ${HY3_API_KEY}
+```
+
+The available model IDs can be checked with:
+
+```bash
+curl "https://tokenhub.tencentmaas.com/v1/models" \
+  -H "Authorization: Bearer ${HY3_API_KEY}"
+```
+
+### Model name
+
+The Hy3 service ID is:
+
+```text
+hy3
+```
+
+Use the service ID in the `model` field rather than a local checkpoint path. Hy3 supports TokenHub's OpenAI Chat Completions, OpenAI Responses, and Anthropic protocols; this guide uses Chat Completions by default.
+
+### Model and throughput limits
+
+The following Hy3 service information was recorded from the [model marketplace](https://console.cloud.tencent.com/tokenhub/models/detail?modelId=hy3&regionId=1&from=all&Is=sdk-topnav) on July 22, 2026:
+
+| Limit | Value | Description |
+| --- | ---: | --- |
+| Maximum input tokens | 192k | Maximum input length for a single request. |
+| Maximum output tokens | 128k | Maximum output length; reasoning tokens count toward this limit. |
+| Context window | 256k | Combined input and output context limit. |
+| Maximum TPM | 1,000,000 | Maximum input and output tokens processed per minute. |
+| Maximum RPM | 60 | Maximum requests per minute. |
+
+The first three values are model capacity limits. TPM and RPM are service throttling limits and may vary by region, plan, API key, or account. Always check the latest value in the model marketplace before production use.
+
+## 4. First request
+
+The Chat Completions request consists of a URL, request headers, and a JSON body:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Hello"}
+    ],
+    "stream": false
+  }'
+```
+
+### Request fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `model` | string | Model or service ID. Use `hy3` for Hy3. |
+| `messages` | array | Ordered conversation messages. |
+| `messages[].role` | string | Message role, such as `system`, `user`, `assistant`, or `tool`. |
+| `messages[].content` | string or array | Message text or supported content blocks. |
+| `stream` | boolean | Whether to return an SSE stream. `false` returns a complete response. |
+
+### Response example
+
+Responses usually contain the following structure:
+
+```json
+{
+  "id": "c27d9b74-497e-4968-8138-530063de4f40",
+  "object": "chat.completion",
+  "model": "hy3",
+  "created": 1784381073,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I help you?"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 22,
+    "completion_tokens": 15,
+    "total_tokens": 37
+  }
+}
+```
+
+For ordinary text, read `choices[0].message.content`. `finish_reason: "stop"` normally indicates that the model completed the answer normally.
+
+### Python OpenAI SDK
+
+Install the SDK:
+
+```bash
+uv sync
+```
+
+The minimal example is [`examples/01_basic_chat.py`](examples/01_basic_chat.py). Run it from the repository root:
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+The script creates an OpenAI-compatible client with the TokenHub Base URL and reads `response.choices[0].message.content`.
+
+## 5. Multi-turn conversations
+
+Pass the conversation history in `messages` in chronological order. The current request should normally end with a `user` message:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Hello"},
+      {"role": "assistant", "content": "Hello! How can I help?"},
+      {"role": "user", "content": "What is 37 × 24?"}
+    ],
+    "stream": false
+  }'
+```
+
+The client is responsible for storing and resending the conversation history. If a previous response contains reasoning-related fields, whether those fields must be preserved depends on the model and TokenHub protocol support.
+
+## 6. Streaming output
+
+Set `stream` to `true` to receive Server-Sent Events (SSE):
+
+```bash
+curl -N -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "Introduce Shenzhen in three sentences."}],
+    "stream": true
+  }'
+```
+
+Typical events look like this:
+
+```text
+data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}
+data: {"choices":[{"index":0,"delta":{"content":"Shenzhen"}}]}
+data: {"choices":[{"index":0,"delta":{"content":" is a modern city."},"finish_reason":"stop"}]}
+data: [DONE]
+```
+
+The client should concatenate `delta.content` in order. Not every chunk contains text, so check that `choices` and `delta.content` are present before reading them. `data: [DONE]` is a stream terminator, not a JSON object.
+
+To receive usage in the final chunk, add:
+
+```json
+"stream_options": {"include_usage": true}
+```
+
+The final usage chunk may contain an empty `choices` array. See [`examples/02_streaming.py`](examples/02_streaming.py) and [`examples/03_streaming_vs_non_streaming.py`](examples/03_streaming_vs_non_streaming.py).
+
+## 7. Reasoning mode
+
+Reasoning parameters are defined by the TokenHub service and may vary by protocol and model. Do not copy local vLLM or SGLang `chat_template_kwargs` settings into a hosted API request without checking the corresponding TokenHub documentation.
+
+For Chat Completions, the commonly used parameters are:
+
+```json
+"thinking": {"type": "enabled"}
+```
+
+Some services also expose:
+
+```json
+"reasoning_effort": "high"
+```
+
+Whether either field is accepted and effective depends on the model and service version. The example [`examples/05_reasoning_mode.py`](examples/05_reasoning_mode.py) compares normal and reasoning requests.
+
+Applications should not display the model's private chain of thought by default. Use the final answer and usage fields required by the application.
+
+### Interleaved thinking
+
+[Interleaved thinking](https://cloud.tencent.com/document/product/1823/130930) combines reasoning and tool calls. The request still uses the supported thinking, reasoning, and tools fields, but the model may call tools multiple times. The application must process each tool call until the model returns a final answer.
+
+## 8. Tool calling
+
+Tool calling usually consists of two model requests and one local function execution:
+
+1. Declare callable functions in `tools`.
+2. Parse `tool_calls` when the model requests a tool and execute the local function.
+3. Send the result back as a `role: "tool"` message so the model can produce the final answer.
+
+The model does not execute local functions. Function execution, permissions, validation, and error handling belong to the application.
+
+### First request: declare a tool
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "What is the weather in Shenzhen?"}],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather information for a city",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "city": {"type": "string", "description": "City name"}
+            },
+            "required": ["city"],
+            "additionalProperties": false
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+`tools` is an array of function definitions. `function.name` selects the application function, `description` helps the model decide when to use it, and `function.parameters` is a JSON Schema. `tool_choice: "auto"` lets the model decide whether to call a tool.
+
+### Model tool call
+
+The model may return a message like:
+
+```json
+{
+  "role": "assistant",
+  "content": null,
+  "tool_calls": [
+    {
+      "id": "chatcmpl-tool-example",
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "arguments": "{\"city\":\"Shenzhen\"}"
+      }
+    }
+  ]
+}
+```
+
+Parse `function.arguments` as a JSON string. The tool call ID must be returned as `tool_call_id`:
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "chatcmpl-tool-example",
+  "content": "{\"city\":\"Shenzhen\",\"weather\":\"sunny\",\"temperature\":28}"
+}
+```
+
+The second request contains the original conversation, the assistant tool-call message, and the tool result. See [`examples/04_tool_calling.py`](examples/04_tool_calling.py) for a complete loop that supports multiple tool calls.
+
+## 9. Structured output
+
+Use `response_format` to request a JSON Schema-constrained answer:
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "Extract the person information: Zhang San, 35, senior software engineer, skilled in Python, Java, and machine learning."}
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "person_info",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "occupation": {"type": "string"},
+            "skills": {"type": "array", "items": {"type": "string"}}
+          },
+          "required": ["name", "age", "occupation", "skills"]
+        }
+      }
+    },
+    "stream": false
+  }'
+```
+
+The structured result is still returned as a string in `choices[0].message.content`. Parse it a second time in the application:
+
+```python
+import json
+
+person = json.loads(response.choices[0].message.content)
+print(person["name"])
+```
+
+The example response contains fields such as `name`, `age`, `occupation`, and `skills`. See [`examples/09_responses_structured_output.py`](examples/09_responses_structured_output.py) for a complete Python example.
+
+## 10. Common request parameters
+
+The following optional parameters are commonly used at the top level of a Chat Completions request:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `temperature` | number | Controls randomness. Lower values are usually more stable; higher values are more diverse. |
+| `top_p` | number | Nucleus sampling threshold. Usually adjust `temperature` or `top_p`, rather than both aggressively. |
+| `max_tokens` | integer | Maximum number of generated output tokens for Chat Completions. Check the model limit. |
+| `stop` | string or string array | Stops generation when a specified sequence is reached. |
+| `tools` | array | Declares callable tools. |
+| `tool_choice` | string or object | Controls tool selection, such as `auto`. |
+| `stream` | boolean | Selects complete or SSE streaming output. |
+
+### `temperature`
+
+Controls sampling randomness. When the same prompt is sent repeatedly, a lower value usually produces more similar answers. Start with a small value such as `0.2` or `0.3` when stable output is important.
+
+### `top_p`
+
+Controls the cumulative probability mass considered for the next token. Lower values usually narrow the candidate set. The supported range is typically `[0, 1]`.
+
+### `max_tokens`
+
+Limits the generated output length. It does not guarantee that the model will finish the requested task within the limit. Reasoning tokens may also count toward the output limit depending on the service.
+
+### `stop`
+
+`stop` is a signal that tells the model to stop when it generates a specified marker; it is not a request to output that marker. For Chat Completions, the following test returned HTTP `200`, omitted `STOP` from the content, and returned `finish_reason: "stop"`:
+
+```bash
+curl -i -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "Output the following and end with STOP: first line, second line."}],
+    "stop": ["STOP"],
+    "stream": false
+  }'
+```
+
+The observed content was `first line\nsecond line\n`, without `STOP`. In contrast, the current Hy3 Responses API test accepted the field but did not truncate the output, so applications should verify the behavior separately for each protocol.
+
+## 11. Common errors and troubleshooting
+
+Errors usually have this structure:
+
+```json
+{
+  "error": {
+    "message": "English error description",
+    "message_zh": "Chinese error description",
+    "code": "Business error code",
+    "type": "Error type",
+    "source": "client | gateway | upstream",
+    "request_id": "Unique request ID"
+  }
+}
+```
+
+Important fields:
+
+| Field | Description |
+| --- | --- |
+| `error.message` | English description, useful for logs. |
+| `error.message_zh` | Chinese description, suitable for Chinese user-facing messages. |
+| `error.code` | TokenHub business error code. It may be a string or an integer. |
+| `error.type` | Error category, such as a parameter or rate-limit error. |
+| `error.source` | Error source: `client`, `gateway`, or `upstream`. |
+| `error.request_id` | Unique request ID for support and troubleshooting. |
+
+Common HTTP status codes include:
+
+| Status | Typical cause | Suggested action |
+| --- | --- | --- |
+| `400` | Invalid body, missing field, or invalid parameter. | Check `model`, `messages`, and parameter ranges. |
+| `401` | Missing, invalid, expired, or disabled API key. | Check the Authorization header and key status. |
+| `403` | Insufficient plan, model, account, IP, or tool permission. | Check service permissions. |
+| `413` | Request body is too large. | Reduce messages, tools, or other input. |
+| `429` | RPM, TPM, TPD, concurrency, or capacity limit. | Reduce frequency or concurrency and retry later. |
+| `451` | Content safety policy triggered. | Adjust the input or output request. |
+| `500`–`504` | Platform, upstream, or gateway failure. | Retry and provide `request_id` if the problem persists. |
+
+### Model service busy: `429006`
+
+The gateway may return this error when the model service is busy or has reached its serving capacity:
+
+```json
+{
+  "error": {
+    "type": "rate_limit_error",
+    "code": "429006",
+    "message": "The model service is currently busy or has reached its serving capacity limit. Please reduce the request frequency and try again later.",
+    "message_zh": "当前模型服务繁忙或已达服务容量上限，请降低请求频率后稍后重试。",
+    "source": "gateway",
+    "request_id": "57b8d6ff-03dd-45a0-8d8e-5eebba3e0470"
+  }
+}
+```
+
+Lower the request rate, wait before retrying, and use exponential backoff with random jitter. If the response includes `Retry-After`, wait for that duration first. Record the request ID, time, and model name if the error persists. This error normally indicates service capacity rather than invalid JSON; changing `messages` or `response_format` does not directly resolve it. See [`examples/10_error_handling_retry.py`](examples/10_error_handling_retry.py).
+
+For the complete error-code list, see [TokenHub API error codes](https://cloud.tencent.com/document/product/1823/131595).
+
+## 12. Examples and further reading
+
+The curl snippets above explain the protocol format. For complete runnable Python examples, read [`examples/README.md`](examples/README.md). Every script has a matching Chinese Markdown description with its run command, parsing logic, and an observed output example.
+
+| Scenario | Example |
+| --- | --- |
+| Basic chat | [`01_basic_chat.py`](examples/01_basic_chat.py) |
+| Streaming | [`02_streaming.py`](examples/02_streaming.py) |
+| Streaming comparison | [`03_streaming_vs_non_streaming.py`](examples/03_streaming_vs_non_streaming.py) |
+| Chat tool calling | [`04_tool_calling.py`](examples/04_tool_calling.py) |
+| Chat reasoning | [`05_reasoning_mode.py`](examples/05_reasoning_mode.py) |
+| Responses basic call | [`06_responses_basic.py`](examples/06_responses_basic.py) |
+| Responses streaming | [`07_responses_streaming.py`](examples/07_responses_streaming.py) |
+| Responses tool calling | [`08_responses_tool_calling.py`](examples/08_responses_tool_calling.py) |
+| Responses structured output | [`09_responses_structured_output.py`](examples/09_responses_structured_output.py) |
+| Error handling and retry | [`10_error_handling_retry.py`](examples/10_error_handling_retry.py) |
+
+Run an example from the repository root:
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+## 13. Reference documentation
+
+- [TokenHub Quickstart](https://cloud.tencent.com/document/product/1823/130058): TokenHub console and basic setup.
+- [TokenHub API usage](https://cloud.tencent.com/document/product/1823/130078): endpoints, authentication, model listing, and exceptions.
+- [TokenHub language-model overview](https://cloud.tencent.com/document/product/1823/130079): common parameters, response fields, tools, and streaming.
+- [Hy3 calling guide](https://cloud.tencent.com/document/product/1823/132252): Hy3 limits, protocol support, and model-specific usage.
+- [TokenHub reasoning](https://cloud.tencent.com/document/product/1823/131208): `thinking`, `reasoning_effort`, and reasoning-related behavior.
+- [TokenHub API error codes](https://cloud.tencent.com/document/product/1823/131595): HTTP status codes, business errors, and troubleshooting.
+- [TokenHub Responses API compatibility](https://cloud.tencent.com/document/product/1823/133813): Responses parameters, input/output structures, and compatibility limits.
+- [TokenHub glossary](https://cloud.tencent.com/document/product/1823/130120#2897): Common TokenHub terminology.
+
+Do not infer parameter support from a single response. When changing the model, region, or protocol, verify the behavior again against the model marketplace, official documentation, and an actual API response.

--- a/quickstart_cn.md
+++ b/quickstart_cn.md
@@ -1,0 +1,1024 @@
+<p align="left">
+   <a href="quickstart.md">English</a> ｜ 中文
+</p>
+
+# Hy3 API 快速开始
+
+本文档面向第一次调用 Hy3 API 的开发者。使用腾讯云 TokenHub 托管 API 时，不需要在本地部署 Hy3 模型。
+
+如果只想完成第一次调用，请按下面的步骤操作：
+
+1. 创建腾讯云 TokenHub API Key。
+2. 将 API Key 保存到环境变量。
+3. 使用 Chat Completions API 发起一次请求。
+
+## 1. 创建 API Key
+
+前往腾讯云 [TokenHub API Key 管理](https://console.cloud.tencent.com/tokenhub/apikey) 页面创建 API Key。
+
+请不要将 API Key 直接写入代码、文档或提交到 Git。建议在当前终端中设置环境变量：
+
+```bash
+export HY3_API_KEY="你的 TokenHub API Key"
+```
+
+如果 API Key 曾经被写入公开仓库、截图或聊天记录，请先在控制台禁用或删除，再重新生成新的 Key。
+
+## 2. 选择 API 协议
+
+Hy3 托管 API 支持两种常见的 OpenAI 兼容协议：
+
+- Chat Completions API：本文档默认使用，适合快速开始、普通对话和流式输出。
+- [Responses API](docs/api/responses_cn.md)：适合统一响应格式、状态衔接和更复杂的 Agent 场景。
+
+本文先介绍 Chat Completions API。更详细的 Hy3 模型限制和专用调用方式，请参考 [Hy3 调用指南](https://cloud.tencent.com/document/product/1823/132252)；公共参数、响应字段、工具调用和流式输出说明，请参考 [TokenHub 语言模型调用概览](https://cloud.tencent.com/document/product/1823/130079)。Responses API 的协议差异见[独立说明](docs/api/responses_cn.md)。
+
+## 3. 基础信息
+
+### Base URL
+
+TokenHub 根据服务地域提供不同的接口地址。API Key、服务地域和 Base URL 必须保持一致，不支持跨地域或跨站点调用。
+
+| 地域  | Base URL                                   | 适用范围 |
+|-----|--------------------------------------------|------|
+| 广州  | `https://tokenhub.tencentmaas.com/v1`      | 中国大陆 |
+| 新加坡 | `https://tokenhub-intl.tencentmaas.com/v1` | 全球   |
+
+官方文档还提供对应的备用域名：广州为 `https://tokenhub.tencentmaas.cn/v1` ，新加坡为 `https://tokenhub-intl.tencentmaas.cn/v1` 。建议仅在默认地址不可用时切换备用地址。
+
+### API Key
+
+API Key 通过 HTTP Header 传递：
+
+```http
+Authorization: Bearer ${HY3_API_KEY}
+```
+
+不要将真实 Key 写入文档、代码、截图或 Git 提交。可以通过 `GET /v1/models` 检查当前 Key 能访问的模型列表：
+
+```bash
+curl "https://tokenhub.tencentmaas.com/v1/models" \
+  -H "Authorization: Bearer ${HY3_API_KEY}"
+```
+
+### Model 名称
+
+Hy3 的模型调用名为：
+
+```text
+hy3
+```
+
+请求中的 `model` 字段应使用服务 ID，而不是本地 checkpoint 路径。Hy3 同时支持 TokenHub 的 OpenAI Chat Completions、OpenAI Responses 和 Anthropic 协议；本文默认使用 Chat Completions。
+
+### 模型限制与吞吐限制
+
+[模型广场](https://console.cloud.tencent.com/tokenhub/models/detail?modelId=hy3&regionId=1&from=all&Is=sdk-topnav) 于 2026 年 7 月 22 日记录的 Hy3 服务信息如下：
+
+| 项目          |         值 | 说明                             |
+|-------------|----------:|--------------------------------|
+| 最大输入 Tokens |      192k | 单次请求允许的最大输入长度。                 |
+| 最大输出 Tokens |      128k | 单次请求允许的最大输出长度；思考 Token 计入输出额度。 |
+| 上下文窗口       |      256k | 输入和输出共同使用的上下文上限。               |
+| 最大 TPM      | 1,000,000 | 服务每分钟可处理的输入和输出 Token 总量上限。     |
+| 最大 RPM      |        60 | 服务每分钟可处理的请求数上限。                |
+
+前三项是模型容量限制；TPM 和 RPM 属于服务限流信息，可能随地域、套餐、API Key 或账户等级变化。实际调用时，应以模型广场中显示的最新信息为准。
+
+## 4. 第一次调用
+
+本文档默认使用 Chat Completions API。请求由 URL、请求头和 JSON 请求体组成：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "system", "content": "你是一个有帮助的助手。"},
+      {"role": "user", "content": "你好"}
+    ],
+    "stream": false
+  }'
+```
+
+### 请求说明
+
+#### 请求地址
+
+```text
+POST https://tokenhub.tencentmaas.com/v1/chat/completions
+```
+
+`POST` 表示向该地址提交一次模型生成请求。
+
+#### 请求头
+
+| 字段              | 类型     | 作用                                  |
+|-----------------|--------|-------------------------------------|
+| `Authorization` | string | 身份认证，格式为 `Bearer ${HY3_API_KEY}`。   |
+| `Content-Type`  | string | 声明请求体为 JSON，固定为 `application/json`。 |
+
+#### 请求体
+
+| 字段                   | 类型              | 必填 | 作用                                   |
+|----------------------|-----------------|----|--------------------------------------|
+| `model`              | string          | 是  | 模型名称，Hy3 托管 API 使用 `hy3`。            |
+| `messages`           | array of object | 是  | 按时间顺序排列的对话消息数组。                      |
+| `messages[].role`    | string          | 是  | 消息角色，例如 `system`、`user`、`assistant`。 |
+| `messages[].content` | string          | 是  | 当前消息的文本内容。                           |
+| `stream`             | boolean         | 否  | 是否启用流式输出。`false` 等待完整结果，`true` 逐段返回。 |
+
+请求中的 `messages` 是数组，因此可以传入多轮对话：
+
+```json
+[
+  {"role": "system", "content": "你是一个有帮助的助手。"},
+  {"role": "user", "content": "我叫小明。"},
+  {"role": "assistant", "content": "你好，小明。"},
+  {"role": "user", "content": "我叫什么？"}
+]
+```
+
+### 响应示例
+
+如果请求成功，服务会返回一个 JSON 对象。格式化后如下：
+
+```json
+{
+  "id": "c27d9b74-497e-4968-8138-530063de4f40",
+  "object": "chat.completion",
+  "model": "hy3",
+  "created": 1784381073,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好！我是你的助手，有什么可以帮你的吗？ 😊"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 22,
+    "completion_tokens": 15,
+    "total_tokens": 37,
+    "prompt_tokens_details": {"cached_tokens": 0},
+    "completion_tokens_details": {"reasoning_tokens": 0}
+  }
+}
+```
+
+### 响应字段说明
+
+| 字段                                                 | 类型              | 作用                                        |
+|----------------------------------------------------|-----------------|-------------------------------------------|
+| `id`                                               | string          | 本次请求的唯一标识，可用于日志追踪和问题排查。                   |
+| `object`                                           | string          | 响应对象类型，非流式响应通常为 `chat.completion`。        |
+| `model`                                            | string          | 实际处理请求的模型名称。                              |
+| `created`                                          | integer         | 请求创建时间，通常为 Unix 时间戳，单位为秒。                 |
+| `choices`                                          | array of object | 模型生成结果列表。即使通常只有一个结果，也需要按数组读取。             |
+| `choices[].index`                                  | integer         | 当前结果在 `choices` 数组中的索引，通常从 `0` 开始。        |
+| `choices[].message`                                | object          | 模型返回的消息对象。                                |
+| `choices[].message.role`                           | string          | 返回消息的角色，通常为 `assistant`。                  |
+| `choices[].message.content`                        | string or null  | 模型生成的文本内容。读取模型回复时通常使用这个字段。                |
+| `choices[].finish_reason`                          | string or null  | 生成结束原因，例如 `stop` 表示正常结束。工具调用或长度限制可能对应其他值。 |
+| `usage`                                            | object          | 本次请求的 Token 使用统计。                         |
+| `usage.prompt_tokens`                              | integer         | 输入消息消耗的 Token 数量。                         |
+| `usage.completion_tokens`                          | integer         | 模型输出消耗的 Token 数量。                         |
+| `usage.total_tokens`                               | integer         | 总 Token 数，通常等于输入和输出 Token 数之和。            |
+| `usage.prompt_tokens_details.cached_tokens`        | integer         | 命中缓存的输入 Token 数量。没有缓存时通常为 `0`。            |
+| `usage.completion_tokens_details.reasoning_tokens` | integer         | 思考过程消耗的 Token 数量；未启用或服务未返回时可能为 `0`。       |
+
+最常用的取值方式是：
+
+```text
+choices[0].message.content
+```
+
+其中，`choices[0]` 表示取第一个生成结果，`message.content` 表示取该结果中的文本内容。
+
+> 注意：启用 `stream: true` 后，响应会拆成多个流式 chunk，响应结构与上面的完整 JSON 不完全相同，应参考下一节解析。
+
+### Python OpenAI SDK
+
+先安装 OpenAI Python SDK：
+
+```bash
+pip install -U openai
+```
+
+SDK 会通过 OpenAI 兼容接口访问 Hy3。示例默认使用广州 Base URL；如果 API Key 属于新加坡地域，请将 `HY3_BASE_URL` 改为 `https://tokenhub-intl.tencentmaas.com/v1` 。API Key 和 Base URL 必须属于同一地域。
+
+```python
+import os
+
+from openai import OpenAI
+
+api_key = os.environ["HY3_API_KEY"]
+base_url = os.getenv(
+    "HY3_BASE_URL",
+    "https://tokenhub.tencentmaas.com/v1",
+)
+
+client = OpenAI(
+    api_key=api_key,
+    base_url=base_url,
+)
+
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[
+        {"role": "system", "content": "你是一个有帮助的助手。"},
+        {"role": "user", "content": "你好，请简单介绍一下你自己。"},
+    ],
+    stream=False,
+)
+
+print(response.choices[0].message.content)
+```
+
+运行前，请先在当前终端设置 API Key：
+
+```bash
+export HY3_API_KEY="你的 TokenHub API Key"
+```
+
+如果使用新加坡地域，还需要设置：
+
+```bash
+export HY3_BASE_URL="https://tokenhub-intl.tencentmaas.com/v1"
+```
+
+代码通过 `response.choices[0].message.content` 读取模型回复。示例文件为 `examples/01_basic_chat.py`，可以使用 uv 运行：
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+如果不使用 `.env` 文件，也可以直接在当前终端导出 `HY3_API_KEY` 和可选的 `HY3_BASE_URL`，再运行：
+
+```bash
+uv run python examples/01_basic_chat.py
+```
+
+后续的流式输出、工具调用和错误重试示例也统一放在 `examples/` 目录中。
+
+## 5. 多轮对话
+
+通过 `messages` 数组传递系统提示和历史对话，模型会按照消息顺序理解上下文并生成下一轮回复。消息通常按以下顺序排列：
+
+```text
+system（可选）→ user → assistant → user → ...
+```
+
+应以 `user` 消息结束本轮请求：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "system", "content": "你是一个有帮助的助手。"},
+      {"role": "user", "content": "你好"},
+      {"role": "assistant", "content": "你好，有什么可以帮你的吗？"},
+      {"role": "user", "content": "我想知道 37 × 24 的计算结果。"}
+    ],
+    "stream": false
+  }'
+```
+
+当历史对话包含思考类响应时，回写 `assistant` 消息时建议同时保留 `content` 和服务返回的思考相关字段，以避免上下文丢失。应用是否需要回写这些字段，应以 TokenHub 的 Hy3 专用协议说明为准。
+
+## 6. 流式输出
+
+将 `stream` 设置为 `true` 后，服务会通过 Server-Sent Events（SSE）逐段返回结果：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "你好"}],
+    "stream": true
+  }'
+```
+
+示例响应：
+
+```text
+data: {"id":"6f649f1b-09fa-46db-bbf2-b91ef3ac12c8","object":"chat.completion.chunk","created":1784688338,"model":"hy3","choices":[{"index":0,"delta":{"role":"assistant"}}]}
+
+data: {"id":"6f649f1b-09fa-46db-bbf2-b91ef3ac12c8","object":"chat.completion.chunk","created":1784688338,"model":"hy3","choices":[{"index":0,"delta":{"content":"你好！"}}]}
+
+data: {"id":"6f649f1b-09fa-46db-bbf2-b91ef3ac12c8","object":"chat.completion.chunk","created":1784688338,"model":"hy3","choices":[{"index":0,"delta":{"content":"有什么可以帮你的吗？"},"finish_reason":"stop"}]}
+
+data: [DONE]
+```
+
+流式响应的每一行以 `data:` 开头，后面是一个 JSON chunk：
+
+- 第一段通常包含 `delta.role`，用于声明返回角色。
+- 中间的 chunk 通过 `delta.content` 返回部分文本，客户端需要按顺序拼接。
+- 最后一段通常包含 `finish_reason: "stop"`，表示本次生成正常结束。
+- `data: [DONE]` 表示整个流结束，不是 JSON 对象。
+
+因此，流式响应不能按照非流式响应的 `choices[0].message.content` 一次性读取。
+
+### 在流式响应中返回 usage
+
+如果希望在最后一个 chunk 中获取完整的 `usage` 统计，需要将 `stream_options.include_usage` 设置为 `true`：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "你好"}],
+    "stream": true,
+    "stream_options": {"include_usage": true}
+  }'
+```
+
+启用后，最后一个包含 `choices: []` 的 chunk 会返回 `usage`；`data: [DONE]` 仍然表示整个流结束。
+
+## 7. 深度思考
+
+### 开启或关闭思考模式
+
+通过 `thinking` 参数控制是否开启思考模式：
+
+```json
+"thinking": {"type": "enabled"}
+```
+
+关闭思考模式：
+
+```json
+"thinking": {"type": "disabled"}
+```
+
+Hy3 默认关闭思考模式，即 `thinking.type` 默认为 `disabled`。
+
+下面使用一个简短、可复核的数学问题演示开启思考模式：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "请计算 37 × 24，并用一句话说明结果。"}],
+    "thinking": {"type": "enabled"},
+    "stream": false
+  }'
+```
+
+示例中重点关注 `choices[0].message.content`。服务可能额外返回 `reasoning_content` 等思考相关字段；应用不应依赖或展示模型的原始思考过程，除非服务协议和产品需求明确要求这样做。
+
+### 配置推理深度
+
+通过 `reasoning_effort` 参数控制推理强度。推理强度越高，通常回答会更充分，但延迟和 Token 消耗也可能增加。
+
+| `reasoning_effort` | 说明                                 |
+|--------------------|------------------------------------|
+| `low`              | 轻量推理，速度较快，适合简单任务。                  |
+| `medium`           | 在速度和推理能力之间取得平衡，适合大多数任务。            |
+| `high`             | 深度推理，适合高难度数学、编程或复杂逻辑任务，但延迟和成本通常更高。 |
+
+Hy3 的默认 `reasoning_effort` 为 `low`。
+
+> 注意：Hy3 正式版在 Tool Calling 场景下具备 adaptive thinking 能力，可以根据任务复杂度自动调整推理深度。为兼容部分工具调用场景，当请求携带 `tools` 且 `reasoning_effort` 设置为 `low` 时，API 可能会将其自动映射为 `high`。
+
+## 8. 工具调用
+
+工具调用通常包含两次模型请求和一次本地函数执行：
+
+1. 第一次请求中通过 `tools` 声明模型可以调用的函数。
+2. 如果模型返回 `tool_calls`，业务代码解析参数并执行对应的本地函数。
+3. 第二次请求将工具结果以 `role: "tool"` 消息回填，让模型生成最终的自然语言回答。
+
+模型只负责提出工具调用建议，不会直接执行你的本地函数；函数的实际执行、权限控制和异常处理都由业务代码负责。
+
+### 第一次请求：声明工具
+
+下面的示例声明一个查询天气的函数，并允许模型自动决定是否调用它。注意：`parameters` 必须是合法的 JSON Schema，不能包含尾随逗号。
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "深圳今天天气怎么样？"}
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "获取指定城市的当前天气信息",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "city": {
+                "type": "string",
+                "description": "城市名称，例如：深圳"
+              }
+            },
+            "required": ["city"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+其中：
+
+- `tools` 是工具定义数组。
+- `type: "function"` 表示工具类型为函数。
+- `function.name` 是业务代码中实际要执行的函数名。
+- `function.description` 用于帮助模型判断何时使用该工具。
+- `function.parameters` 使用 JSON Schema 描述函数参数。
+- `tool_choice: "auto"` 表示由模型自动决定是否调用工具。
+
+### 工具定义字段说明
+
+| 字段                            | 类型               | 作用                                               |
+|-------------------------------|------------------|--------------------------------------------------|
+| `tools`                       | array            | 可用工具列表。一次请求可以声明多个工具。                             |
+| `tools[].type`                | string           | 工具类型。当前函数调用使用 `function`。                        |
+| `tools[].function`            | object           | 函数工具的具体定义。                                       |
+| `function.name`               | string           | 函数名称。业务代码根据这个名称选择并执行对应函数。建议使用字母、数字和下划线，并保持名称稳定。  |
+| `function.description`        | string           | 函数用途说明。模型会参考它判断什么时候应该调用该函数，因此应写清楚功能和适用场景。        |
+| `function.parameters`         | object           | 使用 JSON Schema 描述函数参数的结构、类型和约束。                  |
+| `parameters.type`             | string           | 参数根节点的类型。函数参数通常是一个 JSON 对象，因此使用 `object`。        |
+| `parameters.properties`       | object           | 定义参数对象中的字段。对象的每个 key 是参数名，对应的 value 描述该参数的类型和含义。 |
+| `properties.city`             | object           | 名为 `city` 的参数定义。这里的名称必须和业务函数实际读取的字段一致。           |
+| `properties.city.type`        | string           | `city` 参数的 JSON 类型。本例中为 `string`。                |
+| `properties.city.description` | string           | 参数说明，用于帮助模型生成正确的参数值。                             |
+| `parameters.required`         | array of string  | 必填参数名称列表。本例中 `city` 必须出现在工具调用参数中。                |
+| `tool_choice`                 | string or object | 控制工具调用策略。常用值包括 `auto`、`none` 和 `required`。       |
+
+`properties` 可以同时定义多个参数。例如，如果天气函数还需要查询温度单位，可以这样扩展：
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "city": {
+      "type": "string",
+      "description": "城市名称，例如：深圳"
+    },
+    "unit": {
+      "type": "string",
+      "enum": ["celsius", "fahrenheit"],
+      "description": "温度单位"
+    }
+  },
+  "required": ["city"]
+}
+```
+
+在这个例子中，`city` 是必填参数，`unit` 是可选参数；`enum` 限制了 `unit` 只能取 `celsius` 或 `fahrenheit`。
+
+`tool_choice` 的常见取值如下：
+
+| 值                                                       | 作用                  |
+|---------------------------------------------------------|---------------------|
+| `"auto"`                                                | 由模型自动决定是否调用工具。      |
+| `"none"`                                                | 禁止调用工具，只允许直接生成文本回复。 |
+| `"required"`                                            | 要求模型调用至少一个工具。       |
+| `{"type":"function","function":{"name":"get_weather"}}` | 强制调用指定名称的函数。        |
+
+### 模型返回工具调用
+
+如果模型决定调用工具，响应中的 `finish_reason` 通常为 `tool_calls`，并在 `message.tool_calls` 中返回函数名和参数。下面是一次真实的 Hy3 响应：
+
+```json
+{
+  "id": "4aec87ee-6f19-4a23-9d9c-97f3480432a3",
+  "object": "chat.completion",
+  "model": "hy3",
+  "created": 1784707500,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+          {
+            "id": "chatcmpl-tool-052c157ea6404545840ed45cc35ee1c9",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"city\": \"深圳\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 208,
+    "completion_tokens": 20,
+    "total_tokens": 228,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    }
+  }
+}
+```
+
+业务代码需要解析 `function.name` 和 `function.arguments`，执行对应函数。这里的 `arguments` 是 JSON 字符串，解析后得到：
+
+```json
+{
+  "city": "深圳"
+}
+```
+
+接下来，业务代码应根据 `function.name` 调用本地实现的 `get_weather` 函数。例如，函数返回以下结果：
+
+```json
+{
+  "city": "深圳",
+  "weather": "晴",
+  "temperature": 28
+}
+```
+
+### 工具调用响应字段说明
+
+| 字段                                | 类型             | 作用                                         |
+|-----------------------------------|----------------|--------------------------------------------|
+| `message.tool_calls`              | array          | 模型请求业务代码执行的工具调用列表。一次响应可能包含多个调用。            |
+| `tool_calls[].id`                 | string         | 当前工具调用的唯一标识。回填工具结果时，必须原样放入 `tool_call_id`。 |
+| `tool_calls[].type`               | string         | 工具调用类型，本例为 `function`。                     |
+| `tool_calls[].function.name`      | string         | 需要执行的函数名称。                                 |
+| `tool_calls[].function.arguments` | string         | 函数参数的 JSON 字符串，需要反序列化后再传给本地函数。             |
+| `message.content`                 | string or null | 工具调用阶段通常为空字符串或 `null`，最终回答阶段才包含自然语言文本。     |
+| `finish_reason`                   | string         | `tool_calls` 表示模型请求调用工具；`stop` 表示模型完成最终回答。 |
+| `role: "tool"`                    | string         | 表示这条消息是工具执行结果，而不是用户或模型消息。                  |
+| `tool_call_id`                    | string         | 将工具结果关联到对应的 `tool_calls[].id`。             |
+| `tool.content`                    | string         | 工具执行结果。通常将结构化结果序列化为 JSON 字符串后传回。           |
+
+### 第二次请求：回填工具结果
+
+工具执行完成后，需要将两类消息回填到下一次请求的 `messages` 中：
+
+1. 模型刚刚返回的 `assistant` 消息，其中必须保留完整的 `tool_calls`。
+2. 工具执行结果，使用 `role: "tool"`，并通过 `tool_call_id` 关联原始工具调用。
+
+假设 `get_weather` 返回深圳天气晴朗、温度 28℃，下一次请求如下：
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "user", "content": "深圳今天天气怎么样？"},
+      {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+          {
+            "id": "chatcmpl-tool-052c157ea6404545840ed45cc35ee1c9",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"city\": \"深圳\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "chatcmpl-tool-052c157ea6404545840ed45cc35ee1c9",
+        "content": "{\"city\":\"深圳\",\"weather\":\"晴\",\"temperature\":28}"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "获取指定城市的当前天气信息",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "city": {
+                "type": "string",
+                "description": "城市名称，例如：深圳"
+              }
+            },
+            "required": ["city"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": false
+  }'
+```
+
+模型收到工具结果后，通常会返回普通的 assistant 消息，例如：
+
+```json
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "深圳当前天气晴朗，温度为 28℃。"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+```
+
+`tool_call_id` 必须与模型返回的 `tool_calls[].id` 完全一致，否则模型无法将工具结果对应到原始调用。模型收到工具结果后，才会生成最终的自然语言回复。
+
+> 当启用思考模式且模型响应中包含 `reasoning_content` 时，后续请求应按 TokenHub 的 Hy3 协议要求保留对应的历史字段。不要自行伪造 `reasoning_content`；如果服务没有返回该字段，就不要在下一轮请求中添加。
+
+### 交错式思考模式（Interleaved Thinking）
+
+[交错式思考模式](https://cloud.tencent.com/document/product/1823/130930)将思考能力与工具调用结合起来：模型可以在生成最终答案前，交替进行多轮思考和工具调用，从而提升复杂 Agent 任务中的执行稳定性和回答质量。
+
+它不需要新地请求格式，仍然使用前文介绍的 `thinking`、`reasoning_effort` 和 `tools` 参数。与普通工具调用相比，模型可能在一次任务中多次调用工具；业务代码需要循环处理每次返回的 `tool_calls`，直到模型返回最终回答。
+
+## 9. 结构化输出
+
+通过 `response_format` 可以约束模型按照指定的 JSON Schema 生成结果，适合信息抽取、结构化数据生成等场景。
+
+```bash
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {
+        "role": "user",
+        "content": "请从以下文本中提取人物信息：张三，35 岁，是一名高级软件工程师，擅长 Python、Java 和机器学习。"
+      }
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "person_info",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "人物姓名"
+            },
+            "age": {
+              "type": "integer",
+              "description": "年龄"
+            },
+            "occupation": {
+              "type": "string",
+              "description": "职业"
+            },
+            "skills": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "技能列表"
+            }
+          },
+          "required": ["name", "age", "occupation", "skills"]
+        }
+      }
+    },
+    "stream": false
+  }'
+```
+
+### 请求字段说明
+
+| 字段                            | 类型              | 作用                          |
+|-------------------------------|-----------------|-----------------------------|
+| `response_format`             | object          | 指定模型输出格式。                   |
+| `response_format.type`        | string          | 输出格式类型。本例使用 `json_schema`。  |
+| `response_format.json_schema` | object          | JSON Schema 配置。             |
+| `json_schema.name`            | string          | Schema 名称，用于标识这套输出结构。       |
+| `json_schema.schema`          | object          | 实际的 JSON Schema。            |
+| `schema.type`                 | string          | 根节点类型。本例为 `object`。         |
+| `schema.properties`           | object          | 定义输出对象中的字段及其类型。             |
+| `schema.required`             | array of string | 必须返回的字段名称列表。                |
+| `properties.skills.type`      | string          | `skills` 是数组，因此类型为 `array`。 |
+| `properties.skills.items`     | object          | 定义数组元素的类型。本例要求每个技能都是字符串。    |
+
+### 响应示例
+
+结构化输出通常仍然位于 `choices[0].message.content` 中，但 `content` 的值是一个 JSON 字符串：
+
+```json
+{
+  "id": "f9a779b0-ba60-433e-9245-5df2e5a47500",
+  "object": "chat.completion",
+  "model": "hy3",
+  "created": 1784710662,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\n  \"age\": 35,\n  \"name\": \"张三\",\n  \"occupation\": \"高级软件工程师\",\n  \"skills\": [\n    \"Python\",\n    \"Java\",\n    \"机器学习\"\n  ]\n}"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 40,
+    "completion_tokens": 47,
+    "total_tokens": 87,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0
+    }
+  }
+}
+```
+
+外层响应字段与普通 Chat Completions 响应相同：
+
+| 字段                           | 类型      | 作用                            |
+|------------------------------|---------|-------------------------------|
+| `id`                         | string  | 本次请求的唯一标识。                    |
+| `object`                     | string  | 响应对象类型，本例为 `chat.completion`。 |
+| `model`                      | string  | 实际使用的模型名称。                    |
+| `created`                    | integer | 响应创建时间，通常为 Unix 时间戳。          |
+| `choices[0].index`           | integer | 当前候选结果的索引，本例为 `0`。            |
+| `choices[0].message.role`    | string  | 返回消息的角色，本例为 `assistant`。      |
+| `choices[0].message.content` | string  | 符合 Schema 的 JSON 字符串，需要再次解析。  |
+| `choices[0].finish_reason`   | string  | 生成结束原因，本例为 `stop`。            |
+| `usage`                      | object  | 本次请求的 Token 使用统计。             |
+
+将 `message.content` 解析后，得到的结构化对象为：
+
+```json
+{
+  "age": 35,
+  "name": "张三",
+  "occupation": "高级软件工程师",
+  "skills": [
+    "Python",
+    "Java",
+    "机器学习"
+  ]
+}
+```
+
+内部字段说明：
+
+| 字段           | 类型              | 作用                  |
+|--------------|-----------------|---------------------|
+| `age`        | integer         | 人物年龄。               |
+| `name`       | string          | 人物姓名。               |
+| `occupation` | string          | 职业名称。               |
+| `skills`     | array of string | 技能列表，数组中的每个元素都是字符串。 |
+
+客户端读取 `message.content` 后，还需要再次进行 JSON 解析：
+
+```python
+import json
+
+person = json.loads(response.choices[0].message.content)
+print(person["name"])
+```
+
+## 10. 请求参数
+
+下面介绍几个最常用地可选请求参数。它们都放在请求体的顶层，与 `model`、`messages` 和 `stream` 同级。
+
+### temperature
+
+- 类型：`number`
+- 是否必填：否
+- 取值范围：`0.0`～`2.0`
+- 默认值：`1.0`
+
+采样温度，用于控制输出的随机性。值越低，回答通常越稳定、越容易复现；值越高，回答通常越灵活，但也可能更发散。
+
+即当同一个问题问很多次时，`temperature` 较低时模型更倾向于给出相似答案；较高时更可能换一种说法或提供不同思路。需要稳定输出时，通常可以从 `0.2` 或 `0.3` 开始尝试。
+
+```shell
+curl -X POST "https://tokenhub.tencentmaas.com/v1/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [
+      {"role": "system", "content": "你是一个有帮助的助手。"},
+      {"role": "user", "content": "用一句话介绍深圳。"}
+    ],
+    "temperature": 0.2,
+    "stream": false
+  }'
+```
+
+### top_p
+
+- 类型：`number`
+- 是否必填：否
+- 取值范围：`0.0`～`1.0`
+- 默认值：`1.0`
+
+核采样（Nucleus Sampling）阈值，用于限制模型每一步生成时可以考虑的候选词范围。
+
+即模型每次生成下一个词时，可能有很多候选词。`top_p` 会优先保留累计概率达到该阈值的候选词，值越小，候选范围通常越窄，输出也可能越集中；值为 `1.0` 时不额外缩小候选范围。
+
+通常建议只调整 `temperature` 或 `top_p` 其中一个，不要同时调得很激进。
+
+### max_tokens
+
+- 类型：`integer`
+- 是否必填：否
+
+限制单次请求允许生成的最大 Token 数。Token 是模型处理文本时使用的基本单位，不完全等同于汉字或单词；这个值越大，模型可生成的内容上限越高，但也可能消耗更多额度。
+
+对于启用思考模式的请求，推理 Token 和最终回答 Token 会共同占用该上限。如果设置过小，模型可能还没有完成思考或回答就提前结束，因此应根据任务复杂度适当调大。
+
+示例：限制模型最多输出约 256 个 Token：
+
+```json
+{
+  "model": "hy3",
+  "messages": [{"role": "user", "content": "用三句话介绍深圳。"}],
+  "max_tokens": 256
+}
+```
+
+### stop
+
+- 类型：`string` 或 `array of string`
+- 是否必填：否
+- 数量限制：数组最多包含 4 个停止序列
+
+指定一个或多个“遇到后就停止生成”的字符串。模型生成的内容一旦匹配到停止序列，就会立即结束本次生成，并且通常不会把停止序列本身放进返回内容中。
+
+`stop` 就像给模型设置一个“看到这个标记就停笔”的信号。它不是要求模型必须输出这个字符串，而是告诉模型：如果输出过程中遇到了它，就不要继续写。
+
+例如，要求模型输出多行内容，并在遇到 `END` 时停止：
+
+```json
+{
+  "model": "hy3",
+  "messages": [{
+    "role": "user",
+    "content": "列出三个水果，每行一个。输出完后写 END。"
+  }],
+  "stop": ["END"]
+}
+```
+
+也可以只传入一个字符串：
+
+```json
+"stop": "END"
+```
+
+如果模型生成到 `END`，客户端通常只会收到此前的水果列表，不会收到 `END` 及其后面的内容。需要注意，`stop` 只控制生成何时停止，不能保证模型一定按照提示生成指定格式。
+
+> 其他请求参数如 `n`, `seed` 等可以参考[请求参数](https://cloud.tencent.com/document/product/1823/130079#0f2eb282-746e-4e00-b6db-bb147bedbc77)
+
+## 11. 常见错误与排查
+Chat Completions（`/v1/chat/completions`）和 Responses（`/v1/responses`）协议的错误通常返回以下结构。
+
+### 错误结构
+```json
+{
+  "error": {
+    "message": "<英文错误描述>",
+    "message_zh": "<中文错误描述>",
+    "code": "<业务错误码>",
+    "type": "<错误类型>",
+    "source": "client | gateway | upstream",
+    "upstream_code": "<上游错误码，仅上游错误时返回>",
+    "upstream_status": 502,
+    "request_id": "<请求唯一标识>"
+  }
+}
+```
+### 错误字段说明
+
+| 字段                      | 类型               | 作用                                                              |
+|-------------------------|------------------|-----------------------------------------------------------------|
+| `error.message`         | string           | 英文错误描述，适合记录到日志。                                                 |
+| `error.message_zh`      | string           | 中文错误描述，适合直接展示给中文用户。                                             |
+| `error.code`            | string 或 integer | TokenHub 业务错误码，用于精确定位问题；限流场景下可能返回数字。                            |
+| `error.type`            | string           | 错误类型；鉴权和参数校验等网关拦截错误通常为 `gateway_error`。                         |
+| `error.source`          | string           | 错误来源：`client`（请求端）、`gateway`（网关）或 `upstream`（上游服务）；部分错误不会返回该字段。 |
+| `error.upstream_code`   | string           | 上游服务原始错误码，仅在 `source` 为 `upstream` 时出现。                         |
+| `error.upstream_status` | integer          | 上游服务 HTTP 状态码，仅在上游错误时出现。                                        |
+| `error.request_id`      | string           | 本次请求的唯一标识。联系服务方或提交工单时应一并提供。                                     |
+
+### 常见 HTTP 状态码
+
+| HTTP 状态码                | 常见错误码                               | 常见原因和处理方式                                                          |
+|-------------------------|-------------------------------------|--------------------------------------------------------------------|
+| `400`                   | `400001`、`400002`                   | 请求体格式错误、必填字段缺失或参数取值无效。检查 `model`、`messages` 及参数范围。                 |
+| `400`                   | `400003`                            | 输入 Token 超出模型上下文限制。缩短输入、减少历史消息或调整请求内容。                             |
+| `400`                   | `400004`、`401006`                   | 模型或服务 ID 不存在，或模型与服务不匹配。确认 `model` 使用正确的服务 ID。                      |
+| `400`                   | `400005`、`400006`                   | 当前模型不支持请求的协议、能力或 `response_format`。查看支持范围后调整请求。                    |
+| `401`                   | `401001`～`401004`                   | 未携带认证信息、API Key 错误、过期或被禁用。检查 `Authorization: Bearer ...` 和 Key 状态。 |
+| `403`                   | `403001`～`403006`                   | 套餐、模型、账号、IP 白名单或工具权限不足。检查 API Key 和服务权限。                           |
+| `413`                   | `413001`                            | 请求体过大。减少消息、工具定义或其他请求内容。                                            |
+| `429`                   | `429001`～`429005`                   | 超过请求频率、RPM、TPM、TPD 或并发限制。降低频率或并发量。                                 |
+| `429`                   | `429006`                            | 模型服务繁忙或达到服务容量上限。等待后再重试。                                            |
+| `451`                   | `451001`                            | 输入或输出内容触发安全策略，需要调整请求内容。                                            |
+| `500`、`502`、`503`、`504` | `500001`、`502001`、`503001`、`504001` | 平台内部错误、上游异常、服务暂不可用或网关超时。可重试；持续失败时提供 `request_id` 排查。               |
+
+限流响应还可能包含 `Retry-After` 响应头，单位为秒。客户端应同时兼容字符串和数字两种 `error.code` 类型，并优先按照 `Retry-After` 等待后再重试。
+
+### 模型服务繁忙或达到容量上限
+
+当模型服务当前繁忙，或已达到服务容量上限时，网关可能返回 HTTP `429`。实际遇到的响应如下：
+
+```json
+{
+  "error": {
+    "type": "rate_limit_error",
+    "code": "429006",
+    "message": "The model service is currently busy or has reached its serving capacity limit. Please reduce the request frequency and try again later.",
+    "message_zh": "当前模型服务繁忙或已达服务容量上限，请降低请求频率后稍后重试。",
+    "source": "gateway",
+    "request_id": "57b8d6ff-03dd-45a0-8d8e-5eebba3e0470"
+  }
+}
+```
+
+处理建议：
+
+1. 降低请求频率，避免立即连续重试。
+2. 等待一段时间后再发起请求。
+3. 在客户端实现带指数退避和随机抖动的重试策略。
+4. 检查当前地域、API Key、套餐及模型广场中的 RPM/TPM 限制。
+5. 如果持续出现，记录 `request_id`、请求时间和模型名，并联系服务方排查。
+
+该错误通常不表示请求 JSON 格式错误；修改 `messages` 或 `response_format` 一般不能直接解决服务容量不足问题。
+
+更完整的错误码、协议差异和错误响应示例，请参考腾讯云官方文档：[TokenHub API 错误码说明](https://cloud.tencent.com/document/product/1823/131595)。
+
+## 示例与进一步实践
+
+本文中的 curl 示例用于快速理解请求和响应格式；如果需要运行完整的 Python 代码，请阅读 [`examples/README_cn.md`](examples/README_cn.md)。示例目录提供统一的环境变量配置、运行命令和输出说明，每个 Python 文件都有对应的中文 Markdown 文档。
+
+从以下示例开始，可以逐步验证不同 API 能力：
+
+| 场景              | 示例                                                                                | 说明                                        |
+|-----------------|-----------------------------------------------------------------------------------|-------------------------------------------|
+| 基础对话            | [`01_basic_chat.py`](examples/01_basic_chat.py)                                   | 使用 Chat Completions API 完成最小文本调用。         |
+| 流式输出            | [`02_streaming.py`](examples/02_streaming.py)                                     | 逐个读取 Chat Completions 流式 chunk，并获取 usage。 |
+| 流式对比            | [`03_streaming_vs_non_streaming.py`](examples/03_streaming_vs_non_streaming.py)   | 对比首 chunk 延迟和完整响应耗时。                      |
+| Chat 工具调用       | [`04_tool_calling.py`](examples/04_tool_calling.py)                               | 声明函数工具、执行本地函数并回传工具结果。                     |
+| Chat 推理模式       | [`05_reasoning_mode.py`](examples/05_reasoning_mode.py)                           | 对比普通模式与推理模式的响应。                           |
+| Responses 基础调用  | [`06_responses_basic.py`](examples/06_responses_basic.py)                         | 使用 Responses API 并读取 `output_text`。       |
+| Responses 流式输出  | [`07_responses_streaming.py`](examples/07_responses_streaming.py)                 | 解析 Responses API 的 SSE 事件。                |
+| Responses 工具调用  | [`08_responses_tool_calling.py`](examples/08_responses_tool_calling.py)           | 回传 `function_call_output` 并获取最终回答。        |
+| Responses 结构化输出 | [`09_responses_structured_output.py`](examples/09_responses_structured_output.py) | 使用 JSON Schema 约束输出并解析 JSON。              |
+| 错误处理与重试         | [`10_error_handling_retry.py`](examples/10_error_handling_retry.py)               | 处理超时、网络错误、限流和服务端错误。                       |
+
+从仓库根目录运行示例：
+
+```bash
+uv run --env-file .env python examples/01_basic_chat.py
+```
+
+示例输出会受到模型版本、随机采样、网络延迟和服务负载影响。示例中的天气函数只返回演示数据，不会访问真实天气服务。
+
+## 参考资料
+
+- [TokenHub 快速入门](https://cloud.tencent.com/document/product/1823/130058)：介绍 TokenHub 控制台和基础使用流程。
+- [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)：介绍接口域名、鉴权方式、模型列表和异常处理。
+- [TokenHub 语言模型调用概览](https://cloud.tencent.com/document/product/1823/130079)：介绍公共请求参数、响应字段、工具调用和流式输出。
+- [Hy3 调用指南](https://cloud.tencent.com/document/product/1823/132252)：介绍 Hy3 的模型限制、协议支持和专用调用方式。
+- [TokenHub 深度思考](https://cloud.tencent.com/document/product/1823/131208)：介绍 `thinking`、`reasoning_effort` 和推理模式相关参数。
+- [TokenHub API 错误码说明](https://cloud.tencent.com/document/product/1823/131595)：介绍 HTTP 状态码、业务错误码和错误排查方式。
+- [TokenHub Responses API 兼容模式说明](https://cloud.tencent.com/document/product/1823/133813)：介绍 Responses API 的参数支持范围、输入输出结构和兼容性限制。
+- [词汇表](https://cloud.tencent.com/document/product/1823/130120#2897)：解释 TokenHub 文档中的常用术语。
+
+参数是否支持以及具体行为，不能只根据单次响应推断。接入其他模型或更换地域后，应结合模型广场、官方文档和实际接口响应重新验证。

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,261 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hy3"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "openai" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "openai", specifier = ">=2.46.0" }]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## 概述

本 PR 为通过腾讯云 TokenHub API 使用 Hy3 模型补充完整的文档和可运行示例。

## 主要变更

- 添加中英文快速开始文档。
- 补充 Chat Completions API 使用说明。
- 补充 Responses API 使用说明。
- 添加以下示例：
  - 基础请求
  - 流式输出
  - 工具调用
  - 思考模式
  - 结构化输出
  - 错误处理与重试
- 为 Python 示例添加中英文注释及输出说明。
- 添加相关腾讯云 API 文档链接。

## 验证

- 使用 `py_compile` 验证 Python 示例的语法。
- 检查 Markdown 文档格式及链接。
- 补充实际 API 响应示例，并解释返回字段的作用。

## 关联 Issue

#1 
---
## Summary

This PR adds comprehensive documentation and runnable examples for using Hy3 through Tencent Cloud TokenHub APIs.

## Changes

- Add Chinese and English quickstart documentation.
- Document Chat Completions API usage.
- Document Responses API usage.
- Add examples for:
  - Basic requests
  - Streaming responses
  - Tool calling
  - Reasoning mode
  - Structured output
  - Error handling and retries
- Add bilingual comments and output explanations to the Python examples.
- Include links to the relevant Tencent Cloud API documentation.

## Validation

- Verified the Python examples with `py_compile`.
- Checked Markdown formatting and links.
- Included representative API responses and explanations for the returned fields.

## Related Issue
#1 