### PR TITLE
Add Hy3 API quickstart & examples  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,24 @@
 Thumbs.db
 __pycache__/
 *.pyc
+
+# Local API example environments and test artifacts
+.env
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Local task notes and tooling (not part of Issue #1 deliverables)
+.codemap/
+myTODO.md
+CHANGELOG.md
+
+# Local validation assets (not part of Issue #1 deliverables)
+examples/api/TESTING.md
+examples/api/tests/
+examples/api/requirements-dev.txt
+examples/api/pyproject.toml
+examples/api/Dockerfile.test
+examples/api/.dockerignore

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Model usefulness is not fully captured by benchmarks. Based on extensive product
 
 ## Quickstart
 
+For a hosted/local API walkthrough and six runnable examples, see
+[Hy3 API Quickstart](quickstart.md) and [`examples/api`](examples/api/README.md).
+
 Deploy Hy3 with [vLLM](#vllm) or [SGLang](#sglang) first, then call the OpenAI-compatible API:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -111,10 +111,14 @@ Model usefulness is not fully captured by benchmarks. Based on extensive product
 
 ## Quickstart
 
-For a hosted/local API walkthrough and six runnable examples, see
-[Hy3 API Quickstart](quickstart.md) and [`examples/api`](examples/api/README.md).
+Hy3 supports two API access modes: call the TokenHub hosted API directly, or
+deploy the model with [vLLM](#vllm) / [SGLang](#sglang) and call the
+self-hosted OpenAI-compatible API. For request parameters, client usage, and
+six runnable examples, see [Hy3 API Quickstart](quickstart.md) and
+[`examples/api`](examples/api/README.md). For model serving instructions, see
+[Deployment](#deployment) below.
 
-Deploy Hy3 with [vLLM](#vllm) or [SGLang](#sglang) first, then call the OpenAI-compatible API:
+The following code calls an already deployed local service:
 
 ```python
 from openai import OpenAI
@@ -137,8 +141,6 @@ print(response.choices[0].message.content)
 > **Recommended parameters**: `temperature=0.9`, `top_p=1.0`.
 >
 > **Reasoning mode**: Set `reasoning_effort` to `"high"` for complex tasks (math, coding, reasoning) or `"no_think"` for direct responses.
-
-See the [Deployment](#deployment) section below for how to start the API server.
 
 ## Deployment
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -108,6 +108,9 @@ Hy3 在软件开发、办公生产、金融建模、前端设计、游戏制作�
 
 ## 快速开始
 
+如需五分钟完成云端/本地 API 调用并学习六个可运行示例，请参阅
+[Hy3 API 中文快速开始](quickstart_CN.md) 和 [`examples/api`](examples/api/README.md)。
+
 建议先通过 [vLLM](#使用-vllm-推理) 或 [SGLang](#使用-sglang-推理) 部署服务，然后通过 OpenAI 兼容 API 调用：
 
 ```python

--- a/README_CN.md
+++ b/README_CN.md
@@ -108,10 +108,14 @@ Hy3 在软件开发、办公生产、金融建模、前端设计、游戏制作�
 
 ## 快速开始
 
-如需五分钟完成云端/本地 API 调用并学习六个可运行示例，请参阅
-[Hy3 API 中文快速开始](quickstart_CN.md) 和 [`examples/api`](examples/api/README.md)。
+Hy3 支持两种 API 接入方式：直接调用 TokenHub 托管 API，或先通过
+[vLLM](#使用-vllm-推理) / [SGLang](#使用-sglang-推理) 部署模型，再调用自托管的
+OpenAI 兼容 API。请求参数、客户端调用方式和六个可运行示例请参阅
+[Hy3 API 中文快速开始](quickstart_CN.md) 和
+[`examples/api`](examples/api/README_CN.md)；
+模型部署步骤请参阅下方[推理和部署](#推理和部署)章节。
 
-建议先通过 [vLLM](#使用-vllm-推理) 或 [SGLang](#使用-sglang-推理) 部署服务，然后通过 OpenAI 兼容 API 调用：
+以下代码演示如何调用已经部署的本地服务：
 
 ```python
 from openai import OpenAI
@@ -134,8 +138,6 @@ print(response.choices[0].message.content)
 > **推荐参数**：`temperature=0.9`，`top_p=1.0`。
 >
 > **推理模式**：复杂任务（数学、编程、推理）建议设置 `reasoning_effort="high"`，日常对话可使用默认的 `"no_think"` 直接回复。
-
-具体部署方式请参考下方[推理和部署](#推理和部署)章节。
 
 ## 推理和部署
 

--- a/examples/api/.env.example
+++ b/examples/api/.env.example
@@ -1,0 +1,12 @@
+# tokenhub: Tencent Cloud hosted API; self_hosted: local vLLM/SGLang
+HY3_API_MODE=tokenhub
+HY3_BASE_URL=https://tokenhub.tencentmaas.com/v1
+HY3_API_KEY=replace-with-your-tokenhub-api-key
+HY3_MODEL=hy3
+HY3_TIMEOUT=60
+HY3_MAX_RETRIES=2
+
+# Self-hosted alternative:
+# HY3_API_MODE=self_hosted
+# HY3_BASE_URL=http://127.0.0.1:8000/v1
+# HY3_API_KEY=EMPTY

--- a/examples/api/01_basic_chat.md
+++ b/examples/api/01_basic_chat.md
@@ -1,23 +1,29 @@
-# 01｜基础对话：单轮与多轮
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./01_basic_chat_CN.md">Chinese</a>
+</p>
 
-完整程序：[01_basic_chat.py](01_basic_chat.py)
+# 01 | Basic Chat: Single-Turn and Multi-Turn
 
-## 请求流程
+Complete program: [01_basic_chat.py](01_basic_chat.py)
 
-单轮请求只包含一条 user 消息。脚本发送 `model`、`messages`、采样参数和
-`max_tokens`，然后解析 `response.id`、第一条 choice、`finish_reason`、assistant
-正文和 usage。
+## Request Flow
 
-多轮对话并不是服务端自动保存会话。第二次请求必须按顺序包含：system 指令、
-第一条 user、第一条 assistant、第二条 user。遗漏 assistant 历史会让模型失去
-上一轮回答；历史不断增长时，应在业务侧控制上下文长度。
+A single-turn request contains one user message. The script sends `model`,
+`messages`, sampling parameters, and `max_tokens`, then reads `response.id`, the
+first choice, `finish_reason`, the assistant content, and usage.
 
-核心请求和解析：
+The server does not automatically preserve a multi-turn conversation. The
+second request must contain, in order, the system instruction, first user
+message, first assistant response, and second user message. Omitting the
+assistant history removes context from the previous turn. Applications should
+also control context growth as the conversation becomes longer.
+
+Core request and response parsing:
 
 ```python
 response = client.chat.completions.create(
     model=settings.model,
-    messages=[{"role": "user", "content": "用三句话介绍 Hy3。"}],
+    messages=[{"role": "user", "content": "Introduce Hy3 in three sentences."}],
     temperature=0.9,
     top_p=1.0,
     max_tokens=256,
@@ -28,28 +34,30 @@ print(choice.finish_reason)
 print(response.usage.total_tokens if response.usage else "no usage")
 ```
 
-## 响应字段
+## Response Fields
 
-- `choices[0].message.content`：最终文本。
-- `finish_reason=stop`：自然或 stop 条件结束。
-- `finish_reason=length`：达到输出预算，答案可能不完整。
-- `usage`：输入、输出和总 Token 数；兼容服务可以不返回该字段。
+- `choices[0].message.content`: Final text.
+- `finish_reason=stop`: Generation ended naturally or matched a stop condition.
+- `finish_reason=length`: The output budget was reached and the answer may be
+  incomplete.
+- `usage`: Input, output, and total token counts. Compatible services may omit
+  this field.
 
-## 输出示例
+## Example Output
 
-以下只展示格式，内容与 Token 数以运行结果为准：
+The following shows only the output structure. Content and token counts vary:
 
 ```text
 === Single-turn chat ===
 id: chatcmpl-REDACTED
 finish_reason: stop
-assistant: Hy3 是……
+assistant: Hy3 is...
 usage: prompt=18, completion=72, total=90
 
 === Multi-turn chat ===
-assistant[1]: 列表推导式……
-assistant[2]: 可以写成 [x for x in values if x % 2 == 0]。
+assistant[1]: A list comprehension...
+assistant[2]: You can write [x for x in values if x % 2 == 0].
 usage: prompt=96, completion=35, total=131
 ```
 
-运行：`python 01_basic_chat.py`。
+Run with `python 01_basic_chat.py`.

--- a/examples/api/01_basic_chat.md
+++ b/examples/api/01_basic_chat.md
@@ -1,0 +1,55 @@
+# 01｜基础对话：单轮与多轮
+
+完整程序：[01_basic_chat.py](01_basic_chat.py)
+
+## 请求流程
+
+单轮请求只包含一条 user 消息。脚本发送 `model`、`messages`、采样参数和
+`max_tokens`，然后解析 `response.id`、第一条 choice、`finish_reason`、assistant
+正文和 usage。
+
+多轮对话并不是服务端自动保存会话。第二次请求必须按顺序包含：system 指令、
+第一条 user、第一条 assistant、第二条 user。遗漏 assistant 历史会让模型失去
+上一轮回答；历史不断增长时，应在业务侧控制上下文长度。
+
+核心请求和解析：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": "用三句话介绍 Hy3。"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+)
+choice = response.choices[0]
+print(choice.message.content)
+print(choice.finish_reason)
+print(response.usage.total_tokens if response.usage else "no usage")
+```
+
+## 响应字段
+
+- `choices[0].message.content`：最终文本。
+- `finish_reason=stop`：自然或 stop 条件结束。
+- `finish_reason=length`：达到输出预算，答案可能不完整。
+- `usage`：输入、输出和总 Token 数；兼容服务可以不返回该字段。
+
+## 输出示例
+
+以下只展示格式，内容与 Token 数以运行结果为准：
+
+```text
+=== Single-turn chat ===
+id: chatcmpl-REDACTED
+finish_reason: stop
+assistant: Hy3 是……
+usage: prompt=18, completion=72, total=90
+
+=== Multi-turn chat ===
+assistant[1]: 列表推导式……
+assistant[2]: 可以写成 [x for x in values if x % 2 == 0]。
+usage: prompt=96, completion=35, total=131
+```
+
+运行：`python 01_basic_chat.py`。

--- a/examples/api/01_basic_chat.py
+++ b/examples/api/01_basic_chat.py
@@ -1,0 +1,59 @@
+"""Hy3 basic chat: one turn, multiple turns, and response parsing."""
+
+from common import configure_utf8_output, load_settings, make_client, print_usage
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    client = make_client(settings)
+
+    print("=== Single-turn chat ===")
+    response = client.chat.completions.create(
+        model=settings.model,
+        messages=[{"role": "user", "content": "用三句话介绍 Hy3。"}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=256,
+    )
+    choice = response.choices[0]
+    print(f"id: {response.id}")
+    print(f"finish_reason: {choice.finish_reason}")
+    print(f"assistant: {choice.message.content}")
+    print_usage(response.usage)
+
+    print("\n=== Multi-turn chat ===")
+    messages = [
+        {"role": "system", "content": "你是一位简洁的 Python 助教。"},
+        {"role": "user", "content": "列表推导式是什么？请给一个例子。"},
+    ]
+    first = client.chat.completions.create(
+        model=settings.model,
+        messages=messages,
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=256,
+    )
+    first_text = first.choices[0].message.content or ""
+    print(f"assistant[1]: {first_text}")
+
+    # The API is stateless: append both sides of the previous turn explicitly.
+    messages.extend(
+        [
+            {"role": "assistant", "content": first_text},
+            {"role": "user", "content": "把例子改成只保留偶数。"},
+        ]
+    )
+    second = client.chat.completions.create(
+        model=settings.model,
+        messages=messages,
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=256,
+    )
+    print(f"assistant[2]: {second.choices[0].message.content}")
+    print_usage(second.usage)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/01_basic_chat_CN.md
+++ b/examples/api/01_basic_chat_CN.md
@@ -1,0 +1,59 @@
+<p align="left">
+  <a href="./01_basic_chat.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 01｜基础对话：单轮与多轮
+
+完整程序：[01_basic_chat.py](01_basic_chat.py)
+
+## 请求流程
+
+单轮请求只包含一条 user 消息。脚本发送 `model`、`messages`、采样参数和
+`max_tokens`，然后解析 `response.id`、第一条 choice、`finish_reason`、assistant
+正文和 usage。
+
+多轮对话并不是服务端自动保存会话。第二次请求必须按顺序包含：system 指令、
+第一条 user、第一条 assistant、第二条 user。遗漏 assistant 历史会让模型失去
+上一轮回答；历史不断增长时，应在业务侧控制上下文长度。
+
+核心请求和解析：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": "用三句话介绍 Hy3。"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=256,
+)
+choice = response.choices[0]
+print(choice.message.content)
+print(choice.finish_reason)
+print(response.usage.total_tokens if response.usage else "no usage")
+```
+
+## 响应字段
+
+- `choices[0].message.content`：最终文本。
+- `finish_reason=stop`：自然或 stop 条件结束。
+- `finish_reason=length`：达到输出预算，答案可能不完整。
+- `usage`：输入、输出和总 Token 数；兼容服务可以不返回该字段。
+
+## 输出示例
+
+以下只展示格式，内容与 Token 数以运行结果为准：
+
+```text
+=== Single-turn chat ===
+id: chatcmpl-REDACTED
+finish_reason: stop
+assistant: Hy3 是……
+usage: prompt=18, completion=72, total=90
+
+=== Multi-turn chat ===
+assistant[1]: 列表推导式……
+assistant[2]: 可以写成 [x for x in values if x % 2 == 0]。
+usage: prompt=96, completion=35, total=131
+```
+
+运行：`python 01_basic_chat.py`。

--- a/examples/api/02_streaming.md
+++ b/examples/api/02_streaming.md
@@ -1,23 +1,28 @@
-# 02｜流式请求与逐 chunk 解析
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./02_streaming_CN.md">Chinese</a>
+</p>
 
-完整程序：[02_streaming.py](02_streaming.py)
+# 02 | Streaming Requests and Per-Chunk Parsing
 
-## 请求与解析
+Complete program: [02_streaming.py](02_streaming.py)
 
-流式请求设置 `stream=True`，返回的是可迭代事件流，不是一个完整 response。
-每个 chunk 可能只携带 role、正文的一小段、思考增量、结束原因或 usage；不能假设
-每个 chunk 都有 choice 或 content。
+## Request and Parsing
+
+A streaming request sets `stream=True` and returns an iterable event stream,
+not one complete response. A chunk may contain only a role, a small content
+delta, a reasoning delta, a finish reason, or usage. Do not assume that every
+chunk contains a choice or content.
 
 ```python
 stream = client.chat.completions.create(
     model=settings.model,
-    messages=[{"role": "user", "content": "解释流式输出。"}],
+    messages=[{"role": "user", "content": "Explain streaming output."}],
     stream=True,
     stream_options={"include_usage": True},
 )
 parts = []
 for chunk in stream:
-    if not chunk.choices:  # 最后的 usage-only chunk 可能走这里
+    if not chunk.choices:  # The final usage-only chunk may enter here.
         continue
     delta = chunk.choices[0].delta
     if delta.content:
@@ -26,14 +31,15 @@ for chunk in stream:
 full_text = "".join(parts)
 ```
 
-程序同时独立累积 `reasoning_content`，但默认不打印完整推理内容。工具调用的
-arguments 也可能跨多个 chunk 到达；生产实现必须按 tool-call index/id 累积，不能
-对单个片段直接做 `json.loads`。
+The program accumulates `reasoning_content` separately but does not print
+complete reasoning by default. Tool-call arguments can also span multiple
+chunks. Production code must accumulate them by tool-call index or ID instead
+of calling `json.loads` on an individual fragment.
 
-## 输出示例
+## Example Output
 
 ```text
-assistant: 流式输出让用户在完整答案生成前就能看到内容……
+assistant: Streaming lets users see content before the complete answer...
 
 === Aggregated result ===
 content_chars: 168
@@ -42,5 +48,7 @@ finish_reason: stop
 total_tokens: 102
 ```
 
-如果服务没有实现 `stream_options.include_usage`，脚本会明确提示 usage 缺失，正文
-仍可正常解析。运行：`python 02_streaming.py`。
+If the service does not implement `stream_options.include_usage`, the script
+reports that usage is missing while still parsing the content normally.
+
+Run with `python 02_streaming.py`.

--- a/examples/api/02_streaming.md
+++ b/examples/api/02_streaming.md
@@ -1,0 +1,46 @@
+# 02｜流式请求与逐 chunk 解析
+
+完整程序：[02_streaming.py](02_streaming.py)
+
+## 请求与解析
+
+流式请求设置 `stream=True`，返回的是可迭代事件流，不是一个完整 response。
+每个 chunk 可能只携带 role、正文的一小段、思考增量、结束原因或 usage；不能假设
+每个 chunk 都有 choice 或 content。
+
+```python
+stream = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": "解释流式输出。"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
+parts = []
+for chunk in stream:
+    if not chunk.choices:  # 最后的 usage-only chunk 可能走这里
+        continue
+    delta = chunk.choices[0].delta
+    if delta.content:
+        parts.append(delta.content)
+        print(delta.content, end="", flush=True)
+full_text = "".join(parts)
+```
+
+程序同时独立累积 `reasoning_content`，但默认不打印完整推理内容。工具调用的
+arguments 也可能跨多个 chunk 到达；生产实现必须按 tool-call index/id 累积，不能
+对单个片段直接做 `json.loads`。
+
+## 输出示例
+
+```text
+assistant: 流式输出让用户在完整答案生成前就能看到内容……
+
+=== Aggregated result ===
+content_chars: 168
+reasoning_chars: 0
+finish_reason: stop
+total_tokens: 102
+```
+
+如果服务没有实现 `stream_options.include_usage`，脚本会明确提示 usage 缺失，正文
+仍可正常解析。运行：`python 02_streaming.py`。

--- a/examples/api/02_streaming.py
+++ b/examples/api/02_streaming.py
@@ -1,0 +1,58 @@
+"""Hy3 streaming chat with per-chunk parsing and final aggregation."""
+
+from common import configure_utf8_output, extra_field, load_settings, make_client
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    client = make_client(settings)
+    stream = client.chat.completions.create(
+        model=settings.model,
+        messages=[{"role": "user", "content": "解释为什么流式输出能改善用户体验。"}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=600,
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    finish_reason = None
+    usage = None
+
+    print("assistant: ", end="", flush=True)
+    for chunk in stream:
+        if chunk.usage is not None:
+            usage = chunk.usage
+        if not chunk.choices:
+            continue
+
+        choice = chunk.choices[0]
+        finish_reason = choice.finish_reason or finish_reason
+        delta = choice.delta
+        reasoning = extra_field(delta, "reasoning_content", "") or ""
+        if reasoning:
+            reasoning_parts.append(reasoning)
+        if delta.content:
+            content_parts.append(delta.content)
+            print(delta.content, end="", flush=True)
+
+        # Uncomment this line to inspect every raw protocol chunk.
+        # print(f"\nchunk={chunk.model_dump_json()}")
+
+    full_content = "".join(content_parts)
+    full_reasoning = "".join(reasoning_parts)
+    print("\n\n=== Aggregated result ===")
+    print(f"content_chars: {len(full_content)}")
+    print(f"reasoning_chars: {len(full_reasoning)}")
+    print(f"finish_reason: {finish_reason}")
+    if usage:
+        print(f"total_tokens: {usage.total_tokens}")
+    else:
+        print("usage: server did not include usage in the final chunk")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/02_streaming_CN.md
+++ b/examples/api/02_streaming_CN.md
@@ -1,0 +1,50 @@
+<p align="left">
+  <a href="./02_streaming.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 02｜流式请求与逐 chunk 解析
+
+完整程序：[02_streaming.py](02_streaming.py)
+
+## 请求与解析
+
+流式请求设置 `stream=True`，返回的是可迭代事件流，不是一个完整 response。
+每个 chunk 可能只携带 role、正文的一小段、思考增量、结束原因或 usage；不能假设
+每个 chunk 都有 choice 或 content。
+
+```python
+stream = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": "解释流式输出。"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
+parts = []
+for chunk in stream:
+    if not chunk.choices:  # 最后的 usage-only chunk 可能走这里
+        continue
+    delta = chunk.choices[0].delta
+    if delta.content:
+        parts.append(delta.content)
+        print(delta.content, end="", flush=True)
+full_text = "".join(parts)
+```
+
+程序同时独立累积 `reasoning_content`，但默认不打印完整推理内容。工具调用的
+arguments 也可能跨多个 chunk 到达；生产实现必须按 tool-call index/id 累积，不能
+对单个片段直接做 `json.loads`。
+
+## 输出示例
+
+```text
+assistant: 流式输出让用户在完整答案生成前就能看到内容……
+
+=== Aggregated result ===
+content_chars: 168
+reasoning_chars: 0
+finish_reason: stop
+total_tokens: 102
+```
+
+如果服务没有实现 `stream_options.include_usage`，脚本会明确提示 usage 缺失，正文
+仍可正常解析。运行：`python 02_streaming.py`。

--- a/examples/api/03_streaming_vs_non_streaming.md
+++ b/examples/api/03_streaming_vs_non_streaming.md
@@ -1,0 +1,43 @@
+# 03｜非流式与流式时延对比
+
+完整程序：[03_streaming_vs_non_streaming.py](03_streaming_vs_non_streaming.py)
+
+## 指标定义
+
+- **非流式总耗时**：发送请求到完整 response 返回。
+- **流式 TTFT**：发送请求到收到第一个非空可见 `delta.content`。这不是 TCP 首字节
+  时间，也不是第一个只有 role/思考内容的 chunk。
+- **流式总耗时**：发送请求到流迭代结束。
+
+测量使用单调高精度时钟 `time.perf_counter()`：
+
+```python
+started = perf_counter()
+stream = client.chat.completions.create(..., stream=True)
+first_content_at = None
+for chunk in stream:
+    content = chunk.choices[0].delta.content if chunk.choices else None
+    if content and first_content_at is None:
+        first_content_at = perf_counter()
+total = perf_counter() - started
+ttft = first_content_at - started
+```
+
+## 正确解读
+
+脚本的一次运行只是演示测量方法，不是性能基准。两次请求可能生成不同长度内容，
+还会受到冷启动、排队、网络、缓存和服务负载影响。正式比较至少应预热，固定地域
+和参数，交替执行多轮，并报告中位数及 P95。
+
+```text
+=== Latency comparison (one sample, not a benchmark) ===
+non-streaming total: 2.841s
+streaming TTFT: 0.612s
+streaming total: 3.104s
+non-streaming chars: 174
+streaming chars: 181
+Run multiple warm samples before drawing performance conclusions.
+```
+
+流式的价值通常是更早显示内容，而不保证总耗时更短。运行：
+`python 03_streaming_vs_non_streaming.py`。

--- a/examples/api/03_streaming_vs_non_streaming.md
+++ b/examples/api/03_streaming_vs_non_streaming.md
@@ -1,15 +1,23 @@
-# 03｜非流式与流式时延对比
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./03_streaming_vs_non_streaming_CN.md">Chinese</a>
+</p>
 
-完整程序：[03_streaming_vs_non_streaming.py](03_streaming_vs_non_streaming.py)
+# 03 | Streaming vs. Non-Streaming Latency
 
-## 指标定义
+Complete program:
+[03_streaming_vs_non_streaming.py](03_streaming_vs_non_streaming.py)
 
-- **非流式总耗时**：发送请求到完整 response 返回。
-- **流式 TTFT**：发送请求到收到第一个非空可见 `delta.content`。这不是 TCP 首字节
-  时间，也不是第一个只有 role/思考内容的 chunk。
-- **流式总耗时**：发送请求到流迭代结束。
+## Metric Definitions
 
-测量使用单调高精度时钟 `time.perf_counter()`：
+- **Non-streaming total latency**: Time from sending the request until the
+  complete response is returned.
+- **Streaming TTFT**: Time from sending the request until the first non-empty,
+  visible `delta.content`. This is not TCP time to first byte or a chunk that
+  contains only a role or reasoning.
+- **Streaming total latency**: Time from sending the request until stream
+  iteration finishes.
+
+The measurement uses the monotonic high-resolution `time.perf_counter()` clock:
 
 ```python
 started = perf_counter()
@@ -23,11 +31,13 @@ total = perf_counter() - started
 ttft = first_content_at - started
 ```
 
-## 正确解读
+## Correct Interpretation
 
-脚本的一次运行只是演示测量方法，不是性能基准。两次请求可能生成不同长度内容，
-还会受到冷启动、排队、网络、缓存和服务负载影响。正式比较至少应预热，固定地域
-和参数，交替执行多轮，并报告中位数及 P95。
+One script run demonstrates the measurement method; it is not a benchmark.
+Requests may generate different output lengths and are affected by cold starts,
+queueing, networks, caches, and service load. A formal comparison should warm
+up the service, fix region and parameters, alternate multiple runs, and report
+the median and P95.
 
 ```text
 === Latency comparison (one sample, not a benchmark) ===
@@ -39,5 +49,5 @@ streaming chars: 181
 Run multiple warm samples before drawing performance conclusions.
 ```
 
-流式的价值通常是更早显示内容，而不保证总耗时更短。运行：
-`python 03_streaming_vs_non_streaming.py`。
+Streaming usually provides earlier visible output; it does not guarantee lower
+total latency. Run with `python 03_streaming_vs_non_streaming.py`.

--- a/examples/api/03_streaming_vs_non_streaming.py
+++ b/examples/api/03_streaming_vs_non_streaming.py
@@ -1,0 +1,69 @@
+"""Measure full-response latency and streaming time to first visible token."""
+
+from time import perf_counter
+
+from common import configure_utf8_output, load_settings, make_client
+
+PROMPT = "用不超过 200 字解释大语言模型的流式输出。"
+
+
+def run_non_streaming(client, model: str) -> tuple[float, str]:
+    started = perf_counter()
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=300,
+    )
+    elapsed = perf_counter() - started
+    return elapsed, response.choices[0].message.content or ""
+
+
+def run_streaming(client, model: str) -> tuple[float | None, float, str]:
+    started = perf_counter()
+    first_content_at: float | None = None
+    parts: list[str] = []
+    stream = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=300,
+        stream=True,
+    )
+    for chunk in stream:
+        if not chunk.choices:
+            continue
+        content = chunk.choices[0].delta.content
+        if content:
+            if first_content_at is None:
+                first_content_at = perf_counter()
+            parts.append(content)
+    finished = perf_counter()
+    ttft = None if first_content_at is None else first_content_at - started
+    return ttft, finished - started, "".join(parts)
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    client = make_client(settings)
+
+    non_stream_total, non_stream_text = run_non_streaming(client, settings.model)
+    stream_ttft, stream_total, stream_text = run_streaming(client, settings.model)
+
+    print("=== Latency comparison (one sample, not a benchmark) ===")
+    print(f"non-streaming total: {non_stream_total:.3f}s")
+    print(
+        "streaming TTFT: "
+        + (f"{stream_ttft:.3f}s" if stream_ttft is not None else "no content received")
+    )
+    print(f"streaming total: {stream_total:.3f}s")
+    print(f"non-streaming chars: {len(non_stream_text)}")
+    print(f"streaming chars: {len(stream_text)}")
+    print("Run multiple warm samples before drawing performance conclusions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/03_streaming_vs_non_streaming_CN.md
+++ b/examples/api/03_streaming_vs_non_streaming_CN.md
@@ -1,0 +1,47 @@
+<p align="left">
+  <a href="./03_streaming_vs_non_streaming.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 03｜非流式与流式时延对比
+
+完整程序：[03_streaming_vs_non_streaming.py](03_streaming_vs_non_streaming.py)
+
+## 指标定义
+
+- **非流式总耗时**：发送请求到完整 response 返回。
+- **流式 TTFT**：发送请求到收到第一个非空可见 `delta.content`。这不是 TCP 首字节
+  时间，也不是第一个只有 role/思考内容的 chunk。
+- **流式总耗时**：发送请求到流迭代结束。
+
+测量使用单调高精度时钟 `time.perf_counter()`：
+
+```python
+started = perf_counter()
+stream = client.chat.completions.create(..., stream=True)
+first_content_at = None
+for chunk in stream:
+    content = chunk.choices[0].delta.content if chunk.choices else None
+    if content and first_content_at is None:
+        first_content_at = perf_counter()
+total = perf_counter() - started
+ttft = first_content_at - started
+```
+
+## 正确解读
+
+脚本的一次运行只是演示测量方法，不是性能基准。两次请求可能生成不同长度内容，
+还会受到冷启动、排队、网络、缓存和服务负载影响。正式比较至少应预热，固定地域
+和参数，交替执行多轮，并报告中位数及 P95。
+
+```text
+=== Latency comparison (one sample, not a benchmark) ===
+non-streaming total: 2.841s
+streaming TTFT: 0.612s
+streaming total: 3.104s
+non-streaming chars: 174
+streaming chars: 181
+Run multiple warm samples before drawing performance conclusions.
+```
+
+流式的价值通常是更早显示内容，而不保证总耗时更短。运行：
+`python 03_streaming_vs_non_streaming.py`。

--- a/examples/api/04_tool_calling.md
+++ b/examples/api/04_tool_calling.md
@@ -1,17 +1,24 @@
-# 04｜一次工具调用与多轮工具循环
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./04_tool_calling_CN.md">Chinese</a>
+</p>
 
-完整程序：[04_tool_calling.py](04_tool_calling.py)
+# 04 | One Tool Call and a Multi-Round Tool Loop
 
-## 完整协议循环
+Complete program: [04_tool_calling.py](04_tool_calling.py)
 
-1. 请求包含 `tools` JSON Schema 和 `tool_choice="auto"`。
-2. 解析 assistant 的 `tool_calls`，而不是从自然语言猜工具。
-3. 用白名单解析工具名，使用 `json.loads` 后确认参数是对象。
-4. 业务侧执行函数，将结果序列化为字符串。
-5. 将完整 assistant 消息和 `role="tool"` 结果追加到 messages。
-6. 继续请求，直到 assistant 不再调用工具或达到安全轮数。
+## Complete Protocol Loop
 
-第一轮请求：
+1. Send a request with a `tools` JSON Schema and `tool_choice="auto"`.
+2. Read the assistant's `tool_calls` instead of guessing tools from prose.
+3. Resolve the tool through an allowlist and verify that decoded JSON arguments
+   form an object.
+4. Execute the function in the application and serialize its result as text.
+5. Append the complete assistant message and a `role="tool"` result to
+   `messages`.
+6. Continue until the assistant stops requesting tools or the safety limit is
+   reached.
+
+First request:
 
 ```python
 response = client.chat.completions.create(
@@ -24,7 +31,7 @@ response = client.chat.completions.create(
 )
 ```
 
-回填工具结果：
+Return the tool result:
 
 ```python
 messages.append(assistant_message_dict(message))
@@ -37,22 +44,25 @@ messages.append(
 )
 ```
 
-`assistant_message_dict` 会保留 `content`、`tool_calls` 以及慢思考工具流程需要的
-`reasoning_content`。示例天气函数返回固定数据，不调用外网，便于复现。
+`assistant_message_dict` preserves `content`, `tool_calls`, and the
+`reasoning_content` required by reasoning-plus-tool flows. The example weather
+function returns fixed data and does not access the internet.
 
-## 安全边界
+## Security Boundaries
 
-- 只允许 `TOOL_REGISTRY` 中的函数。
-- 不使用 `eval`/`exec`，不执行模型生成的命令。
-- 参数 JSON 错误或函数参数不匹配时，把受控错误作为工具结果返回。
-- 工具循环最多四轮，防止模型反复调用。
-- 真实工具还需要权限校验、超时、审计和输出长度限制。
+- Allow only functions registered in `TOOL_REGISTRY`.
+- Do not use `eval` or `exec`, and do not execute model-generated commands.
+- Return controlled tool errors for invalid JSON or mismatched arguments.
+- Limit the tool loop to four rounds.
+- Real tools also require permission checks, timeouts, auditing, and output
+  limits.
 
 ```text
 round 1: finish_reason=tool_calls
-tool_call: get_weather({"city":"深圳"})
+tool_call: get_weather({"city":"Shenzhen"})
 round 2: finish_reason=stop
-final answer: 深圳当前示例天气为晴，26°C……
+final answer: The example weather in Shenzhen is sunny, 26 C...
 ```
 
-模型是否调用工具具有采样差异；输出仅为格式示例。运行：`python 04_tool_calling.py`。
+Tool selection varies with sampling; the output is structural only. Run with
+`python 04_tool_calling.py`.

--- a/examples/api/04_tool_calling.md
+++ b/examples/api/04_tool_calling.md
@@ -1,0 +1,58 @@
+# 04｜一次工具调用与多轮工具循环
+
+完整程序：[04_tool_calling.py](04_tool_calling.py)
+
+## 完整协议循环
+
+1. 请求包含 `tools` JSON Schema 和 `tool_choice="auto"`。
+2. 解析 assistant 的 `tool_calls`，而不是从自然语言猜工具。
+3. 用白名单解析工具名，使用 `json.loads` 后确认参数是对象。
+4. 业务侧执行函数，将结果序列化为字符串。
+5. 将完整 assistant 消息和 `role="tool"` 结果追加到 messages。
+6. 继续请求，直到 assistant 不再调用工具或达到安全轮数。
+
+第一轮请求：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=messages,
+    tools=TOOLS,
+    tool_choice="auto",
+    max_tokens=512,
+    extra_body=reasoning_extra_body(settings.api_mode, "no_think"),
+)
+```
+
+回填工具结果：
+
+```python
+messages.append(assistant_message_dict(message))
+messages.append(
+    {
+        "role": "tool",
+        "tool_call_id": tool_call.id,
+        "content": execute_tool(name, tool_call.function.arguments),
+    }
+)
+```
+
+`assistant_message_dict` 会保留 `content`、`tool_calls` 以及慢思考工具流程需要的
+`reasoning_content`。示例天气函数返回固定数据，不调用外网，便于复现。
+
+## 安全边界
+
+- 只允许 `TOOL_REGISTRY` 中的函数。
+- 不使用 `eval`/`exec`，不执行模型生成的命令。
+- 参数 JSON 错误或函数参数不匹配时，把受控错误作为工具结果返回。
+- 工具循环最多四轮，防止模型反复调用。
+- 真实工具还需要权限校验、超时、审计和输出长度限制。
+
+```text
+round 1: finish_reason=tool_calls
+tool_call: get_weather({"city":"深圳"})
+round 2: finish_reason=stop
+final answer: 深圳当前示例天气为晴，26°C……
+```
+
+模型是否调用工具具有采样差异；输出仅为格式示例。运行：`python 04_tool_calling.py`。

--- a/examples/api/04_tool_calling.py
+++ b/examples/api/04_tool_calling.py
@@ -1,0 +1,109 @@
+"""Hy3 tool calling: inspect one call, then execute a bounded tool loop."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from common import (
+    assistant_message_dict,
+    configure_utf8_output,
+    load_settings,
+    make_client,
+    parse_json_arguments,
+    reasoning_extra_body,
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "查询指定城市的示例天气。",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "城市名称"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def get_weather(city: str) -> dict[str, Any]:
+    """A deterministic local demo tool; replace it with a real weather API."""
+
+    return {"city": city, "weather": "晴", "temperature_c": 26}
+
+
+TOOL_REGISTRY: dict[str, Callable[..., dict[str, Any]]] = {
+    "get_weather": get_weather,
+}
+
+
+def execute_tool(name: str, raw_arguments: str) -> str:
+    if name not in TOOL_REGISTRY:
+        raise ValueError(f"Tool is not allowed: {name}")
+    arguments = parse_json_arguments(raw_arguments)
+    result = TOOL_REGISTRY[name](**arguments)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def run_tool_loop(client, settings, *, max_rounds: int = 4) -> str:
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "需要天气信息时调用工具，不要猜测。"},
+        {"role": "user", "content": "深圳天气如何？适合穿什么？"},
+    ]
+    extra_body = reasoning_extra_body(settings.api_mode, "no_think")
+
+    for round_number in range(1, max_rounds + 1):
+        response = client.chat.completions.create(
+            model=settings.model,
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+            temperature=0.9,
+            top_p=1.0,
+            max_tokens=512,
+            extra_body=extra_body,
+        )
+        message = response.choices[0].message
+        print(
+            f"round {round_number}: finish_reason={response.choices[0].finish_reason}"
+        )
+
+        # No tool call means the model has produced its final answer.
+        if not message.tool_calls:
+            return message.content or ""
+
+        messages.append(assistant_message_dict(message))
+        for tool_call in message.tool_calls:
+            name = tool_call.function.name
+            print(f"tool_call: {name}({tool_call.function.arguments})")
+            try:
+                result = execute_tool(name, tool_call.function.arguments)
+            except (TypeError, ValueError) as exc:
+                result = json.dumps({"error": str(exc)}, ensure_ascii=False)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                }
+            )
+
+    raise RuntimeError(f"Tool loop exceeded the safe limit of {max_rounds} rounds")
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    client = make_client(settings)
+    answer = run_tool_loop(client, settings)
+    print(f"final answer: {answer}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/04_tool_calling_CN.md
+++ b/examples/api/04_tool_calling_CN.md
@@ -1,0 +1,62 @@
+<p align="left">
+  <a href="./04_tool_calling.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 04｜一次工具调用与多轮工具循环
+
+完整程序：[04_tool_calling.py](04_tool_calling.py)
+
+## 完整协议循环
+
+1. 请求包含 `tools` JSON Schema 和 `tool_choice="auto"`。
+2. 解析 assistant 的 `tool_calls`，而不是从自然语言猜工具。
+3. 用白名单解析工具名，使用 `json.loads` 后确认参数是对象。
+4. 业务侧执行函数，将结果序列化为字符串。
+5. 将完整 assistant 消息和 `role="tool"` 结果追加到 messages。
+6. 继续请求，直到 assistant 不再调用工具或达到安全轮数。
+
+第一轮请求：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=messages,
+    tools=TOOLS,
+    tool_choice="auto",
+    max_tokens=512,
+    extra_body=reasoning_extra_body(settings.api_mode, "no_think"),
+)
+```
+
+回填工具结果：
+
+```python
+messages.append(assistant_message_dict(message))
+messages.append(
+    {
+        "role": "tool",
+        "tool_call_id": tool_call.id,
+        "content": execute_tool(name, tool_call.function.arguments),
+    }
+)
+```
+
+`assistant_message_dict` 会保留 `content`、`tool_calls` 以及慢思考工具流程需要的
+`reasoning_content`。示例天气函数返回固定数据，不调用外网，便于复现。
+
+## 安全边界
+
+- 只允许 `TOOL_REGISTRY` 中的函数。
+- 不使用 `eval`/`exec`，不执行模型生成的命令。
+- 参数 JSON 错误或函数参数不匹配时，把受控错误作为工具结果返回。
+- 工具循环最多四轮，防止模型反复调用。
+- 真实工具还需要权限校验、超时、审计和输出长度限制。
+
+```text
+round 1: finish_reason=tool_calls
+tool_call: get_weather({"city":"深圳"})
+round 2: finish_reason=stop
+final answer: 深圳当前示例天气为晴，26°C……
+```
+
+模型是否调用工具具有采样差异；输出仅为格式示例。运行：`python 04_tool_calling.py`。

--- a/examples/api/05_reasoning_mode.md
+++ b/examples/api/05_reasoning_mode.md
@@ -1,0 +1,56 @@
+# 05｜思考模式开关对比
+
+完整程序：[05_reasoning_mode.py](05_reasoning_mode.py)
+
+脚本对同一道题分别发送 `no_think` 和 `high`，记录总耗时、输出 Token 数、
+`reasoning_content` 长度和最终回答。TokenHub 与自托管服务参数位置不同，
+`common.reasoning_extra_body` 会根据 `HY3_API_MODE` 生成正确结构：
+
+```python
+# TokenHub 开启深度思考
+{"thinking": {"type": "enabled"}, "reasoning_effort": "high"}
+
+# TokenHub 关闭思考
+{"thinking": {"type": "disabled"}}
+
+# TokenHub 也支持 medium 推理深度
+{"thinking": {"type": "enabled"}, "reasoning_effort": "medium"}
+
+# 自托管 chat template
+{"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+完整调用：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": PROMPT}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=1024 if effort == "no_think" else 16384,
+    extra_body=reasoning_extra_body(settings.api_mode, effort),
+)
+```
+
+## 输出示例
+
+```text
+=== reasoning_effort=no_think ===
+elapsed: 1.532s
+completion_tokens: 83
+reasoning_chars: 0
+answer: 净注水速度为 1/6 - 1/9 = 1/18……
+
+=== reasoning_effort=high ===
+elapsed: 3.876s
+completion_tokens: 216
+reasoning_chars: 294
+answer: ……因此需要 18 小时。
+```
+
+不要凭一次调用断言某模式更快或更好。对真实业务题集多次运行，评估正确率、总耗时
+和费用。思考模式需要更大的 `max_tokens`；不要把完整推理内容写入包含敏感数据的
+日志。服务版本不支持某个取值时会返回 400，应以目标服务文档为准。
+
+运行：`python 05_reasoning_mode.py`。

--- a/examples/api/05_reasoning_mode.md
+++ b/examples/api/05_reasoning_mode.md
@@ -1,26 +1,32 @@
-# 05｜思考模式开关对比
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./05_reasoning_mode_CN.md">Chinese</a>
+</p>
 
-完整程序：[05_reasoning_mode.py](05_reasoning_mode.py)
+# 05 | Comparing Reasoning Modes
 
-脚本对同一道题分别发送 `no_think` 和 `high`，记录总耗时、输出 Token 数、
-`reasoning_content` 长度和最终回答。TokenHub 与自托管服务参数位置不同，
-`common.reasoning_extra_body` 会根据 `HY3_API_MODE` 生成正确结构：
+Complete program: [05_reasoning_mode.py](05_reasoning_mode.py)
+
+The script sends the same problem with `no_think` and `high`, recording total
+latency, output tokens, `reasoning_content` length, and the final answer.
+TokenHub and self-hosted services place these parameters differently.
+`common.reasoning_extra_body` generates the correct structure from
+`HY3_API_MODE`:
 
 ```python
-# TokenHub 开启深度思考
+# Enable deep reasoning on TokenHub.
 {"thinking": {"type": "enabled"}, "reasoning_effort": "high"}
 
-# TokenHub 关闭思考
+# Disable reasoning on TokenHub.
 {"thinking": {"type": "disabled"}}
 
-# TokenHub 也支持 medium 推理深度
+# TokenHub also supports medium reasoning depth.
 {"thinking": {"type": "enabled"}, "reasoning_effort": "medium"}
 
-# 自托管 chat template
+# Self-hosted chat template.
 {"chat_template_kwargs": {"reasoning_effort": "high"}}
 ```
 
-完整调用：
+Complete call:
 
 ```python
 response = client.chat.completions.create(
@@ -33,24 +39,26 @@ response = client.chat.completions.create(
 )
 ```
 
-## 输出示例
+## Example Output
 
 ```text
 === reasoning_effort=no_think ===
 elapsed: 1.532s
 completion_tokens: 83
 reasoning_chars: 0
-answer: 净注水速度为 1/6 - 1/9 = 1/18……
+answer: The net fill rate is 1/6 - 1/9 = 1/18...
 
 === reasoning_effort=high ===
 elapsed: 3.876s
 completion_tokens: 216
 reasoning_chars: 294
-answer: ……因此需要 18 小时。
+answer: Therefore, filling the pool takes 18 hours.
 ```
 
-不要凭一次调用断言某模式更快或更好。对真实业务题集多次运行，评估正确率、总耗时
-和费用。思考模式需要更大的 `max_tokens`；不要把完整推理内容写入包含敏感数据的
-日志。服务版本不支持某个取值时会返回 400，应以目标服务文档为准。
+Do not conclude that one mode is faster or better from a single request.
+Evaluate accuracy, total latency, and cost over repeated runs on a real task
+set. Reasoning needs a larger `max_tokens` budget. Do not log complete reasoning
+that contains sensitive data. An unsupported value returns HTTP 400, so follow
+the target service documentation.
 
-运行：`python 05_reasoning_mode.py`。
+Run with `python 05_reasoning_mode.py`.

--- a/examples/api/05_reasoning_mode.py
+++ b/examples/api/05_reasoning_mode.py
@@ -1,0 +1,57 @@
+"""Compare Hy3 direct-answer and deep-reasoning modes."""
+
+from time import perf_counter
+
+from common import (
+    configure_utf8_output,
+    extra_field,
+    load_settings,
+    make_client,
+    reasoning_extra_body,
+)
+
+PROMPT = (
+    "一个水池有进水管和出水管。单开进水管 6 小时注满，"
+    "单开出水管 9 小时排空。两管同时打开，多久注满？说明计算过程。"
+)
+
+
+def run_mode(client, settings, effort: str) -> dict[str, object]:
+    started = perf_counter()
+    response = client.chat.completions.create(
+        model=settings.model,
+        messages=[{"role": "user", "content": PROMPT}],
+        temperature=0.9,
+        top_p=1.0,
+        max_tokens=1024 if effort == "no_think" else 16384,
+        extra_body=reasoning_extra_body(settings.api_mode, effort),
+    )
+    elapsed = perf_counter() - started
+    message = response.choices[0].message
+    usage = response.usage
+    return {
+        "effort": effort,
+        "elapsed": elapsed,
+        "reasoning": extra_field(message, "reasoning_content", "") or "",
+        "content": message.content or "",
+        "completion_tokens": None if usage is None else usage.completion_tokens,
+    }
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    client = make_client(settings)
+    for effort in ("no_think", "high"):
+        result = run_mode(client, settings, effort)
+        print(f"\n=== reasoning_effort={effort} ===")
+        print(f"elapsed: {result['elapsed']:.3f}s")
+        print(f"completion_tokens: {result['completion_tokens']}")
+        print(f"reasoning_chars: {len(str(result['reasoning']))}")
+        print(f"answer: {result['content']}")
+
+    print("\nLatency and token counts vary; compare several runs for evaluation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/05_reasoning_mode_CN.md
+++ b/examples/api/05_reasoning_mode_CN.md
@@ -1,0 +1,60 @@
+<p align="left">
+  <a href="./05_reasoning_mode.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 05｜思考模式开关对比
+
+完整程序：[05_reasoning_mode.py](05_reasoning_mode.py)
+
+脚本对同一道题分别发送 `no_think` 和 `high`，记录总耗时、输出 Token 数、
+`reasoning_content` 长度和最终回答。TokenHub 与自托管服务参数位置不同，
+`common.reasoning_extra_body` 会根据 `HY3_API_MODE` 生成正确结构：
+
+```python
+# TokenHub 开启深度思考
+{"thinking": {"type": "enabled"}, "reasoning_effort": "high"}
+
+# TokenHub 关闭思考
+{"thinking": {"type": "disabled"}}
+
+# TokenHub 也支持 medium 推理深度
+{"thinking": {"type": "enabled"}, "reasoning_effort": "medium"}
+
+# 自托管 chat template
+{"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+完整调用：
+
+```python
+response = client.chat.completions.create(
+    model=settings.model,
+    messages=[{"role": "user", "content": PROMPT}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=1024 if effort == "no_think" else 16384,
+    extra_body=reasoning_extra_body(settings.api_mode, effort),
+)
+```
+
+## 输出示例
+
+```text
+=== reasoning_effort=no_think ===
+elapsed: 1.532s
+completion_tokens: 83
+reasoning_chars: 0
+answer: 净注水速度为 1/6 - 1/9 = 1/18……
+
+=== reasoning_effort=high ===
+elapsed: 3.876s
+completion_tokens: 216
+reasoning_chars: 294
+answer: ……因此需要 18 小时。
+```
+
+不要凭一次调用断言某模式更快或更好。对真实业务题集多次运行，评估正确率、总耗时
+和费用。思考模式需要更大的 `max_tokens`；不要把完整推理内容写入包含敏感数据的
+日志。服务版本不支持某个取值时会返回 400，应以目标服务文档为准。
+
+运行：`python 05_reasoning_mode.py`。

--- a/examples/api/06_error_handling_retry.md
+++ b/examples/api/06_error_handling_retry.md
@@ -1,49 +1,59 @@
-# 06｜错误处理、重试与退避
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./06_error_handling_retry_CN.md">Chinese</a>
+</p>
 
-完整程序：[06_error_handling_retry.py](06_error_handling_retry.py)
+# 06 | Error Handling, Retries, and Backoff
 
-## 错误分类
+Complete program: [06_error_handling_retry.py](06_error_handling_retry.py)
 
-| 类型 | 是否重试 | 原因 |
+## Error Classification
+
+| Type | Retry? | Reason |
 | --- | --- | --- |
-| 超时、连接失败 | 是，有限次数 | 常为短暂网络问题 |
-| 408、409、429 | 是 | 请求超时、冲突或限流可能恢复 |
-| 500、502、503、504 | 是 | 短暂服务异常 |
-| 400 | 否 | 请求内容错误，原样重试无效 |
-| 401、403 | 否 | 凭据或权限问题，重试无效 |
-| 其他未知异常 | 否 | 避免掩盖程序错误 |
+| Timeout or connection failure | Yes, a limited number | Often a transient network problem |
+| 408, 409, 429 | Yes | Timeout, conflict, or rate limiting may recover |
+| 500, 502, 503, 504 | Yes | Transient service failure |
+| 400 | No | Retrying the same invalid request cannot succeed |
+| 401, 403 | No | Credentials or permissions require intervention |
+| Other unknown exception | No | Avoid hiding application defects |
 
-本示例把 SDK 的 `max_retries` 设为 0，让所有重试都由可见代码负责，避免 SDK 和
-业务代码形成重试乘法。
+The example sets the SDK's `max_retries` to 0 so that all retries remain
+visible in application code and SDK retries do not multiply application
+retries.
 
-## 等待策略
+## Wait Strategy
 
-若响应有 `Retry-After`，支持秒数和 HTTP 日期两种格式，并按服务端要求等待；否则使用：
+When a response contains `Retry-After`, the code supports both seconds and HTTP
+date formats and waits as instructed. Otherwise it uses:
 
 ```text
-min(base × 2^attempt + random(0, 1) × base, cap)
+min(base * 2^attempt + random(0, 1) * base, cap)
 ```
 
-jitter 防止多个客户端在同一时刻再次冲击服务。除了 `max_attempts=4`，程序还有
-`max_total_wait=60` 总等待预算；如果 `Retry-After` 超出剩余预算，程序会停止并将
-控制权交给调用方，而不是提前重试。
+Jitter prevents multiple clients from retrying at the same instant. In addition
+to `max_attempts=4`, the program has a `max_total_wait=60` budget. If
+`Retry-After` exceeds the remaining budget, it stops and returns control to the
+caller instead of retrying early.
 
 ```python
 response = call_with_retry(
     lambda: client.chat.completions.create(
         model=settings.model,
-        messages=[{"role": "user", "content": "解释指数退避。"}],
+        messages=[{"role": "user", "content": "Explain exponential backoff."}],
     )
 )
 ```
 
-## 输出示例
+## Example Output
 
 ```text
 attempt 1 failed with RateLimitError; retrying in 2.00s
 attempt 2 failed with APIConnectionError; retrying in 2.37s
-assistant: 指数退避是在连续失败后逐步增加等待时间的重试策略。
+assistant: Exponential backoff increases the delay after consecutive failures.
 ```
 
-生产环境还应记录脱敏 request ID、状态码、尝试次数和延迟，并结合幂等性判断是否
-能重试有副作用的业务操作。运行：`python 06_error_handling_retry.py`。
+Production systems should also record redacted request IDs, status codes,
+attempt counts, and latency. Consider idempotency before retrying operations
+with side effects.
+
+Run with `python 06_error_handling_retry.py`.

--- a/examples/api/06_error_handling_retry.md
+++ b/examples/api/06_error_handling_retry.md
@@ -1,0 +1,49 @@
+# 06｜错误处理、重试与退避
+
+完整程序：[06_error_handling_retry.py](06_error_handling_retry.py)
+
+## 错误分类
+
+| 类型 | 是否重试 | 原因 |
+| --- | --- | --- |
+| 超时、连接失败 | 是，有限次数 | 常为短暂网络问题 |
+| 408、409、429 | 是 | 请求超时、冲突或限流可能恢复 |
+| 500、502、503、504 | 是 | 短暂服务异常 |
+| 400 | 否 | 请求内容错误，原样重试无效 |
+| 401、403 | 否 | 凭据或权限问题，重试无效 |
+| 其他未知异常 | 否 | 避免掩盖程序错误 |
+
+本示例把 SDK 的 `max_retries` 设为 0，让所有重试都由可见代码负责，避免 SDK 和
+业务代码形成重试乘法。
+
+## 等待策略
+
+若响应有 `Retry-After`，支持秒数和 HTTP 日期两种格式，并按服务端要求等待；否则使用：
+
+```text
+min(base × 2^attempt + random(0, 1) × base, cap)
+```
+
+jitter 防止多个客户端在同一时刻再次冲击服务。除了 `max_attempts=4`，程序还有
+`max_total_wait=60` 总等待预算；如果 `Retry-After` 超出剩余预算，程序会停止并将
+控制权交给调用方，而不是提前重试。
+
+```python
+response = call_with_retry(
+    lambda: client.chat.completions.create(
+        model=settings.model,
+        messages=[{"role": "user", "content": "解释指数退避。"}],
+    )
+)
+```
+
+## 输出示例
+
+```text
+attempt 1 failed with RateLimitError; retrying in 2.00s
+attempt 2 failed with APIConnectionError; retrying in 2.37s
+assistant: 指数退避是在连续失败后逐步增加等待时间的重试策略。
+```
+
+生产环境还应记录脱敏 request ID、状态码、尝试次数和延迟，并结合幂等性判断是否
+能重试有副作用的业务操作。运行：`python 06_error_handling_retry.py`。

--- a/examples/api/06_error_handling_retry.py
+++ b/examples/api/06_error_handling_retry.py
@@ -1,0 +1,131 @@
+"""Explicit bounded retries for timeout, connection, throttling, and 5xx errors."""
+
+from __future__ import annotations
+
+import random
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    OpenAI,
+    PermissionDeniedError,
+)
+
+from common import configure_utf8_output, load_settings
+
+RETRYABLE_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
+
+
+def parse_retry_after(value: str | None, now: datetime | None = None) -> float | None:
+    """Parse Retry-After as seconds or an HTTP date."""
+
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        return max(0.0, (retry_at - current).total_seconds())
+
+
+def retry_delay(
+    attempt: int,
+    *,
+    retry_after: str | None = None,
+    base: float = 1.0,
+    cap: float = 30.0,
+    jitter: Callable[[], float] = random.random,
+) -> float:
+    """Honor Retry-After; otherwise use capped exponential backoff + jitter."""
+
+    server_delay = parse_retry_after(retry_after)
+    if server_delay is not None:
+        return server_delay
+    return min(base * (2**attempt) + jitter() * base, cap)
+
+
+def retryable(error: Exception) -> bool:
+    if isinstance(error, (APIConnectionError, APITimeoutError)):
+        return True
+    return (
+        isinstance(error, APIStatusError)
+        and error.status_code in RETRYABLE_STATUS_CODES
+    )
+
+
+def call_with_retry(
+    operation: Callable[[], Any],
+    *,
+    max_attempts: int = 4,
+    max_total_wait: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Any:
+    """Run an API operation with finite retries and a total wait budget."""
+
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+    waited = 0.0
+    for attempt in range(max_attempts):
+        try:
+            return operation()
+        except (AuthenticationError, PermissionDeniedError, BadRequestError):
+            raise  # Retrying invalid credentials or invalid input will not help.
+        except Exception as error:
+            final_attempt = attempt + 1 >= max_attempts
+            if final_attempt or not retryable(error):
+                raise
+            response = getattr(error, "response", None)
+            retry_after = (
+                None if response is None else response.headers.get("Retry-After")
+            )
+            delay = retry_delay(attempt, retry_after=retry_after)
+            if waited + delay > max_total_wait:
+                raise RuntimeError("Retry wait budget exhausted") from error
+            print(
+                f"attempt {attempt + 1} failed with {type(error).__name__}; "
+                f"retrying in {delay:.2f}s"
+            )
+            sleep(delay)
+            waited += delay
+    raise AssertionError("unreachable")
+
+
+def main() -> None:
+    configure_utf8_output()
+    settings = load_settings()
+    # Disable SDK retries here so this example owns and explains every retry.
+    client = OpenAI(
+        base_url=settings.base_url,
+        api_key=settings.api_key,
+        timeout=settings.timeout,
+        max_retries=0,
+    )
+
+    response = call_with_retry(
+        lambda: client.chat.completions.create(
+            model=settings.model,
+            messages=[{"role": "user", "content": "请用一句话解释指数退避。"}],
+            temperature=0.9,
+            top_p=1.0,
+            max_tokens=128,
+        )
+    )
+    print(f"assistant: {response.choices[0].message.content}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api/06_error_handling_retry_CN.md
+++ b/examples/api/06_error_handling_retry_CN.md
@@ -1,0 +1,53 @@
+<p align="left">
+  <a href="./06_error_handling_retry.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# 06｜错误处理、重试与退避
+
+完整程序：[06_error_handling_retry.py](06_error_handling_retry.py)
+
+## 错误分类
+
+| 类型 | 是否重试 | 原因 |
+| --- | --- | --- |
+| 超时、连接失败 | 是，有限次数 | 常为短暂网络问题 |
+| 408、409、429 | 是 | 请求超时、冲突或限流可能恢复 |
+| 500、502、503、504 | 是 | 短暂服务异常 |
+| 400 | 否 | 请求内容错误，原样重试无效 |
+| 401、403 | 否 | 凭据或权限问题，重试无效 |
+| 其他未知异常 | 否 | 避免掩盖程序错误 |
+
+本示例把 SDK 的 `max_retries` 设为 0，让所有重试都由可见代码负责，避免 SDK 和
+业务代码形成重试乘法。
+
+## 等待策略
+
+若响应有 `Retry-After`，支持秒数和 HTTP 日期两种格式，并按服务端要求等待；否则使用：
+
+```text
+min(base × 2^attempt + random(0, 1) × base, cap)
+```
+
+jitter 防止多个客户端在同一时刻再次冲击服务。除了 `max_attempts=4`，程序还有
+`max_total_wait=60` 总等待预算；如果 `Retry-After` 超出剩余预算，程序会停止并将
+控制权交给调用方，而不是提前重试。
+
+```python
+response = call_with_retry(
+    lambda: client.chat.completions.create(
+        model=settings.model,
+        messages=[{"role": "user", "content": "解释指数退避。"}],
+    )
+)
+```
+
+## 输出示例
+
+```text
+attempt 1 failed with RateLimitError; retrying in 2.00s
+attempt 2 failed with APIConnectionError; retrying in 2.37s
+assistant: 指数退避是在连续失败后逐步增加等待时间的重试策略。
+```
+
+生产环境还应记录脱敏 request ID、状态码、尝试次数和延迟，并结合幂等性判断是否
+能重试有副作用的业务操作。运行：`python 06_error_handling_retry.py`。

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,16 +1,21 @@
-# Hy3 API 可运行示例
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./README_CN.md">Chinese</a>
+</p>
 
-本目录对应仓库根目录的 [中文快速开始](../../quickstart_CN.md) 和
-[English quickstart](../../quickstart.md)。六个示例互相独立，可按编号依次运行。
+# Runnable Hy3 API Examples
 
-## 1. 准备环境
+This directory accompanies the repository's
+[English quickstart](../../quickstart.md). The six examples are independent and
+can be run in numbered order.
+
+## 1. Set Up the Environment
 
 ```bash
 cd examples/api
 python -m venv .venv
 ```
 
-激活虚拟环境：
+Activate the virtual environment:
 
 ```bash
 # Linux / macOS
@@ -20,7 +25,7 @@ source .venv/bin/activate
 .venv\Scripts\Activate.ps1
 ```
 
-安装依赖并创建本地配置：
+Install the dependencies and create a local configuration:
 
 ```bash
 python -m pip install -r requirements.txt
@@ -28,21 +33,21 @@ cp .env.example .env                 # Linux / macOS
 Copy-Item .env.example .env          # Windows PowerShell
 ```
 
-编辑 `.env`，填入 TokenHub API Key。若使用本地 vLLM/SGLang，则切换
-`HY3_API_MODE=self_hosted`，并使用本地服务地址。
+Edit `.env` and add your TokenHub API key. For a local vLLM/SGLang service, set
+`HY3_API_MODE=self_hosted` and use the local service URL.
 
-## 2. 示例索引
+## 2. Example Index
 
-| 编号 | 脚本 | 学习目标 | 配套文档 |
+| No. | Script | Learning goal | Detailed guide |
 | --- | --- | --- | --- |
-| 01 | `01_basic_chat.py` | 单轮、多轮、usage | [说明](01_basic_chat.md) |
-| 02 | `02_streaming.py` | 逐 chunk 解析与安全拼接 | [说明](02_streaming.md) |
-| 03 | `03_streaming_vs_non_streaming.py` | TTFT 与总耗时 | [说明](03_streaming_vs_non_streaming.md) |
-| 04 | `04_tool_calling.py` | 单次调用与有界工具循环 | [说明](04_tool_calling.md) |
-| 05 | `05_reasoning_mode.py` | 思考模式开/关对比 | [说明](05_reasoning_mode.md) |
-| 06 | `06_error_handling_retry.py` | 分类重试与退避 | [说明](06_error_handling_retry.md) |
+| 01 | `01_basic_chat.py` | Single-turn and multi-turn chat, plus usage | [Guide](01_basic_chat.md) |
+| 02 | `02_streaming.py` | Per-chunk parsing and safe aggregation | [Guide](02_streaming.md) |
+| 03 | `03_streaming_vs_non_streaming.py` | Time to first token and total latency | [Guide](03_streaming_vs_non_streaming.md) |
+| 04 | `04_tool_calling.py` | One call and a bounded tool loop | [Guide](04_tool_calling.md) |
+| 05 | `05_reasoning_mode.py` | Reasoning on/off comparison | [Guide](05_reasoning_mode.md) |
+| 06 | `06_error_handling_retry.py` | Error classification and backoff | [Guide](06_error_handling_retry.md) |
 
-运行方式：
+Run the examples:
 
 ```bash
 python 01_basic_chat.py
@@ -53,10 +58,13 @@ python 05_reasoning_mode.py
 python 06_error_handling_retry.py
 ```
 
-## 3. 安全与复现约定
+## 3. Security and Reproducibility
 
-- API Key 只从环境变量或被 Git 忽略的 `.env` 读取。
-- 示例不会打印 API Key。
-- 文档中的输出是脱敏的格式示例；延迟和内容以实际运行结果为准。
-- 工具调用示例只执行代码中显式注册的本地函数，不执行模型生成的任意代码。
-- 重试示例设置最大尝试次数和最大等待时间，避免无限重试。
+- API keys are read only from environment variables or a Git-ignored `.env`.
+- The examples never print an API key.
+- Documented outputs are redacted structural examples. Actual content and
+  latency vary between runs.
+- The tool-calling example executes only local functions explicitly registered
+  in the code. It does not execute arbitrary model-generated code.
+- The retry example limits both attempts and total wait time to prevent
+  unbounded retries.

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,62 @@
+# Hy3 API 可运行示例
+
+本目录对应仓库根目录的 [中文快速开始](../../quickstart_CN.md) 和
+[English quickstart](../../quickstart.md)。六个示例互相独立，可按编号依次运行。
+
+## 1. 准备环境
+
+```bash
+cd examples/api
+python -m venv .venv
+```
+
+激活虚拟环境：
+
+```bash
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows PowerShell
+.venv\Scripts\Activate.ps1
+```
+
+安装依赖并创建本地配置：
+
+```bash
+python -m pip install -r requirements.txt
+cp .env.example .env                 # Linux / macOS
+Copy-Item .env.example .env          # Windows PowerShell
+```
+
+编辑 `.env`，填入 TokenHub API Key。若使用本地 vLLM/SGLang，则切换
+`HY3_API_MODE=self_hosted`，并使用本地服务地址。
+
+## 2. 示例索引
+
+| 编号 | 脚本 | 学习目标 | 配套文档 |
+| --- | --- | --- | --- |
+| 01 | `01_basic_chat.py` | 单轮、多轮、usage | [说明](01_basic_chat.md) |
+| 02 | `02_streaming.py` | 逐 chunk 解析与安全拼接 | [说明](02_streaming.md) |
+| 03 | `03_streaming_vs_non_streaming.py` | TTFT 与总耗时 | [说明](03_streaming_vs_non_streaming.md) |
+| 04 | `04_tool_calling.py` | 单次调用与有界工具循环 | [说明](04_tool_calling.md) |
+| 05 | `05_reasoning_mode.py` | 思考模式开/关对比 | [说明](05_reasoning_mode.md) |
+| 06 | `06_error_handling_retry.py` | 分类重试与退避 | [说明](06_error_handling_retry.md) |
+
+运行方式：
+
+```bash
+python 01_basic_chat.py
+python 02_streaming.py
+python 03_streaming_vs_non_streaming.py
+python 04_tool_calling.py
+python 05_reasoning_mode.py
+python 06_error_handling_retry.py
+```
+
+## 3. 安全与复现约定
+
+- API Key 只从环境变量或被 Git 忽略的 `.env` 读取。
+- 示例不会打印 API Key。
+- 文档中的输出是脱敏的格式示例；延迟和内容以实际运行结果为准。
+- 工具调用示例只执行代码中显式注册的本地函数，不执行模型生成的任意代码。
+- 重试示例设置最大尝试次数和最大等待时间，避免无限重试。

--- a/examples/api/README_CN.md
+++ b/examples/api/README_CN.md
@@ -1,0 +1,66 @@
+<p align="left">
+  <a href="./README.md">English</a>&nbsp;|&nbsp;中文
+</p>
+
+# Hy3 API 可运行示例
+
+本目录对应仓库根目录的 [中文快速开始](../../quickstart_CN.md)。六个示例互相独立，
+可按编号依次运行。
+
+## 1. 准备环境
+
+```bash
+cd examples/api
+python -m venv .venv
+```
+
+激活虚拟环境：
+
+```bash
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows PowerShell
+.venv\Scripts\Activate.ps1
+```
+
+安装依赖并创建本地配置：
+
+```bash
+python -m pip install -r requirements.txt
+cp .env.example .env                 # Linux / macOS
+Copy-Item .env.example .env          # Windows PowerShell
+```
+
+编辑 `.env`，填入 TokenHub API Key。若使用本地 vLLM/SGLang，则切换
+`HY3_API_MODE=self_hosted`，并使用本地服务地址。
+
+## 2. 示例索引
+
+| 编号 | 脚本 | 学习目标 | 配套文档 |
+| --- | --- | --- | --- |
+| 01 | `01_basic_chat.py` | 单轮、多轮、usage | [说明](01_basic_chat_CN.md) |
+| 02 | `02_streaming.py` | 逐 chunk 解析与安全拼接 | [说明](02_streaming_CN.md) |
+| 03 | `03_streaming_vs_non_streaming.py` | TTFT 与总耗时 | [说明](03_streaming_vs_non_streaming_CN.md) |
+| 04 | `04_tool_calling.py` | 单次调用与有界工具循环 | [说明](04_tool_calling_CN.md) |
+| 05 | `05_reasoning_mode.py` | 思考模式开/关对比 | [说明](05_reasoning_mode_CN.md) |
+| 06 | `06_error_handling_retry.py` | 分类重试与退避 | [说明](06_error_handling_retry_CN.md) |
+
+运行方式：
+
+```bash
+python 01_basic_chat.py
+python 02_streaming.py
+python 03_streaming_vs_non_streaming.py
+python 04_tool_calling.py
+python 05_reasoning_mode.py
+python 06_error_handling_retry.py
+```
+
+## 3. 安全与复现约定
+
+- API Key 只从环境变量或被 Git 忽略的 `.env` 读取。
+- 示例不会打印 API Key。
+- 文档中的输出是脱敏的格式示例；延迟和内容以实际运行结果为准。
+- 工具调用示例只执行代码中显式注册的本地函数，不执行模型生成的任意代码。
+- 重试示例设置最大尝试次数和最大等待时间，避免无限重试。

--- a/examples/api/common.py
+++ b/examples/api/common.py
@@ -1,0 +1,164 @@
+"""Shared configuration and response helpers for the Hy3 API examples."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+TOKENHUB_BASE_URL = "https://tokenhub.tencentmaas.com/v1"
+LOCAL_BASE_URL = "http://127.0.0.1:8000/v1"
+
+
+def configure_utf8_output() -> None:
+    """Use UTF-8 for model output in Windows terminals."""
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime settings loaded from environment variables."""
+
+    api_mode: str
+    base_url: str
+    api_key: str
+    model: str
+    timeout: float
+    max_retries: int
+
+
+def load_settings() -> Settings:
+    """Load and validate settings without ever printing the API key."""
+
+    load_dotenv()
+    api_mode = os.getenv("HY3_API_MODE", "tokenhub").strip().lower()
+    if api_mode not in {"tokenhub", "self_hosted"}:
+        raise ValueError("HY3_API_MODE must be 'tokenhub' or 'self_hosted'")
+
+    default_url = TOKENHUB_BASE_URL if api_mode == "tokenhub" else LOCAL_BASE_URL
+    default_key = "" if api_mode == "tokenhub" else "EMPTY"
+    api_key = os.getenv("HY3_API_KEY", default_key).strip()
+    if not api_key:
+        raise ValueError(
+            "HY3_API_KEY is required for TokenHub. Copy .env.example to .env "
+            "and fill in your key."
+        )
+
+    timeout = float(os.getenv("HY3_TIMEOUT", "60"))
+    max_retries = int(os.getenv("HY3_MAX_RETRIES", "2"))
+    if timeout <= 0:
+        raise ValueError("HY3_TIMEOUT must be greater than 0")
+    if max_retries < 0:
+        raise ValueError("HY3_MAX_RETRIES must be 0 or greater")
+
+    return Settings(
+        api_mode=api_mode,
+        base_url=os.getenv("HY3_BASE_URL", default_url).rstrip("/"),
+        api_key=api_key,
+        model=os.getenv("HY3_MODEL", "hy3").strip() or "hy3",
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+
+def make_client(settings: Settings) -> OpenAI:
+    """Create an OpenAI-compatible client with bounded SDK retries."""
+
+    return OpenAI(
+        base_url=settings.base_url,
+        api_key=settings.api_key,
+        timeout=settings.timeout,
+        max_retries=settings.max_retries,
+    )
+
+
+def reasoning_extra_body(api_mode: str, effort: str) -> dict[str, Any]:
+    """Build the provider-specific body for Hy3 reasoning mode.
+
+    TokenHub uses ``thinking.type`` to enable/disable reasoning and a top-level
+    ``reasoning_effort`` to select the depth after reasoning is enabled.
+    Self-hosted vLLM/SGLang follows the repository chat-template convention.
+    """
+
+    if api_mode == "tokenhub":
+        allowed = {"no_think", "low", "medium", "high"}
+        if effort not in allowed:
+            raise ValueError(f"TokenHub effort must be one of {sorted(allowed)}")
+        if effort == "no_think":
+            return {"thinking": {"type": "disabled"}}
+        return {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": effort,
+        }
+    if api_mode == "self_hosted":
+        allowed = {"no_think", "low", "high"}
+        if effort not in allowed:
+            raise ValueError(f"Self-hosted effort must be one of {sorted(allowed)}")
+        return {"chat_template_kwargs": {"reasoning_effort": effort}}
+    raise ValueError("api_mode must be 'tokenhub' or 'self_hosted'")
+
+
+def extra_field(value: Any, field: str, default: Any = None) -> Any:
+    """Read SDK-known or provider-specific fields from an OpenAI model."""
+
+    direct = getattr(value, field, None)
+    if direct is not None:
+        return direct
+    extra = getattr(value, "model_extra", None) or {}
+    return extra.get(field, default)
+
+
+def assistant_message_dict(message: Any) -> dict[str, Any]:
+    """Serialize an assistant message for the next tool-calling turn.
+
+    Provider-specific ``reasoning_content`` is preserved because interleaved
+    reasoning needs it in subsequent requests.
+    """
+
+    result: dict[str, Any] = {
+        "role": "assistant",
+        "content": message.content or "",
+    }
+    reasoning = extra_field(message, "reasoning_content")
+    if reasoning:
+        result["reasoning_content"] = reasoning
+    if message.tool_calls:
+        result["tool_calls"] = [
+            tool_call.model_dump(exclude_none=True) for tool_call in message.tool_calls
+        ]
+    return result
+
+
+def parse_json_arguments(raw: str) -> dict[str, Any]:
+    """Parse tool arguments and require a JSON object, not a scalar or list."""
+
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Tool arguments are not valid JSON: {exc.msg}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("Tool arguments must decode to a JSON object")
+    return value
+
+
+def print_usage(usage: Any) -> None:
+    """Print token usage when the server supplies it."""
+
+    if usage is None:
+        print("usage: server did not return token statistics")
+        return
+    print(
+        "usage: "
+        f"prompt={usage.prompt_tokens}, "
+        f"completion={usage.completion_tokens}, "
+        f"total={usage.total_tokens}"
+    )

--- a/examples/api/requirements.txt
+++ b/examples/api/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.30.0,<3
+python-dotenv>=1.0.0,<2

--- a/quickstart.md
+++ b/quickstart.md
@@ -8,12 +8,17 @@ This guide helps developers make their first Hy3 API request in about five
 minutes and learn chat, streaming, tool calling, reasoning modes, and reliable
 retries in about thirty minutes.
 
-Hy3 provides an OpenAI-compatible Chat Completions API with two access modes:
+Hy3 provides an OpenAI-compatible Chat Completions API with two API access
+modes:
 
 - **TokenHub hosted API**: Create an API key and enable a service without
   deploying the model yourself.
-- **Self-hosted service**: Follow the [README](README.md#deployment)
-  to start Hy3 with vLLM or SGLang, then call its local OpenAI-compatible API.
+- **Self-hosted API**: Follow the [README](README.md#deployment) to deploy Hy3
+  with vLLM or SGLang, then call the OpenAI-compatible API exposed by that
+  service.
+
+This guide covers API usage for both services. It does not cover model
+downloads, GPU planning, or server deployment.
 
 ## 1. Basic Information
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,123 +1,398 @@
+<p align="left">
+  English&nbsp;|&nbsp;<a href="./quickstart_CN.md">Chinese</a>
+</p>
+
 # Hy3 API Quickstart
 
-> Make the first request in five minutes and learn chat, streaming, tools,
-> reasoning, and reliable retries in thirty minutes. 中文版：
-> [quickstart_CN.md](quickstart_CN.md).
+This guide helps developers make their first Hy3 API request in about five
+minutes and learn chat, streaming, tool calling, reasoning modes, and reliable
+retries in about thirty minutes.
 
-Hy3 exposes an OpenAI-compatible Chat Completions API. Use Tencent Cloud
-TokenHub (`https://tokenhub.tencentmaas.com/v1`, model `hy3`) or a local
-vLLM/SGLang server (`http://127.0.0.1:8000/v1`, key `EMPTY`). The TokenHub
-Singapore endpoint is `https://tokenhub-intl.tencentmaas.com/v1`; use the
-region where your resource is enabled.
+Hy3 provides an OpenAI-compatible Chat Completions API with two access modes:
 
-## Five-minute request
+- **TokenHub hosted API**: Create an API key and enable a service without
+  deploying the model yourself.
+- **Self-hosted service**: Follow the [README](README.md#deployment)
+  to start Hy3 with vLLM or SGLang, then call its local OpenAI-compatible API.
 
-```bash
-export HY3_API_KEY="replace-with-your-key"
-curl https://tokenhub.tencentmaas.com/v1/chat/completions \
-  -H "Authorization: Bearer $HY3_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "hy3",
-    "messages": [{"role": "user", "content": "Introduce Hy3 in one sentence."}],
-    "temperature": 0.9,
-    "top_p": 1.0,
-    "max_tokens": 128
-  }'
-```
+## 1. Basic Information
+
+| Item | TokenHub Guangzhou | TokenHub Singapore | Self-hosted default |
+| --- | --- | --- | --- |
+| Base URL | `https://tokenhub.tencentmaas.com/v1` | `https://tokenhub-intl.tencentmaas.com/v1` | `http://127.0.0.1:8000/v1` |
+| Chat endpoint | `/chat/completions` | `/chat/completions` | `/chat/completions` |
+| API key | Created in the TokenHub console | Created in the TokenHub console | Usually `EMPTY` |
+| Model | `hy3` or a service ID | `hy3` or a service ID | Matches `--served-model-name` |
+| Protocol | OpenAI Chat Completions | OpenAI Chat Completions | OpenAI-compatible API |
+
+TokenHub does not support cross-region requests. The API key, service resource,
+and Base URL must belong to the same region. For a custom online inference
+service, use the service ID shown in the console, such as `ep-xxxxxxxx`.
+
+Hy3 supports a model context length of up to 256K tokens. The usable context
+also depends on service configuration, input and output budgets, concurrency,
+and available GPU memory. This repository does not define a fixed RPM or TPM
+that applies to every deployment:
+
+- TokenHub limits depend on the account, region, plan, and inference service.
+- Self-hosted throughput depends on GPUs, parallelism, gateway settings, queues,
+  and context length.
+- On HTTP 429, honor `Retry-After`; otherwise use exponential backoff with
+  jitter.
+
+## 2. Configure the Environment
+
+Install the OpenAI Python SDK:
 
 ```bash
 python -m pip install "openai>=1.30,<3"
 ```
 
+### Linux / macOS
+
+TokenHub Singapore example:
+
+```bash
+export HY3_BASE_URL="https://tokenhub-intl.tencentmaas.com/v1"
+export HY3_API_KEY="replace-with-your-key"
+export HY3_MODEL="hy3"
+```
+
+Self-hosted example:
+
+```bash
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+### Windows PowerShell
+
+```powershell
+$env:HY3_BASE_URL = "https://tokenhub-intl.tencentmaas.com/v1"
+$env:HY3_API_KEY = "replace-with-your-key"
+$env:HY3_MODEL = "hy3"
+```
+
+Never put a real API key in source code, notebooks, screenshots, or Git
+history. Revoke and replace a key immediately if it is exposed.
+
+### Connectivity Check
+
+Linux / macOS:
+
+```bash
+curl "${HY3_BASE_URL}/models" \
+  -H "Authorization: Bearer ${HY3_API_KEY}"
+```
+
+Windows PowerShell:
+
+```powershell
+curl.exe "$env:HY3_BASE_URL/models" `
+  -H "Authorization: Bearer $env:HY3_API_KEY"
+```
+
+The model or service ID returned in the list should match `HY3_MODEL`. Some
+self-hosted frameworks also expose `/health`, but that route is not part of the
+OpenAI protocol and is not available on every service.
+
+## 3. Make a Request in Five Minutes
+
+### curl
+
+Linux / macOS:
+
+```bash
+curl "${HY3_BASE_URL}/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d @- <<JSON
+{
+  "model": "${HY3_MODEL}",
+  "messages": [
+    {"role": "user", "content": "In one sentence, explain how you can help."}
+  ],
+  "temperature": 0.9,
+  "top_p": 1.0,
+  "max_tokens": 128,
+  "stream": false
+}
+JSON
+```
+
+Windows PowerShell:
+
+```powershell
+$body = @{
+  model = $env:HY3_MODEL
+  messages = @(
+    @{ role = "user"; content = "In one sentence, explain how you can help." }
+  )
+  temperature = 0.9
+  top_p = 1.0
+  max_tokens = 128
+  stream = $false
+} | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod `
+  -Uri "$env:HY3_BASE_URL/chat/completions" `
+  -Method Post `
+  -Headers @{ Authorization = "Bearer $env:HY3_API_KEY" } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+The core response structure is shown below. IDs, content, and token counts vary:
+
+```json
+{
+  "id": "chatcmpl-REDACTED",
+  "object": "chat.completion",
+  "model": "hy3",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Example response content..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 18,
+    "completion_tokens": 24,
+    "total_tokens": 42
+  }
+}
+```
+
+### Python OpenAI SDK
+
 ```python
 import os
+
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://tokenhub.tencentmaas.com/v1",
+    base_url=os.environ["HY3_BASE_URL"],
     api_key=os.environ["HY3_API_KEY"],
     timeout=60.0,
 )
+
 response = client.chat.completions.create(
-    model="hy3",
-    messages=[{"role": "user", "content": "Introduce Hy3 in one sentence."}],
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[
+        {"role": "user", "content": "In one sentence, explain how you can help."},
+    ],
     temperature=0.9,
     top_p=1.0,
     max_tokens=128,
 )
-print(response.choices[0].message.content)
-print("finish_reason:", response.choices[0].finish_reason)
+
+choice = response.choices[0]
+print(choice.message.content)
+print("finish_reason:", choice.finish_reason)
+if response.usage:
+    print("total_tokens:", response.usage.total_tokens)
 ```
 
-For local serving, change the client to:
+The service does not automatically preserve multi-turn conversations. The
+client must include earlier `user` and `assistant` messages in order in the
+next request. See [`01_basic_chat.py`](examples/api/01_basic_chat.py) for a
+complete implementation.
+
+## 4. Request Parameters
+
+| Parameter | Type | Example | Description |
+| --- | --- | --- | --- |
+| `model` | string | `hy3` | Model or service ID returned by `/models` |
+| `messages` | array | `system/user/assistant/tool` | Conversation history maintained by the client |
+| `temperature` | number | `0.9` | Sampling randomness; the repository recommends `0.9` |
+| `top_p` | number | `1.0` | Nucleus sampling threshold; avoid aggressively tuning it together with temperature |
+| `max_tokens` | integer | `512` | Output limit; reserve a larger budget for reasoning |
+| `stop` | string/array | `["Observation:"]` | Stop generation when a sequence is matched |
+| `stream` | boolean | `true` | Return incremental chunks instead of waiting for a complete response |
+| `stream_options` | object | `{"include_usage": true}` | Include usage in the final streaming chunk |
+| `tools` | array | JSON Schema | Define functions that the model can select |
+| `tool_choice` | string/object | `auto` | Control whether or how a tool is selected |
+| `parallel_tool_calls` | boolean | `false` | Allow the model to request multiple tools at once |
+| `response_format` | object | `{"type": "json_object"}` | Constrain output when supported by the target service |
+
+Supported parameters may differ between service versions. Check the target
+service documentation and the actual `/models` response before use.
+
+Common `finish_reason` values:
+
+- `stop`: Generation completed normally.
+- `length`: The output budget was reached and the answer may be incomplete.
+- `tool_calls`: The model requested that the application execute a tool.
+
+## 5. Reasoning Modes
+
+TokenHub and self-hosted services place reasoning settings in different fields:
+
+| Service | Disable reasoning | Enable reasoning |
+| --- | --- | --- |
+| TokenHub | `{"thinking":{"type":"disabled"}}` | Set `thinking.type=enabled` and depth to `low/medium/high` |
+| Self-hosted | `reasoning_effort=no_think` | Set `reasoning_effort=low/high` |
+
+### TokenHub
 
 ```python
-client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+response = client.chat.completions.create(
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[
+        {"role": "user", "content": "Prove that the square root of 2 is irrational."}
+    ],
+    max_tokens=16384,
+    extra_body={
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "high",
+    },
+)
 ```
 
-## Parameters
-
-| Parameter | Meaning |
-| --- | --- |
-| `temperature` | Sampling randomness; repository recommendation: `0.9`. |
-| `top_p` | Nucleus sampling threshold; repository recommendation: `1.0`. |
-| `max_tokens` | Maximum generated tokens; reserve more for reasoning. |
-| `stop` | String/list that stops generation when matched. |
-| `stream` | Return incremental chunks instead of one response. |
-| `tools` | JSON Schema functions; the application executes them. |
-| `tool_choice` | Tool selection policy; TokenHub tool flows use `auto`. |
-
-`finish_reason="length"` means the response was truncated.
-
-## Reasoning mode
-
-TokenHub uses `thinking.type` to enable reasoning and a top-level
-`reasoning_effort` to select its depth:
+To disable reasoning:
 
 ```python
-extra_body={
-    "thinking": {"type": "enabled"},
-    "reasoning_effort": "high",
+extra_body = {"thinking": {"type": "disabled"}}
+```
+
+### Self-hosted vLLM/SGLang
+
+```python
+extra_body = {
+    "chat_template_kwargs": {
+        "reasoning_effort": "high",
+    }
 }
 ```
 
-The self-hosted repository chat-template convention is:
+Self-hosted templates use `no_think`, `low`, or `high`. The server must also
+enable the corresponding reasoning parser. Read the provider-specific
+`reasoning_content` field defensively:
 
 ```python
-extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+reasoning = getattr(response.choices[0].message, "reasoning_content", "")
 ```
 
-Disable TokenHub reasoning with `{"thinking": {"type": "disabled"}}`.
-TokenHub supports `low`, `medium`, or `high` after reasoning is enabled.
-Self-hosted chat templates use `no_think`, `low`, or `high`; confirm what the
-target service version supports.
-Provider-specific reasoning can be read with
-`getattr(message, "reasoning_content", "")`. In reasoning-plus-tool flows,
-preserve the complete assistant message in the next request.
+When reasoning and tool calling are combined, preserve the complete assistant
+message, including `reasoning_content` and `tool_calls`, in the next request.
+Do not log complete reasoning that contains sensitive business data. See
+[`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py) for a complete
+comparison.
 
-## Limits, retries, and troubleshooting
+## 6. Streaming Responses
 
-There is no repository-wide fixed RPM/TPM. TokenHub limits depend on account,
-region, and resources; local throughput depends on hardware and gateway policy.
-Honor `Retry-After` for 429. Retry timeouts, connections, 429, and selected 5xx
-errors with finite backoff and jitter. Never retry invalid credentials,
-permissions, or malformed requests.
+With `stream=True`, the SDK returns an iterable event stream. A chunk may
+contain only a role, partial content, a reasoning delta, a finish reason, or
+usage. Do not assume every chunk contains text:
 
-Check `/v1/models` for 401/404 issues. Ensure the Base URL includes `/v1`.
-Iterate all streaming chunks because usage-only chunks may have empty `choices`.
-Bound tool loops and validate all tool names and JSON arguments.
+```python
+stream = client.chat.completions.create(
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[{"role": "user", "content": "Explain streaming responses."}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
 
-Never commit API keys or place them in notebooks, logs, screenshots, or Git
-history.
+parts = []
+for chunk in stream:
+    if not chunk.choices:
+        continue
+    content = chunk.choices[0].delta.content
+    if content:
+        parts.append(content)
+        print(content, end="", flush=True)
 
-## Complete examples
+full_text = "".join(parts)
+```
 
-See [`examples/api/README.md`](examples/api/README.md) for six runnable Python
-examples and detailed per-example protocol notes. The
-[Chinese quickstart](quickstart_CN.md) contains the complete parameter and
-troubleshooting tables.
+Tool arguments can also span multiple chunks. Production code must accumulate
+them by tool-call index or ID before parsing. See
+[`02_streaming.py`](examples/api/02_streaming.py) for a complete implementation.
 
-Official references: [TokenHub API](https://cloud.tencent.com/document/product/1823/130078),
-[Hy3 guide](https://cloud.tencent.com/document/product/1823/132252), and
-[interleaved reasoning](https://cloud.tencent.com/document/product/1823/130930).
+## 7. Tool Calling
+
+Self-hosted services must enable tool parsing first:
+
+- vLLM: Use `--tool-call-parser hy_v3` and
+  `--enable-auto-tool-choice`.
+- SGLang: Use the Hunyuan tool-parser configuration documented in the
+  repository README.
+
+The complete application-side flow is:
+
+1. Define a `tools` JSON Schema.
+2. Send a request with `tool_choice="auto"`.
+3. Inspect the assistant's `tool_calls`.
+4. Validate the tool name against an allowlist and validate its JSON arguments.
+5. Execute the tool in the application.
+6. Add a `role="tool"` result message with the same `tool_call_id`.
+7. Send the complete history again until the model returns a final answer.
+
+Production code must limit tool rounds and enforce tool timeouts, permissions,
+and output size. Never use `eval`, `exec`, or a shell to execute model-generated
+content directly. See [`04_tool_calling.py`](examples/api/04_tool_calling.py)
+for a complete implementation.
+
+## 8. Example Index
+
+| Guide | Script | Demonstrates |
+| --- | --- | --- |
+| [Basic chat](examples/api/01_basic_chat.md) | [`01_basic_chat.py`](examples/api/01_basic_chat.py) | Single-turn and multi-turn chat, plus usage |
+| [Streaming](examples/api/02_streaming.md) | [`02_streaming.py`](examples/api/02_streaming.py) | Per-chunk parsing and aggregation |
+| [Latency comparison](examples/api/03_streaming_vs_non_streaming.md) | [`03_streaming_vs_non_streaming.py`](examples/api/03_streaming_vs_non_streaming.py) | Time to first token and total latency |
+| [Tool calling](examples/api/04_tool_calling.md) | [`04_tool_calling.py`](examples/api/04_tool_calling.py) | One call and a bounded tool loop |
+| [Reasoning modes](examples/api/05_reasoning_mode.md) | [`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py) | `no_think` and `high` comparison |
+| [Errors and retries](examples/api/06_error_handling_retry.md) | [`06_error_handling_retry.py`](examples/api/06_error_handling_retry.py) | Error classification and exponential backoff |
+
+Each guide includes the request flow, response parsing, important caveats, and
+redacted output examples. See
+[`examples/api/README.md`](examples/api/README.md) for installation and run
+instructions.
+
+## 9. Troubleshooting
+
+| Symptom | Common cause | Resolution |
+| --- | --- | --- |
+| HTTP 400 | Invalid parameter type, message order, tool Schema, or unsupported capability | Inspect a redacted request and reduce it field by field; do not retry unchanged |
+| HTTP 401 / `401002` | Missing or invalid key, or region mismatch | Match the key and Base URL region, then verify with `/models` |
+| HTTP 402 / endpoint inactive | Inference service, quota, or billing is inactive | Check the online inference service in the TokenHub console |
+| HTTP 403 | Account, model, IP allowlist, or resource permission issue | Check key permissions, region, and service status |
+| HTTP 404 / model not found | Incorrect URL, path, model name, or service ID | Include `/v1` in the URL and query `/models` |
+| HTTP 429 | Concurrency, rate, or quota limit | Honor `Retry-After`; otherwise use exponential backoff with jitter |
+| HTTP 5xx | Temporary service failure | Retry only selected statuses a limited number of times |
+| Connection refused | Self-hosted service is stopped or the port is wrong | Check the service process, bind address, firewall, and proxy |
+| Chat-template-related 400 | Missing template or incompatible service version | Use the Hy3 tokenizer/chat template and update the framework |
+| Empty `tool_calls` | Tool parser is disabled or the Schema is underspecified | Check the parser, tool_choice, and JSON Schema |
+| Missing `reasoning_content` | Reasoning parser is disabled or the mode does not return it | Check server startup options and reasoning mode |
+| Truncated output | `finish_reason=length` | Increase max_tokens or shorten the input |
+| Empty streaming content | Only the first chunk is read or empty choices are mishandled | Iterate the complete stream and process usage separately |
+| CUDA out of memory | Context, output budget, or concurrency is too high | Shorten context, reduce concurrency, or adjust parallelism |
+| Client timeout | Model loading, long context, or deep reasoning takes longer | Adjust timeout or task size, or use streaming |
+
+## 10. Production and Security Guidance
+
+- Read API keys only from environment variables or a secret manager.
+- Logs may contain redacted request IDs, status codes, latency, retry counts,
+  and token usage.
+- Do not log authorization headers, complete sensitive user content, or complete
+  reasoning content.
+- Select tools only from an explicit allowlist and validate arguments,
+  permissions, timeouts, and output.
+- Set explicit limits for tool loops, network retries, and total wait time.
+- Do not assume fixed rate limits. Adjust concurrency from 429 responses,
+  `Retry-After`, and application metrics.
+- Warm up and run multiple trials for latency comparisons. Report median and
+  P95 instead of drawing conclusions from one request.
+
+## 11. Official References
+
+- [TokenHub API instructions](https://cloud.tencent.com/document/product/1823/130078)
+- [TokenHub language model overview](https://cloud.tencent.com/document/product/1823/130079)
+- [TokenHub deep reasoning](https://cloud.tencent.com/document/product/1823/131208)
+- [TokenHub interleaved reasoning](https://cloud.tencent.com/document/product/1823/130930)
+- [Hy3 inference and deployment](README.md#deployment)

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,123 @@
+# Hy3 API Quickstart
+
+> Make the first request in five minutes and learn chat, streaming, tools,
+> reasoning, and reliable retries in thirty minutes. 中文版：
+> [quickstart_CN.md](quickstart_CN.md).
+
+Hy3 exposes an OpenAI-compatible Chat Completions API. Use Tencent Cloud
+TokenHub (`https://tokenhub.tencentmaas.com/v1`, model `hy3`) or a local
+vLLM/SGLang server (`http://127.0.0.1:8000/v1`, key `EMPTY`). The TokenHub
+Singapore endpoint is `https://tokenhub-intl.tencentmaas.com/v1`; use the
+region where your resource is enabled.
+
+## Five-minute request
+
+```bash
+export HY3_API_KEY="replace-with-your-key"
+curl https://tokenhub.tencentmaas.com/v1/chat/completions \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "Introduce Hy3 in one sentence."}],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128
+  }'
+```
+
+```bash
+python -m pip install "openai>=1.30,<3"
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    api_key=os.environ["HY3_API_KEY"],
+    timeout=60.0,
+)
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "Introduce Hy3 in one sentence."}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+)
+print(response.choices[0].message.content)
+print("finish_reason:", response.choices[0].finish_reason)
+```
+
+For local serving, change the client to:
+
+```python
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+```
+
+## Parameters
+
+| Parameter | Meaning |
+| --- | --- |
+| `temperature` | Sampling randomness; repository recommendation: `0.9`. |
+| `top_p` | Nucleus sampling threshold; repository recommendation: `1.0`. |
+| `max_tokens` | Maximum generated tokens; reserve more for reasoning. |
+| `stop` | String/list that stops generation when matched. |
+| `stream` | Return incremental chunks instead of one response. |
+| `tools` | JSON Schema functions; the application executes them. |
+| `tool_choice` | Tool selection policy; TokenHub tool flows use `auto`. |
+
+`finish_reason="length"` means the response was truncated.
+
+## Reasoning mode
+
+TokenHub uses `thinking.type` to enable reasoning and a top-level
+`reasoning_effort` to select its depth:
+
+```python
+extra_body={
+    "thinking": {"type": "enabled"},
+    "reasoning_effort": "high",
+}
+```
+
+The self-hosted repository chat-template convention is:
+
+```python
+extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+Disable TokenHub reasoning with `{"thinking": {"type": "disabled"}}`.
+TokenHub supports `low`, `medium`, or `high` after reasoning is enabled.
+Self-hosted chat templates use `no_think`, `low`, or `high`; confirm what the
+target service version supports.
+Provider-specific reasoning can be read with
+`getattr(message, "reasoning_content", "")`. In reasoning-plus-tool flows,
+preserve the complete assistant message in the next request.
+
+## Limits, retries, and troubleshooting
+
+There is no repository-wide fixed RPM/TPM. TokenHub limits depend on account,
+region, and resources; local throughput depends on hardware and gateway policy.
+Honor `Retry-After` for 429. Retry timeouts, connections, 429, and selected 5xx
+errors with finite backoff and jitter. Never retry invalid credentials,
+permissions, or malformed requests.
+
+Check `/v1/models` for 401/404 issues. Ensure the Base URL includes `/v1`.
+Iterate all streaming chunks because usage-only chunks may have empty `choices`.
+Bound tool loops and validate all tool names and JSON arguments.
+
+Never commit API keys or place them in notebooks, logs, screenshots, or Git
+history.
+
+## Complete examples
+
+See [`examples/api/README.md`](examples/api/README.md) for six runnable Python
+examples and detailed per-example protocol notes. The
+[Chinese quickstart](quickstart_CN.md) contains the complete parameter and
+troubleshooting tables.
+
+Official references: [TokenHub API](https://cloud.tencent.com/document/product/1823/130078),
+[Hy3 guide](https://cloud.tencent.com/document/product/1823/132252), and
+[interleaved reasoning](https://cloud.tencent.com/document/product/1823/130930).

--- a/quickstart_CN.md
+++ b/quickstart_CN.md
@@ -7,11 +7,13 @@
 本指南帮助开发者在约 5 分钟内完成第一次 Hy3 API 调用，并在约 30 分钟内掌握
 对话、流式输出、工具调用、思考模式和可靠重试。
 
-Hy3 提供 OpenAI 兼容的 Chat Completions API，支持两种接入方式：
+Hy3 提供 OpenAI 兼容的 Chat Completions API，支持两种 API 接入方式：
 
 - **TokenHub 托管 API**：无需部署模型，开通服务并创建 API Key 后即可调用。
-- **自托管服务**：先按照仓库 [README_CN.md](README_CN.md#推理和部署) 使用
-  vLLM 或 SGLang 启动 Hy3，再调用本地 OpenAI 兼容接口。
+- **自托管 API**：先按照仓库 [README_CN.md](README_CN.md#推理和部署) 使用
+  vLLM 或 SGLang 部署 Hy3，再调用该服务提供的 OpenAI 兼容接口。
+
+本文只说明两种服务的 API 调用方式，不包含模型下载、GPU 规划或服务部署步骤。
 
 ## 1. 基础信息
 
@@ -322,15 +324,15 @@ full_text = "".join(parts)
 
 | 说明文档 | 示例脚本 | 演示内容 |
 | --- | --- | --- |
-| [基础对话](examples/api/01_basic_chat.md) | [`01_basic_chat.py`](examples/api/01_basic_chat.py) | 单轮、多轮及 usage |
-| [流式输出](examples/api/02_streaming.md) | [`02_streaming.py`](examples/api/02_streaming.py) | 逐 chunk 解析与聚合 |
-| [时延对比](examples/api/03_streaming_vs_non_streaming.md) | [`03_streaming_vs_non_streaming.py`](examples/api/03_streaming_vs_non_streaming.py) | TTFT 与总耗时 |
-| [工具调用](examples/api/04_tool_calling.md) | [`04_tool_calling.py`](examples/api/04_tool_calling.py) | 一次调用及有界工具循环 |
-| [思考模式](examples/api/05_reasoning_mode.md) | [`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py) | `no_think` 与 `high` 对比 |
-| [错误重试](examples/api/06_error_handling_retry.md) | [`06_error_handling_retry.py`](examples/api/06_error_handling_retry.py) | 错误分类与指数退避 |
+| [基础对话](examples/api/01_basic_chat_CN.md) | [`01_basic_chat.py`](examples/api/01_basic_chat.py) | 单轮、多轮及 usage |
+| [流式输出](examples/api/02_streaming_CN.md) | [`02_streaming.py`](examples/api/02_streaming.py) | 逐 chunk 解析与聚合 |
+| [时延对比](examples/api/03_streaming_vs_non_streaming_CN.md) | [`03_streaming_vs_non_streaming.py`](examples/api/03_streaming_vs_non_streaming.py) | TTFT 与总耗时 |
+| [工具调用](examples/api/04_tool_calling_CN.md) | [`04_tool_calling.py`](examples/api/04_tool_calling.py) | 一次调用及有界工具循环 |
+| [思考模式](examples/api/05_reasoning_mode_CN.md) | [`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py) | `no_think` 与 `high` 对比 |
+| [错误重试](examples/api/06_error_handling_retry_CN.md) | [`06_error_handling_retry.py`](examples/api/06_error_handling_retry.py) | 错误分类与指数退避 |
 
 每个说明文档均包含请求流程、响应解析、注意事项和脱敏输出示例。安装及运行方式见
-[`examples/api/README.md`](examples/api/README.md)。
+[`examples/api/README_CN.md`](examples/api/README_CN.md)。
 
 ## 9. 常见错误排查
 

--- a/quickstart_CN.md
+++ b/quickstart_CN.md
@@ -1,106 +1,188 @@
+<p align="left">
+  <a href="./quickstart.md">English</a>&nbsp;｜&nbsp;中文
+</p>
+
 # Hy3 API 快速开始
 
-> 目标：5 分钟完成第一次调用，30 分钟掌握对话、流式输出、工具调用、思考模式和可靠重试。English: [quickstart.md](quickstart.md)。
+本指南帮助开发者在约 5 分钟内完成第一次 Hy3 API 调用，并在约 30 分钟内掌握
+对话、流式输出、工具调用、思考模式和可靠重试。
 
-Hy3 提供 OpenAI 兼容的 Chat Completions 接口。本指南覆盖 TokenHub 托管 API 和本地 vLLM/SGLang 服务。
+Hy3 提供 OpenAI 兼容的 Chat Completions API，支持两种接入方式：
+
+- **TokenHub 托管 API**：无需部署模型，开通服务并创建 API Key 后即可调用。
+- **自托管服务**：先按照仓库 [README_CN.md](README_CN.md#推理和部署) 使用
+  vLLM 或 SGLang 启动 Hy3，再调用本地 OpenAI 兼容接口。
 
 ## 1. 基础信息
 
-| 项目 | TokenHub 广州 | TokenHub 新加坡 | 自托管 |
+| 项目 | TokenHub 广州 | TokenHub 新加坡 | 自托管默认值 |
 | --- | --- | --- | --- |
-| Base URL | `https://tokenhub.tencentmaas.com/v1` | `https://tokenhub-intl.tencentmaas.com/v1` | 默认 `http://127.0.0.1:8000/v1` |
-| API Key | TokenHub 控制台创建 | TokenHub 控制台创建 | 示例使用 `EMPTY` |
-| Model | `hy3` | `hy3` | 由 `--served-model-name hy3` 设置 |
+| Base URL | `https://tokenhub.tencentmaas.com/v1` | `https://tokenhub-intl.tencentmaas.com/v1` | `http://127.0.0.1:8000/v1` |
+| Chat endpoint | `/chat/completions` | `/chat/completions` | `/chat/completions` |
+| API Key | TokenHub 控制台创建 | TokenHub 控制台创建 | 通常使用 `EMPTY` |
+| Model | `hy3` 或服务 ID | `hy3` 或服务 ID | 与 `--served-model-name` 一致 |
 | 协议 | OpenAI Chat Completions | OpenAI Chat Completions | OpenAI 兼容接口 |
 
-TokenHub 不支持跨地域调用，请使用资源开通地域对应的地址。先验证 Key 和模型状态：
+TokenHub 不支持跨地域调用。API Key、服务资源和 Base URL 必须属于同一地域。
+自定义在线推理服务应使用控制台显示的服务 ID，例如 `ep-xxxxxxxx`。
+
+Hy3 模型上下文长度最高为 256K Token；实际可用长度还取决于服务配置、输入输出
+预算、并发和可用显存。仓库没有适用于所有用户的固定 RPM/TPM：
+
+- TokenHub 限制取决于账号、地域、套餐和推理服务配置。
+- 自托管吞吐取决于 GPU、并行配置、网关、队列和上下文长度。
+- 收到 HTTP 429 时应遵循 `Retry-After`，否则使用带 jitter 的指数退避。
+
+## 2. 配置环境
+
+安装 OpenAI Python SDK：
 
 ```bash
-curl https://tokenhub.tencentmaas.com/v1/models \
-  -H "Authorization: Bearer $HY3_API_KEY"
+python -m pip install "openai>=1.30,<3"
 ```
 
-PowerShell 建议使用 `curl.exe`，避免 `curl` 别名差异：
+### Linux / macOS
+
+TokenHub 新加坡示例：
+
+```bash
+export HY3_BASE_URL="https://tokenhub-intl.tencentmaas.com/v1"
+export HY3_API_KEY="replace-with-your-key"
+export HY3_MODEL="hy3"
+```
+
+自托管示例：
+
+```bash
+export HY3_BASE_URL="http://127.0.0.1:8000/v1"
+export HY3_API_KEY="EMPTY"
+export HY3_MODEL="hy3"
+```
+
+### Windows PowerShell
 
 ```powershell
-curl.exe https://tokenhub.tencentmaas.com/v1/models `
+$env:HY3_BASE_URL = "https://tokenhub-intl.tencentmaas.com/v1"
+$env:HY3_API_KEY = "replace-with-your-key"
+$env:HY3_MODEL = "hy3"
+```
+
+不要把真实 API Key 写进源码、Notebook、截图或 Git 历史。Key 泄露后应立即撤销
+并重新创建。
+
+### 连通性检查
+
+Linux / macOS：
+
+```bash
+curl "${HY3_BASE_URL}/models" \
+  -H "Authorization: Bearer ${HY3_API_KEY}"
+```
+
+Windows PowerShell：
+
+```powershell
+curl.exe "$env:HY3_BASE_URL/models" `
   -H "Authorization: Bearer $env:HY3_API_KEY"
 ```
 
-### API Key 安全
+返回列表中的模型或服务 ID 应与 `HY3_MODEL` 一致。部分自托管框架还提供
+`/health`，但该路径不是 OpenAI 协议的一部分，不能假设所有服务均支持。
 
-不要把 Key 写进源码、Notebook 输出、截图或 Git 历史。示例从 `HY3_API_KEY` 环境变量读取，`.env` 已被 Git 忽略。Key 泄露后应立即撤销并重新创建。
-
-### 速率限制
-
-仓库没有适用于所有用户的固定 RPM/TPM。TokenHub 限制取决于账号、地域和购买资源，以控制台及服务端响应为准；HTTP 429 应优先遵循 `Retry-After`。自托管吞吐取决于 GPU、并行配置、上下文长度和网关策略。业务代码不应假设固定限额。
-
-## 2. 五分钟完成第一次调用
-
-设置 Key：
-
-```bash
-export HY3_API_KEY="replace-with-your-key"       # Linux / macOS
-```
-
-```powershell
-$env:HY3_API_KEY = "replace-with-your-key"       # Windows PowerShell
-```
+## 3. 五分钟完成第一次调用
 
 ### curl
 
+Linux / macOS：
+
 ```bash
-curl https://tokenhub.tencentmaas.com/v1/chat/completions \
-  -H "Authorization: Bearer $HY3_API_KEY" \
+curl "${HY3_BASE_URL}/chat/completions" \
+  -H "Authorization: Bearer ${HY3_API_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "hy3",
-    "messages": [{"role": "user", "content": "用一句话介绍 Hy3。"}],
-    "temperature": 0.9,
-    "top_p": 1.0,
-    "max_tokens": 128,
-    "stream": false
-  }'
+  -d @- <<JSON
+{
+  "model": "${HY3_MODEL}",
+  "messages": [
+    {"role": "user", "content": "请用一句话说明你能提供哪些帮助。"}
+  ],
+  "temperature": 0.9,
+  "top_p": 1.0,
+  "max_tokens": 128,
+  "stream": false
+}
+JSON
 ```
 
-核心响应结构（实际 ID、内容和 Token 数会变化）：
+Windows PowerShell：
+
+```powershell
+$body = @{
+  model = $env:HY3_MODEL
+  messages = @(
+    @{ role = "user"; content = "请用一句话说明你能提供哪些帮助。" }
+  )
+  temperature = 0.9
+  top_p = 1.0
+  max_tokens = 128
+  stream = $false
+} | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod `
+  -Uri "$env:HY3_BASE_URL/chat/completions" `
+  -Method Post `
+  -Headers @{ Authorization = "Bearer $env:HY3_API_KEY" } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+核心响应结构如下。实际 ID、内容和 Token 数会变化：
 
 ```json
 {
   "id": "chatcmpl-REDACTED",
   "object": "chat.completion",
   "model": "hy3",
-  "choices": [{
-    "index": 0,
-    "message": {"role": "assistant", "content": "Hy3 是……"},
-    "finish_reason": "stop"
-  }],
-  "usage": {"prompt_tokens": 16, "completion_tokens": 25, "total_tokens": 41}
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "示例回答内容……"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 18,
+    "completion_tokens": 24,
+    "total_tokens": 42
+  }
 }
 ```
 
 ### Python OpenAI SDK
 
-```bash
-python -m pip install "openai>=1.30,<3"
-```
-
 ```python
 import os
+
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://tokenhub.tencentmaas.com/v1",
+    base_url=os.environ["HY3_BASE_URL"],
     api_key=os.environ["HY3_API_KEY"],
     timeout=60.0,
 )
+
 response = client.chat.completions.create(
-    model="hy3",
-    messages=[{"role": "user", "content": "用一句话介绍 Hy3。"}],
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[
+        {"role": "user", "content": "请用一句话说明你能提供哪些帮助。"},
+    ],
     temperature=0.9,
     top_p=1.0,
     max_tokens=128,
 )
+
 choice = response.choices[0]
 print(choice.message.content)
 print("finish_reason:", choice.finish_reason)
@@ -108,35 +190,49 @@ if response.usage:
     print("total_tokens:", response.usage.total_tokens)
 ```
 
-自托管只需改客户端：
+多轮对话不会由服务端自动保存。客户端需要按顺序把之前的 `user` 和 `assistant`
+消息重新放入下一次请求。完整实现见
+[`01_basic_chat.py`](examples/api/01_basic_chat.py)。
 
-```python
-client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
-```
-
-## 3. 参数说明
+## 4. 请求参数参考
 
 | 参数 | 类型 | 示例 | 说明 |
 | --- | --- | --- | --- |
-| `model` | string | `hy3` | 与 `/v1/models` 或 served model name 一致 |
-| `messages` | array | system/user/assistant/tool | 多轮请求由客户端显式回传历史 |
-| `temperature` | number | `0.9` | 控制随机性；与 `top_p` 通常不要同时大幅调整 |
-| `top_p` | number | `1.0` | 核采样阈值 |
-| `max_tokens` | integer | 按任务设置 | 输出上限；思考模式需预留更多预算 |
-| `stop` | string/array | 自定义或不传 | 命中停止串时提前结束 |
-| `stream` | boolean | `true`/`false` | 是否返回增量 chunk |
-| `tools` | array | JSON Schema | 模型生成调用意图，业务方执行工具 |
-| `tool_choice` | string | `auto` | TokenHub 工具场景使用自动选择 |
+| `model` | string | `hy3` | 使用 `/models` 返回的模型或服务 ID |
+| `messages` | array | `system/user/assistant/tool` | 客户端显式维护的对话历史 |
+| `temperature` | number | `0.9` | 控制采样随机性；仓库推荐值为 `0.9` |
+| `top_p` | number | `1.0` | 核采样阈值；通常不要与 temperature 同时激进调整 |
+| `max_tokens` | integer | `512` | 输出上限；思考模式应预留更大预算 |
+| `stop` | string/array | `["Observation:"]` | 命中停止序列时结束生成 |
+| `stream` | boolean | `true` | 返回增量 chunk，而不是等待完整回答 |
+| `stream_options` | object | `{"include_usage": true}` | 请求在最后一个流式 chunk 中返回 usage |
+| `tools` | array | JSON Schema | 定义模型可以选择的函数 |
+| `tool_choice` | string/object | `auto` | 控制是否或如何选择工具 |
+| `parallel_tool_calls` | boolean | `false` | 是否允许模型一次请求多个工具 |
+| `response_format` | object | `{"type": "json_object"}` | 目标服务支持时约束输出格式 |
 
-`finish_reason="length"` 表示输出达到限制，不应当作完整答案；可增大 `max_tokens` 或缩短输入。
+不同服务版本支持的参数可能不同。使用前应以目标服务文档和实际 `/models` 结果为准。
 
-## 4. 思考模式
+常见 `finish_reason`：
 
-TokenHub 用 `thinking.type` 开关思考，并在开启后用顶层 `reasoning_effort` 控制深度。Python SDK 通过 `extra_body` 传入：
+- `stop`：正常结束。
+- `length`：达到输出预算，回答可能不完整。
+- `tool_calls`：模型请求应用执行工具。
+
+## 5. 思考模式
+
+TokenHub 和自托管服务的参数位置不同：
+
+| 场景 | 关闭思考 | 开启思考 |
+| --- | --- | --- |
+| TokenHub | `{"thinking":{"type":"disabled"}}` | `thinking.type=enabled`，深度为 `low/medium/high` |
+| 自托管 | `reasoning_effort=no_think` | `reasoning_effort=low/high` |
+
+### TokenHub
 
 ```python
 response = client.chat.completions.create(
-    model="hy3",
+    model=os.getenv("HY3_MODEL", "hy3"),
     messages=[{"role": "user", "content": "证明根号 2 是无理数。"}],
     max_tokens=16384,
     extra_body={
@@ -146,51 +242,130 @@ response = client.chat.completions.create(
 )
 ```
 
-本地 vLLM/SGLang 使用仓库 chat template 约定：
+关闭思考：
 
 ```python
-extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+extra_body = {"thinking": {"type": "disabled"}}
 ```
 
-TokenHub 关闭思考使用 `{"thinking": {"type": "disabled"}}`；开启后可使用 `low`、`medium`、`high`。仓库自托管约定使用 `no_think`、`low`、`high`。`reasoning_content` 是提供商扩展字段，可兼容读取：
+### 自托管 vLLM/SGLang
+
+```python
+extra_body = {
+    "chat_template_kwargs": {
+        "reasoning_effort": "high",
+    }
+}
+```
+
+自托管约定使用 `no_think`、`low` 或 `high`。服务端还需启用对应的 reasoning
+parser。提供商扩展字段 `reasoning_content` 可以兼容读取：
 
 ```python
 reasoning = getattr(response.choices[0].message, "reasoning_content", "")
 ```
 
-慢思考结合工具调用时，下一轮必须保留完整 assistant 消息，包括 `reasoning_content` 和 `tool_calls`。
+思考模式与工具调用结合时，下一轮必须保留完整 assistant 消息，包括
+`reasoning_content` 和 `tool_calls`。不要把包含敏感业务数据的完整推理内容写入
+日志。完整对比见 [`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py)。
 
-## 5. 工具调用流程与安全
+## 6. 流式响应
 
-1. 发送工具 JSON Schema。
-2. 检查 `tool_calls`。
-3. 使用白名单查找工具并验证 JSON 参数。
-4. 在业务侧执行工具。
-5. 使用相同 `tool_call_id` 添加 `role="tool"` 消息。
-6. 回传完整历史，直到最终回答。
+设置 `stream=True` 后，SDK 返回可迭代事件流。chunk 可能只包含 role、部分正文、
+思考增量、结束原因或 usage，不能假设每个 chunk 都有正文：
 
-生产代码必须设置最大工具轮数、超时和参数验证；绝不能执行模型返回的任意代码或命令。完整实现见 [`04_tool_calling.py`](examples/api/04_tool_calling.py)。
+```python
+stream = client.chat.completions.create(
+    model=os.getenv("HY3_MODEL", "hy3"),
+    messages=[{"role": "user", "content": "解释流式输出。"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
 
-## 6. 常见错误排查
+parts = []
+for chunk in stream:
+    if not chunk.choices:
+        continue
+    content = chunk.choices[0].delta.content
+    if content:
+        parts.append(content)
+        print(content, end="", flush=True)
+
+full_text = "".join(parts)
+```
+
+工具参数也可能跨多个流式 chunk 到达，生产代码必须按 tool-call index 或 ID
+累积后再解析。完整实现见 [`02_streaming.py`](examples/api/02_streaming.py)。
+
+## 7. 工具调用
+
+自托管服务需要先启用工具解析：
+
+- vLLM：使用 `--tool-call-parser hy_v3` 和 `--enable-auto-tool-choice`。
+- SGLang：使用仓库 README 中的 Hunyuan 工具解析器配置。
+
+应用侧完整流程：
+
+1. 定义 `tools` JSON Schema。
+2. 使用 `tool_choice="auto"` 发送请求。
+3. 检查 assistant 返回的 `tool_calls`。
+4. 通过白名单确认工具名，并验证 JSON 参数。
+5. 在业务侧执行工具。
+6. 使用相同 `tool_call_id` 添加 `role="tool"` 的结果消息。
+7. 回传完整历史，直到模型输出最终回答。
+
+生产代码必须设置最大工具轮数、工具超时、权限校验和输出长度限制。绝不能使用
+`eval`、`exec` 或 Shell 直接执行模型生成的内容。完整实现见
+[`04_tool_calling.py`](examples/api/04_tool_calling.py)。
+
+## 8. 示例索引
+
+| 说明文档 | 示例脚本 | 演示内容 |
+| --- | --- | --- |
+| [基础对话](examples/api/01_basic_chat.md) | [`01_basic_chat.py`](examples/api/01_basic_chat.py) | 单轮、多轮及 usage |
+| [流式输出](examples/api/02_streaming.md) | [`02_streaming.py`](examples/api/02_streaming.py) | 逐 chunk 解析与聚合 |
+| [时延对比](examples/api/03_streaming_vs_non_streaming.md) | [`03_streaming_vs_non_streaming.py`](examples/api/03_streaming_vs_non_streaming.py) | TTFT 与总耗时 |
+| [工具调用](examples/api/04_tool_calling.md) | [`04_tool_calling.py`](examples/api/04_tool_calling.py) | 一次调用及有界工具循环 |
+| [思考模式](examples/api/05_reasoning_mode.md) | [`05_reasoning_mode.py`](examples/api/05_reasoning_mode.py) | `no_think` 与 `high` 对比 |
+| [错误重试](examples/api/06_error_handling_retry.md) | [`06_error_handling_retry.py`](examples/api/06_error_handling_retry.py) | 错误分类与指数退避 |
+
+每个说明文档均包含请求流程、响应解析、注意事项和脱敏输出示例。安装及运行方式见
+[`examples/api/README.md`](examples/api/README.md)。
+
+## 9. 常见错误排查
 
 | 现象 | 常见原因 | 处理方式 |
 | --- | --- | --- |
-| HTTP 400 | 类型、消息顺序、工具 Schema 或能力不匹配 | 检查脱敏请求并逐项缩减；不要重试 |
-| HTTP 401 | Key 缺失或无效 | 用 `/v1/models` 验证 Key 和 Bearer 头 |
-| HTTP 403 | 账号或资源无权限 | 检查地域、开通状态和授权；不要重试 |
-| HTTP 404 | URL、路径或模型名错误 | URL 应含 `/v1`，查询 `/v1/models` |
-| HTTP 429 | 并发、速率或配额限制 | 遵循 `Retry-After`，否则退避加 jitter |
-| HTTP 5xx | 暂时服务异常 | 只对选定状态做有限重试 |
-| 连接失败 | 地址、代理、防火墙或本地服务问题 | 检查 DNS、TLS、端口和服务日志 |
-| 超时 | 长上下文或深度思考 | 有意识地调 timeout 或缩短任务 |
-| 输出截断 | `finish_reason=length` | 增大输出预算或压缩输入 |
-| 流为空 | 只看首个 chunk 或没处理空 choices | 遍历全部 chunk，分开处理 usage |
-| 工具循环卡住 | 历史不完整或没有轮数上限 | 原样回填并限制轮数 |
+| HTTP 400 | 参数类型、消息顺序、工具 Schema 或能力不匹配 | 检查脱敏请求并逐项缩减；不要原样重试 |
+| HTTP 401 / `401002` | Key 缺失、无效或地域不匹配 | 核对 Key 和 Base URL 地域，用 `/models` 验证 |
+| HTTP 402 / endpoint inactive | 推理服务未激活、额度或计费未启用 | 在 TokenHub 控制台检查在线推理服务 |
+| HTTP 403 | 账号、模型、IP 白名单或资源无权限 | 检查 Key 权限、地域和服务状态 |
+| HTTP 404 / model not found | URL、路径、模型名或服务 ID 错误 | URL 应包含 `/v1`，并查询 `/models` |
+| HTTP 429 | 并发、速率或配额限制 | 遵循 `Retry-After`，否则指数退避加 jitter |
+| HTTP 5xx | 暂时服务异常 | 仅对选定状态进行有限次数重试 |
+| Connection refused | 自托管服务未启动或端口错误 | 检查服务进程、监听地址、防火墙和代理 |
+| chat template 相关 400 | 模板缺失或与服务版本不兼容 | 使用 Hy3 tokenizer/chat template 并更新框架 |
+| `tool_calls` 为空 | 未启用工具解析器或 Schema 描述不足 | 检查 parser、tool_choice 和 JSON Schema |
+| 缺少 `reasoning_content` | 未启用 reasoning parser 或当前模式不返回 | 检查服务启动参数和思考模式 |
+| 输出截断 | `finish_reason=length` | 增大 max_tokens 或压缩输入 |
+| 流式正文为空 | 只读取首个 chunk 或忽略空 choices | 遍历完整事件流并分别处理 usage |
+| CUDA OOM | 上下文、输出预算或并发过高 | 缩短上下文、降低并发或调整并行配置 |
+| 客户端超时 | 模型加载、长上下文或深度思考耗时较长 | 调整 timeout、任务规模或使用流式输出 |
 
-日志可记录 request ID、状态码、耗时、重试次数和 Token 用量，但不得记录 Key，也应谨慎记录用户内容和完整推理内容。
+## 10. 生产与安全建议
 
-## 7. 示例和验证
+- API Key 只从环境变量或密钥管理服务读取。
+- 日志可记录脱敏 request ID、状态码、耗时、重试次数和 Token 用量。
+- 不记录 Authorization Header、完整用户敏感内容或完整推理内容。
+- 工具只能从显式白名单中选择，并对参数、权限、超时和输出做校验。
+- 为工具循环、网络重试和总等待时间设置明确上限。
+- 不要假设固定限流；根据 429、`Retry-After` 和业务指标动态调节并发。
+- 时延比较应预热并运行多轮，报告中位数和 P95，不能用单次结果下结论。
 
-[`examples/api`](examples/api/README.md) 提供六组完整 Python 示例：基础对话、流式解析、时延对比、工具循环、思考对比和可靠重试，并为每组示例提供独立说明。
+## 11. 官方参考
 
-官方参考：[TokenHub API](https://cloud.tencent.com/document/product/1823/130078)、[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)、[交错式思考](https://cloud.tencent.com/document/product/1823/130930)。
+- [TokenHub API 使用说明](https://cloud.tencent.com/document/product/1823/130078)
+- [TokenHub 语言模型调用概览](https://cloud.tencent.com/document/product/1823/130079)
+- [TokenHub 深度思考](https://cloud.tencent.com/document/product/1823/131208)
+- [TokenHub 交错式思考](https://cloud.tencent.com/document/product/1823/130930)
+- [Hy3 推理和部署](README_CN.md#推理和部署)

--- a/quickstart_CN.md
+++ b/quickstart_CN.md
@@ -1,0 +1,196 @@
+# Hy3 API 快速开始
+
+> 目标：5 分钟完成第一次调用，30 分钟掌握对话、流式输出、工具调用、思考模式和可靠重试。English: [quickstart.md](quickstart.md)。
+
+Hy3 提供 OpenAI 兼容的 Chat Completions 接口。本指南覆盖 TokenHub 托管 API 和本地 vLLM/SGLang 服务。
+
+## 1. 基础信息
+
+| 项目 | TokenHub 广州 | TokenHub 新加坡 | 自托管 |
+| --- | --- | --- | --- |
+| Base URL | `https://tokenhub.tencentmaas.com/v1` | `https://tokenhub-intl.tencentmaas.com/v1` | 默认 `http://127.0.0.1:8000/v1` |
+| API Key | TokenHub 控制台创建 | TokenHub 控制台创建 | 示例使用 `EMPTY` |
+| Model | `hy3` | `hy3` | 由 `--served-model-name hy3` 设置 |
+| 协议 | OpenAI Chat Completions | OpenAI Chat Completions | OpenAI 兼容接口 |
+
+TokenHub 不支持跨地域调用，请使用资源开通地域对应的地址。先验证 Key 和模型状态：
+
+```bash
+curl https://tokenhub.tencentmaas.com/v1/models \
+  -H "Authorization: Bearer $HY3_API_KEY"
+```
+
+PowerShell 建议使用 `curl.exe`，避免 `curl` 别名差异：
+
+```powershell
+curl.exe https://tokenhub.tencentmaas.com/v1/models `
+  -H "Authorization: Bearer $env:HY3_API_KEY"
+```
+
+### API Key 安全
+
+不要把 Key 写进源码、Notebook 输出、截图或 Git 历史。示例从 `HY3_API_KEY` 环境变量读取，`.env` 已被 Git 忽略。Key 泄露后应立即撤销并重新创建。
+
+### 速率限制
+
+仓库没有适用于所有用户的固定 RPM/TPM。TokenHub 限制取决于账号、地域和购买资源，以控制台及服务端响应为准；HTTP 429 应优先遵循 `Retry-After`。自托管吞吐取决于 GPU、并行配置、上下文长度和网关策略。业务代码不应假设固定限额。
+
+## 2. 五分钟完成第一次调用
+
+设置 Key：
+
+```bash
+export HY3_API_KEY="replace-with-your-key"       # Linux / macOS
+```
+
+```powershell
+$env:HY3_API_KEY = "replace-with-your-key"       # Windows PowerShell
+```
+
+### curl
+
+```bash
+curl https://tokenhub.tencentmaas.com/v1/chat/completions \
+  -H "Authorization: Bearer $HY3_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hy3",
+    "messages": [{"role": "user", "content": "用一句话介绍 Hy3。"}],
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_tokens": 128,
+    "stream": false
+  }'
+```
+
+核心响应结构（实际 ID、内容和 Token 数会变化）：
+
+```json
+{
+  "id": "chatcmpl-REDACTED",
+  "object": "chat.completion",
+  "model": "hy3",
+  "choices": [{
+    "index": 0,
+    "message": {"role": "assistant", "content": "Hy3 是……"},
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 16, "completion_tokens": 25, "total_tokens": 41}
+}
+```
+
+### Python OpenAI SDK
+
+```bash
+python -m pip install "openai>=1.30,<3"
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://tokenhub.tencentmaas.com/v1",
+    api_key=os.environ["HY3_API_KEY"],
+    timeout=60.0,
+)
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "用一句话介绍 Hy3。"}],
+    temperature=0.9,
+    top_p=1.0,
+    max_tokens=128,
+)
+choice = response.choices[0]
+print(choice.message.content)
+print("finish_reason:", choice.finish_reason)
+if response.usage:
+    print("total_tokens:", response.usage.total_tokens)
+```
+
+自托管只需改客户端：
+
+```python
+client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+```
+
+## 3. 参数说明
+
+| 参数 | 类型 | 示例 | 说明 |
+| --- | --- | --- | --- |
+| `model` | string | `hy3` | 与 `/v1/models` 或 served model name 一致 |
+| `messages` | array | system/user/assistant/tool | 多轮请求由客户端显式回传历史 |
+| `temperature` | number | `0.9` | 控制随机性；与 `top_p` 通常不要同时大幅调整 |
+| `top_p` | number | `1.0` | 核采样阈值 |
+| `max_tokens` | integer | 按任务设置 | 输出上限；思考模式需预留更多预算 |
+| `stop` | string/array | 自定义或不传 | 命中停止串时提前结束 |
+| `stream` | boolean | `true`/`false` | 是否返回增量 chunk |
+| `tools` | array | JSON Schema | 模型生成调用意图，业务方执行工具 |
+| `tool_choice` | string | `auto` | TokenHub 工具场景使用自动选择 |
+
+`finish_reason="length"` 表示输出达到限制，不应当作完整答案；可增大 `max_tokens` 或缩短输入。
+
+## 4. 思考模式
+
+TokenHub 用 `thinking.type` 开关思考，并在开启后用顶层 `reasoning_effort` 控制深度。Python SDK 通过 `extra_body` 传入：
+
+```python
+response = client.chat.completions.create(
+    model="hy3",
+    messages=[{"role": "user", "content": "证明根号 2 是无理数。"}],
+    max_tokens=16384,
+    extra_body={
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "high",
+    },
+)
+```
+
+本地 vLLM/SGLang 使用仓库 chat template 约定：
+
+```python
+extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}
+```
+
+TokenHub 关闭思考使用 `{"thinking": {"type": "disabled"}}`；开启后可使用 `low`、`medium`、`high`。仓库自托管约定使用 `no_think`、`low`、`high`。`reasoning_content` 是提供商扩展字段，可兼容读取：
+
+```python
+reasoning = getattr(response.choices[0].message, "reasoning_content", "")
+```
+
+慢思考结合工具调用时，下一轮必须保留完整 assistant 消息，包括 `reasoning_content` 和 `tool_calls`。
+
+## 5. 工具调用流程与安全
+
+1. 发送工具 JSON Schema。
+2. 检查 `tool_calls`。
+3. 使用白名单查找工具并验证 JSON 参数。
+4. 在业务侧执行工具。
+5. 使用相同 `tool_call_id` 添加 `role="tool"` 消息。
+6. 回传完整历史，直到最终回答。
+
+生产代码必须设置最大工具轮数、超时和参数验证；绝不能执行模型返回的任意代码或命令。完整实现见 [`04_tool_calling.py`](examples/api/04_tool_calling.py)。
+
+## 6. 常见错误排查
+
+| 现象 | 常见原因 | 处理方式 |
+| --- | --- | --- |
+| HTTP 400 | 类型、消息顺序、工具 Schema 或能力不匹配 | 检查脱敏请求并逐项缩减；不要重试 |
+| HTTP 401 | Key 缺失或无效 | 用 `/v1/models` 验证 Key 和 Bearer 头 |
+| HTTP 403 | 账号或资源无权限 | 检查地域、开通状态和授权；不要重试 |
+| HTTP 404 | URL、路径或模型名错误 | URL 应含 `/v1`，查询 `/v1/models` |
+| HTTP 429 | 并发、速率或配额限制 | 遵循 `Retry-After`，否则退避加 jitter |
+| HTTP 5xx | 暂时服务异常 | 只对选定状态做有限重试 |
+| 连接失败 | 地址、代理、防火墙或本地服务问题 | 检查 DNS、TLS、端口和服务日志 |
+| 超时 | 长上下文或深度思考 | 有意识地调 timeout 或缩短任务 |
+| 输出截断 | `finish_reason=length` | 增大输出预算或压缩输入 |
+| 流为空 | 只看首个 chunk 或没处理空 choices | 遍历全部 chunk，分开处理 usage |
+| 工具循环卡住 | 历史不完整或没有轮数上限 | 原样回填并限制轮数 |
+
+日志可记录 request ID、状态码、耗时、重试次数和 Token 用量，但不得记录 Key，也应谨慎记录用户内容和完整推理内容。
+
+## 7. 示例和验证
+
+[`examples/api`](examples/api/README.md) 提供六组完整 Python 示例：基础对话、流式解析、时延对比、工具循环、思考对比和可靠重试，并为每组示例提供独立说明。
+
+官方参考：[TokenHub API](https://cloud.tencent.com/document/product/1823/130078)、[混元调用指南](https://cloud.tencent.com/document/product/1823/132252)、[交错式思考](https://cloud.tencent.com/document/product/1823/130930)。


### PR DESCRIPTION
## Summary

Adding the Hy3 API quickstart and six runnable examples requested in the issue.

## Deliverables

- Add `quickstart.md` and `quickstart_CN.md`, covering:
  - Base URL, API key, model name, and rate-limit behavior
  - Minimal `curl` and OpenAI Python SDK requests
  - `temperature`, `top_p`, `max_tokens`, `stop`, and `tools`
  - Reasoning mode configuration
  - Common errors and troubleshooting

- Add six runnable examples:
  - Basic single-turn and multi-turn chat
  - Streaming requests and chunk parsing
  - Streaming vs. non-streaming latency
  - Single and multi-round tool calling
  - Reasoning mode comparison
  - Error handling, retries, and exponential backoff

- Provide an independent Python script and English/Chinese documentation for each example.
- Add shared environment configuration and helper functions.
- Update the root README links.

## Validation

- Ruff lint and formatting checks passed
- 15 offline tests passed
- All six examples passed against the live API
- Python 3.10 slim Linux container tests passed
- Live API smoke tests passed on Windows and Linux
- Documentation links and secret checks passed

Closes #1 